### PR TITLE
test: run go generate before running tests

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -103,11 +103,13 @@ tasks:
   test:
     desc: Run backend unit tests.
     cmds:
+      - task: goa:generate
       - sh -c 'cd server && GOCACHE=${GOCACHE:-/tmp/gocache-attesta} go test $(go list ./... | grep -v "/gen")'
 
   cover:
     desc: Run backend tests with a 90% coverage gate.
     cmds:
+      - task: goa:generate
       - |
           sh -c '
           set -eu


### PR DESCRIPTION
This solve missing openapi files
