### PR TITLE
Extract substep_shell component from stream timeline

### DIFF
--- a/docs/css.md
+++ b/docs/css.md
@@ -44,7 +44,7 @@ Org-admin forms, dialogs, and pickers live in `components/org-admin.css`, not th
 | `components/substep-body.css` | `.substep-body-*` | `components/substep_body.html`, `attachment_carousel.html` |
 | `components/stream-step-summary.css` | `.stream-step-summary-*` | `components/stream_step_summary.html` |
 | `components/stream-timeline.css` | `.stream-timeline-list`, `.stream-timeline-step*` | `components/stream_timeline.html` |
-| `components/substep-shell.css` | `.substep*`, override modal | `components/stream_timeline.html`, `substep_override_editor.html` |
+| `components/substep-shell.css` | `.substep*`, override modal | `components/substep_shell.html`, `substep_override_editor.html` |
 
 Other partials (`icons.html`, …) still live at `server/templates/` root until migrated one by one. Split reused styles into `components/` and page-specific styles into `pages/`.
 
@@ -58,7 +58,8 @@ Other partials (`icons.html`, …) still live at `server/templates/` root until 
 | `pages/stream.html` | `pages/home.css`, `pages/stream.css` | `components/stream.css`, `components/stream-timeline.css`, `role-palette.css` |
 | `pages/process.html` | `pages/process.css` | `components/substep-shell.css`, `components/stream-timeline.css`, `components/substep-body.css`, `layout/responsive.css` (`.layout-stack-separator`), `role-palette.css` |
 | `components/stream_step_summary.html` | `components/stream-step-summary.css` | — |
-| `components/stream_timeline.html` | `components/stream-timeline.css` | `components/stream-step-summary.css`, `components/substep-shell.css`, `components/substep-body.css`, `role-palette.css` |
+| `components/stream_timeline.html` | `components/stream-timeline.css` | `components/stream-step-summary.css`, `components/substep-body.css`, `role-palette.css` |
+| `components/substep_shell.html` | `components/substep-shell.css` | `components/substep-body.css`, `role-palette.css` |
 | `components/substep_body.html` | `components/substep-body.css` | `components/forms.css`, `role-palette.css` |
 | `pages/dpp.html` | `pages/dpp.css` | `components/stream-timeline.css`, `components/stream-step-summary.css`, `components/substep-shell.css`, `components/substep-body.css`, `role-palette.css` |
 | `pages/org_admin.html` | `pages/org-admin-page.css` | `components/org-admin.css`, `role-palette.css` |

--- a/server/cmd/server/substep_shell_test.go
+++ b/server/cmd/server/substep_shell_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func testSubstepShellView() StreamTimelineSubstepView {
+	return StreamTimelineSubstepView{
+		Substep: TimelineSubstep{
+			SubstepID: "1.1",
+			Title:     "Capture batch data",
+			Status:    "available",
+			Selected:  true,
+			Palette:   "blue",
+			Body: &SubstepBodyView{
+				WorkflowKey: "workflow",
+				ProcessID:   "process-1",
+				SubstepID:   "1.1",
+				Title:       "Capture batch data",
+				Status:      "available",
+				FormSchema:  `{"type":"object"}`,
+			},
+		},
+		HideStatus: false,
+	}
+}
+
+func TestSubstepShellTemplateRendersAccordion(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+
+	var out bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&out, "substep_shell", testSubstepShellView()); err != nil {
+		t.Fatalf("render substep_shell template: %v", err)
+	}
+	body := out.String()
+	compactBody := strings.Join(strings.Fields(body), " ")
+
+	for _, want := range []string{
+		`class="substep substep-available"`,
+		`class="substep-accordion js-process-substep-panel"`,
+		`data-substep-id="1.1"`,
+		`class="substep-details"`,
+		`<span class="status">available</span>`,
+		"Capture batch data",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in rendered substep shell, got: %s", want, body)
+		}
+	}
+	if !strings.Contains(compactBody, `class="substep-accordion js-process-substep-panel" data-substep-id="1.1" open`) {
+		t.Fatalf("expected selected substep accordion open, got: %s", body)
+	}
+}
+
+func TestSubstepShellTemplateHidesStatusWhenHideStatus(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+
+	view := testSubstepShellView()
+	view.HideStatus = true
+
+	var out bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&out, "substep_shell", view); err != nil {
+		t.Fatalf("render substep_shell template: %v", err)
+	}
+	body := out.String()
+
+	if strings.Contains(body, `<span class="status">`) {
+		t.Fatalf("did not expect status pill when HideStatus is true, got: %s", body)
+	}
+	if strings.Contains(body, `class="substep substep-available"`) {
+		t.Fatalf("did not expect status-colored substep class when HideStatus is true, got: %s", body)
+	}
+	if !strings.Contains(body, `class="substep"`) {
+		t.Fatalf("expected bare substep class, got: %s", body)
+	}
+}
+
+func TestSubstepShellTemplateDispatchesToSubstepBody(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+
+	var out bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&out, "substep_shell", testSubstepShellView()); err != nil {
+		t.Fatalf("render substep_shell template: %v", err)
+	}
+	body := out.String()
+
+	if !strings.Contains(body, `class="substep-body-form"`) {
+		t.Fatalf("expected substep_body form markup, got: %s", body)
+	}
+}
+
+func TestSubstepShellTemplateRendersMissingBodyMessage(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+
+	view := testSubstepShellView()
+	view.Substep.Body = nil
+
+	var out bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&out, "substep_shell", view); err != nil {
+		t.Fatalf("render substep_shell template: %v", err)
+	}
+	body := out.String()
+
+	if !strings.Contains(body, "No data form configured for this substep.") {
+		t.Fatalf("expected missing-body fallback copy, got: %s", body)
+	}
+}

--- a/server/templates/components/stream_timeline.html
+++ b/server/templates/components/stream_timeline.html
@@ -21,57 +21,8 @@
     </summary>
     <ul class="stream-timeline-substeps">
       {{ range .Step.Substeps }}
-        {{ template "stream_timeline_substep" (streamTimelineSubstep . $.HideStatus) }}
+        {{ template "substep_shell" (streamTimelineSubstep . $.HideStatus) }}
       {{ end }}
     </ul>
   </details>
-{{ end }}
-
-{{ define "stream_timeline_substep" }}
-  <li
-    class="substep{{ if not .HideStatus }} substep-{{ .Substep.Status }}{{ end }}"
-    data-role-palette="{{ .Substep.Palette }}"
-  >
-    <details
-      class="substep-accordion js-process-substep-panel"
-      data-substep-id="{{ .Substep.SubstepID }}"
-      {{ if .Substep.Selected }}open{{ end }}
-    >
-      <summary class="substep-accordion-summary">
-        <div class="substep-summary-main">
-          <span class="pill pill-panel">{{ .Substep.SubstepID }}</span>
-          <div class="substep-title">
-            <span class="substep-title-heading">{{ .Substep.Title }}</span>
-            {{ if eq .Substep.Status "done" }}
-              <div class="substep-meta">
-                {{ if .Substep.DoneAt }}
-                  <span
-                    ><strong>Completed at:</strong> {{ .Substep.DoneAt }}</span
-                  >
-                {{ end }}
-                {{ if .Substep.DoneBy }}
-                  <span><strong>Operator:</strong> {{ .Substep.DoneBy }}</span>
-                {{ end }}
-              </div>
-            {{ end }}
-          </div>
-        </div>
-        {{ if not .HideStatus }}
-          <span class="status">{{- if .Substep.StatusLabel }}{{ .Substep.StatusLabel }}{{ else }}{{ .Substep.Status }}{{ end -}}</span>
-        {{ end }}
-        <span class="substep-accordion-chevron" aria-hidden="true">
-          {{ template "icon-chevron-down" . }}
-        </span>
-      </summary>
-      <div class="substep-details">
-        {{ with .Substep.Body }}
-          {{ template "substep_body" . }}
-        {{ else }}
-          <p class="muted">
-            No data form configured for this substep.
-          </p>
-        {{ end }}
-      </div>
-    </details>
-  </li>
 {{ end }}

--- a/server/templates/components/substep_shell.html
+++ b/server/templates/components/substep_shell.html
@@ -1,0 +1,48 @@
+{{ define "substep_shell" }}
+  <li
+    class="substep{{ if not .HideStatus }} substep-{{ .Substep.Status }}{{ end }}"
+    data-role-palette="{{ .Substep.Palette }}"
+  >
+    <details
+      class="substep-accordion js-process-substep-panel"
+      data-substep-id="{{ .Substep.SubstepID }}"
+      {{ if .Substep.Selected }}open{{ end }}
+    >
+      <summary class="substep-accordion-summary">
+        <div class="substep-summary-main">
+          <span class="pill pill-panel">{{ .Substep.SubstepID }}</span>
+          <div class="substep-title">
+            <span class="substep-title-heading">{{ .Substep.Title }}</span>
+            {{ if eq .Substep.Status "done" }}
+              <div class="substep-meta">
+                {{ if .Substep.DoneAt }}
+                  <span
+                    ><strong>Completed at:</strong> {{ .Substep.DoneAt }}</span
+                  >
+                {{ end }}
+                {{ if .Substep.DoneBy }}
+                  <span><strong>Operator:</strong> {{ .Substep.DoneBy }}</span>
+                {{ end }}
+              </div>
+            {{ end }}
+          </div>
+        </div>
+        {{ if not .HideStatus }}
+          <span class="status">{{- if .Substep.StatusLabel }}{{ .Substep.StatusLabel }}{{ else }}{{ .Substep.Status }}{{ end -}}</span>
+        {{ end }}
+        <span class="substep-accordion-chevron" aria-hidden="true">
+          {{ template "icon-chevron-down" . }}
+        </span>
+      </summary>
+      <div class="substep-details">
+        {{ with .Substep.Body }}
+          {{ template "substep_body" . }}
+        {{ else }}
+          <p class="muted">
+            No data form configured for this substep.
+          </p>
+        {{ end }}
+      </div>
+    </details>
+  </li>
+{{ end }}


### PR DESCRIPTION
## Summary
- Extract `stream_timeline_substep` markup into reusable `substep_shell.html` (`define "substep_shell"`)
- Update `stream_timeline.html` to delegate substeps via `{{ template "substep_shell" dict ... }}`
- Add focused template tests in `substep_shell_test.go` and update `docs/css.md` template index

## Test plan
- [x] `cd server && go test ./cmd/server/ -count=1`
- [x] `SubstepShell` tests cover accordion render, HideStatus, substep_body dispatch, missing body fallback
- [x] Existing `StreamTimeline` tests still pass


Made with [Cursor](https://cursor.com)