### PR TITLE
Extract shared timeline substep status helper

### DIFF
--- a/server/cmd/server/dpp.go
+++ b/server/cmd/server/dpp.go
@@ -268,9 +268,10 @@ func buildDPPTraceabilityView(def WorkflowDef, process *Process, workflowKey str
 				overrideReason = strings.TrimSpace(override.Reason)
 			}
 
-			progress, done := process.Progress[sub.SubstepID]
-			if done && progress.State == "done" {
-				status = "done"
+			status = resolveTimelineSubstepStatus(sub.SubstepID, process, availableMap, terminated, terminationSubstepID, pastTermination)
+			switch status {
+			case "done":
+				progress := process.Progress[sub.SubstepID]
 				if hasOverride {
 					reason = "Completed with local form adaptation."
 					if overrideReason != "" {
@@ -297,19 +298,15 @@ func buildDPPTraceabilityView(def WorkflowDef, process *Process, workflowKey str
 				digest = digestPayload(progress.Data)
 				values = dppTraceValues(sub, progress)
 				attachments = buildSubstepAttachments(workflowKey, process, progress.Data)
-			} else if terminated && strings.TrimSpace(sub.SubstepID) == terminationSubstepID {
-				status = processStatusTerminated
+			case processStatusTerminated:
 				reason = "Stream ended early"
 				detailMessage = terminationReason
 				if detailMessage == "" {
 					detailMessage = "No reason provided."
 				}
-			} else if terminated && (pastTermination || terminationSubstepID == "") {
-				status = "skipped"
+			case "skipped":
 				reason = "Stream ended early"
 				detailMessage = "Step not completed because the stream was ended before this."
-			} else if availableMap[sub.SubstepID] {
-				status = "available"
 			}
 
 			body := &SubstepBodyView{
@@ -348,9 +345,7 @@ func buildDPPTraceabilityView(def WorkflowDef, process *Process, workflowKey str
 				Body:        body,
 			}
 			row.Substeps = append(row.Substeps, entry)
-			if terminated && strings.TrimSpace(sub.SubstepID) == terminationSubstepID {
-				pastTermination = true
-			}
+			pastTermination = advanceTimelinePastTermination(sub.SubstepID, terminated, terminationSubstepID, pastTermination)
 		}
 		steps = append(steps, row)
 	}

--- a/server/cmd/server/timeline_builder.go
+++ b/server/cmd/server/timeline_builder.go
@@ -2,6 +2,29 @@ package main
 
 import "strings"
 
+func resolveTimelineSubstepStatus(substepID string, process *Process, availableMap map[string]bool, terminated bool, terminationSubstepID string, pastTermination bool) string {
+	if process == nil {
+		return "locked"
+	}
+	if progress, ok := process.Progress[substepID]; ok && progress.State == "done" {
+		return "done"
+	}
+	if terminated && strings.TrimSpace(substepID) == terminationSubstepID {
+		return processStatusTerminated
+	}
+	if terminated && (pastTermination || terminationSubstepID == "") {
+		return "skipped"
+	}
+	if availableMap[substepID] {
+		return "available"
+	}
+	return "locked"
+}
+
+func advanceTimelinePastTermination(substepID string, terminated bool, terminationSubstepID string, pastTermination bool) bool {
+	return pastTermination || (terminated && strings.TrimSpace(substepID) == terminationSubstepID)
+}
+
 func buildTimeline(def WorkflowDef, process *Process, workflowKey string, roleIndex map[roleMetaKey]RoleMeta, cfgRoles []WorkflowRole, orgNames map[string]string) []TimelineStep {
 	steps := sortedSteps(def)
 	substepOrgs := substepOrganizationMap(def)
@@ -32,38 +55,25 @@ func buildTimeline(def WorkflowDef, process *Process, workflowKey string, roleIn
 				Title:     sub.Title,
 				Palette:   meta.Palette,
 			}
-			if process != nil {
-				if progress, ok := process.Progress[sub.SubstepID]; ok && progress.State == "done" {
-					entry.Status = "done"
-					if progress.DoneBy != nil {
-						entry.DoneBy = progress.DoneBy.ID
-						entry.DoneRole = progress.DoneBy.Role
-						selectedRole := strings.TrimSpace(progress.DoneBy.Role)
-						if selectedRole != "" {
-							selectedMeta := roleMetaForOrg(substepOrgs[sub.SubstepID], selectedRole, roleIndex, cfgRoles)
-							entry.Palette = selectedMeta.Palette
-						}
+			entry.Status = resolveTimelineSubstepStatus(sub.SubstepID, process, availableMap, terminated, terminationSubstepID, pastTermination)
+			if entry.Status == "done" && process != nil {
+				progress := process.Progress[sub.SubstepID]
+				if progress.DoneBy != nil {
+					entry.DoneBy = progress.DoneBy.ID
+					entry.DoneRole = progress.DoneBy.Role
+					selectedRole := strings.TrimSpace(progress.DoneBy.Role)
+					if selectedRole != "" {
+						selectedMeta := roleMetaForOrg(substepOrgs[sub.SubstepID], selectedRole, roleIndex, cfgRoles)
+						entry.Palette = selectedMeta.Palette
 					}
-					if progress.DoneAt != nil {
-						entry.DoneAt = humanReadableTraceabilityTime(*progress.DoneAt)
-					}
-				} else if terminated && strings.TrimSpace(sub.SubstepID) == terminationSubstepID {
-					entry.Status = processStatusTerminated
-				} else if terminated && (pastTermination || terminationSubstepID == "") {
-					entry.Status = "skipped"
-				} else if availableMap[sub.SubstepID] {
-					entry.Status = "available"
-				} else {
-					entry.Status = "locked"
 				}
-			} else {
-				entry.Status = "locked"
+				if progress.DoneAt != nil {
+					entry.DoneAt = humanReadableTraceabilityTime(*progress.DoneAt)
+				}
 			}
 			entry.StatusLabel = processStatusLabel(entry.Status)
 			row.Substeps = append(row.Substeps, entry)
-			if terminated && strings.TrimSpace(sub.SubstepID) == terminationSubstepID {
-				pastTermination = true
-			}
+			pastTermination = advanceTimelinePastTermination(sub.SubstepID, terminated, terminationSubstepID, pastTermination)
 		}
 		timeline = append(timeline, row)
 	}

--- a/server/cmd/server/timeline_builder_test.go
+++ b/server/cmd/server/timeline_builder_test.go
@@ -7,6 +7,158 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
+func TestResolveTimelineSubstepStatus(t *testing.T) {
+	process := &Process{
+		ID: primitive.NewObjectID(),
+		Progress: map[string]ProcessStep{
+			"1.1": {State: "done"},
+			"1.2": {State: "pending"},
+		},
+		Termination: &ProcessTermination{SubstepID: "1.3"},
+	}
+	availableMap := map[string]bool{
+		"1.4": true,
+	}
+
+	tests := []struct {
+		name                 string
+		substepID            string
+		process              *Process
+		availableMap         map[string]bool
+		terminated           bool
+		terminationSubstepID string
+		pastTermination      bool
+		want                 string
+	}{
+		{
+			name:         "nil process locked",
+			substepID:    "1.1",
+			process:      nil,
+			availableMap: availableMap,
+			want:         "locked",
+		},
+		{
+			name:         "done progress",
+			substepID:    "1.1",
+			process:      process,
+			availableMap: availableMap,
+			want:         "done",
+		},
+		{
+			name:                 "termination substep",
+			substepID:            "1.3",
+			process:              process,
+			availableMap:         availableMap,
+			terminated:           true,
+			terminationSubstepID: "1.3",
+			want:                 processStatusTerminated,
+		},
+		{
+			name:                 "skipped after termination",
+			substepID:            "1.4",
+			process:              process,
+			availableMap:         availableMap,
+			terminated:           true,
+			terminationSubstepID: "1.3",
+			pastTermination:      true,
+			want:                 "skipped",
+		},
+		{
+			name:                 "skipped when termination id missing",
+			substepID:            "1.2",
+			process:              process,
+			availableMap:         availableMap,
+			terminated:           true,
+			terminationSubstepID: "",
+			want:                 "skipped",
+		},
+		{
+			name:         "available before termination",
+			substepID:    "1.4",
+			process:      process,
+			availableMap: availableMap,
+			want:         "available",
+		},
+		{
+			name:         "locked pending progress",
+			substepID:    "1.2",
+			process:      process,
+			availableMap: availableMap,
+			want:         "locked",
+		},
+		{
+			name:                 "done beats termination on same substep",
+			substepID:            "1.1",
+			process:              process,
+			availableMap:         availableMap,
+			terminated:           true,
+			terminationSubstepID: "1.1",
+			want:                 "done",
+		},
+		{
+			name:                 "available beats skipped when not past termination",
+			substepID:            "1.4",
+			process:              process,
+			availableMap:         availableMap,
+			terminated:           true,
+			terminationSubstepID: "1.3",
+			pastTermination:      false,
+			want:                 "available",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveTimelineSubstepStatus(tc.substepID, tc.process, tc.availableMap, tc.terminated, tc.terminationSubstepID, tc.pastTermination)
+			if got != tc.want {
+				t.Fatalf("status = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAdvanceTimelinePastTermination(t *testing.T) {
+	tests := []struct {
+		name                 string
+		substepID            string
+		terminated           bool
+		terminationSubstepID string
+		pastTermination      bool
+		want                 bool
+	}{
+		{
+			name:            "already past termination",
+			substepID:       "1.4",
+			terminated:      true,
+			pastTermination: true,
+			want:            true,
+		},
+		{
+			name:                 "marks termination substep",
+			substepID:            "1.3",
+			terminated:           true,
+			terminationSubstepID: "1.3",
+			want:                 true,
+		},
+		{
+			name:                 "before termination substep",
+			substepID:            "1.2",
+			terminated:           true,
+			terminationSubstepID: "1.3",
+			want:                 false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := advanceTimelinePastTermination(tc.substepID, tc.terminated, tc.terminationSubstepID, tc.pastTermination)
+			if got != tc.want {
+				t.Fatalf("pastTermination = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestBuildTimelineLegacyActorWithoutOrgSlug(t *testing.T) {
 	cfg := testRuntimeConfig()
 	doneAt := time.Date(2026, 2, 26, 10, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Summary
- Add `resolveTimelineSubstepStatus` and `advanceTimelinePastTermination` in `timeline_builder.go` to centralize substep status resolution (done, terminated, skipped, available, locked).
- Wire `buildTimeline` and `buildDPPTraceabilityView` to the shared helper, preserving existing behavior and DPP-specific reason/detail messaging.
- Add table-driven unit tests for status edge cases and past-termination advancement.

## Test plan
- [x] `cd server && go test ./cmd/server/ -count=1`
- [x] New tests: `TestResolveTimelineSubstepStatus`, `TestAdvanceTimelinePastTermination`
- [x] Existing timeline/DPP tests still pass


Made with [Cursor](https://cursor.com)