### PR TITLE
refactor(ui): typed view DTOs for stream timeline templates

### DIFF
--- a/server/cmd/server/components.go
+++ b/server/cmd/server/components.go
@@ -108,6 +108,24 @@ type TimelineStep struct {
 	Substeps []TimelineSubstep
 }
 
+// StreamTimelineView is the view model for templates/components/stream_timeline.html.
+type StreamTimelineView struct {
+	Timeline   []TimelineStep
+	HideStatus bool
+}
+
+// StreamTimelineStepView wraps one timeline step for stream_timeline_step.
+type StreamTimelineStepView struct {
+	Step       TimelineStep
+	HideStatus bool
+}
+
+// StreamTimelineSubstepView wraps one timeline substep for stream_timeline_substep.
+type StreamTimelineSubstepView struct {
+	Substep    TimelineSubstep
+	HideStatus bool
+}
+
 // StreamInstanceDetailView is the HTMX/SSE partial payload for stream instance detail content.
 type StreamInstanceDetailView struct {
 	WorkflowKey       string
@@ -128,4 +146,11 @@ type StreamInstanceDetailView struct {
 	TerminateSubstep  string
 	TerminateRoles    []SubstepRoleOption
 	Termination       *ProcessTerminationView
+}
+
+func (v StreamInstanceDetailView) StreamTimeline() StreamTimelineView {
+	return StreamTimelineView{
+		Timeline:   v.Timeline,
+		HideStatus: v.HideStatus,
+	}
 }

--- a/server/cmd/server/stream_timeline_test.go
+++ b/server/cmd/server/stream_timeline_test.go
@@ -6,10 +6,8 @@ import (
 	"testing"
 )
 
-func testStreamTimelineView() StreamInstanceDetailView {
-	return StreamInstanceDetailView{
-		WorkflowKey: "workflow",
-		ProcessID:   "process-1",
+func testStreamTimelineView() StreamTimelineView {
+	return StreamTimelineView{
 		Timeline: []TimelineStep{{
 			Summary: StepSummaryView{
 				StepID:           "1",

--- a/server/cmd/server/templates.go
+++ b/server/cmd/server/templates.go
@@ -15,6 +15,12 @@ var templateGlobPatterns = []string{
 
 func templateFuncs() template.FuncMap {
 	return template.FuncMap{
+		"streamTimelineStep": func(step TimelineStep, hideStatus bool) StreamTimelineStepView {
+			return StreamTimelineStepView{Step: step, HideStatus: hideStatus}
+		},
+		"streamTimelineSubstep": func(substep TimelineSubstep, hideStatus bool) StreamTimelineSubstepView {
+			return StreamTimelineSubstepView{Substep: substep, HideStatus: hideStatus}
+		},
 		"dict": func(values ...any) (map[string]any, error) {
 			if len(values)%2 != 0 {
 				return nil, fmt.Errorf("dict: odd number of arguments")

--- a/server/templates/components/stream_timeline.html
+++ b/server/templates/components/stream_timeline.html
@@ -3,7 +3,7 @@
 {{ define "stream_timeline" }}
   <div class="stream-timeline-list">
     {{ range .Timeline }}
-      {{ template "stream_timeline_step" dict "Step" . "HideStatus" $.HideStatus }}
+      {{ template "stream_timeline_step" (streamTimelineStep . $.HideStatus) }}
     {{ end }}
   </div>
 {{ end }}
@@ -21,7 +21,7 @@
     </summary>
     <ul class="stream-timeline-substeps">
       {{ range .Step.Substeps }}
-        {{ template "stream_timeline_substep" dict "Substep" . "HideStatus" $.HideStatus }}
+        {{ template "stream_timeline_substep" (streamTimelineSubstep . $.HideStatus) }}
       {{ end }}
     </ul>
   </details>

--- a/server/templates/pages/dpp.html
+++ b/server/templates/pages/dpp.html
@@ -65,7 +65,7 @@
             <div class="dpp-history-rail" aria-hidden="true">
               <span class="dpp-history-dot"></span>
             </div>
-            {{ template "stream_timeline_step" dict "Step" . "HideStatus" true }}
+            {{ template "stream_timeline_step" (streamTimelineStep . true) }}
           </div>
         {{ end }}
       </div>

--- a/server/templates/pages/process.html
+++ b/server/templates/pages/process.html
@@ -20,7 +20,7 @@
     {{ template "page_header" .Header }}
     {{ if .Detail.ProcessDone }}
       <div class="process-resources-grid">
-        {{ template "stream_timeline" .Detail }}
+        {{ template "stream_timeline" .Detail.StreamTimeline }}
         <div class="stack layout-stack-separator u-gap-4">
           {{ template "process_termination_details" .Detail }}
           {{ template "process_dpp" . }}
@@ -28,7 +28,7 @@
         </div>
       </div>
     {{ else }}
-      {{ template "stream_timeline" .Detail }}
+      {{ template "stream_timeline" .Detail.StreamTimeline }}
       {{ if .Detail.CanTerminate }}
         <div class="manage-dialog-actions manage-dialog-actions-end">
           <button

--- a/server/templates/pages/stream.html
+++ b/server/templates/pages/stream.html
@@ -154,7 +154,7 @@
               </button>
             </header>
             <div class="stream-preview-dialog-body">
-              {{ template "stream_timeline" .Preview }}
+              {{ template "stream_timeline" .Preview.StreamTimeline }}
             </div>
           </div>
         </dialog>


### PR DESCRIPTION
## Summary
- Add `StreamTimelineView`, `StreamTimelineStepView`, and `StreamTimelineSubstepView` in `components.go`.
- Replace `dict` wrappers at inner `stream_timeline` define call sites with template funcs and typed structs.
- Update process, stream preview, and DPP history call sites to pass narrow timeline view contracts.

## Test plan
- [x] `cd server && go test ./cmd/server/ -count=1`
- [x] Stream timeline, process template, home preview, and DPP handler template tests pass


Made with [Cursor](https://cursor.com)