### PR TITLE
refactor(css): split substep override module and dedupe chevrons

### DIFF
--- a/docs/css.md
+++ b/docs/css.md
@@ -44,7 +44,8 @@ Org-admin forms, dialogs, and pickers live in `components/org-admin.css`, not th
 | `components/substep-body.css` | `.substep-body-*` | `components/substep_body.html`, `attachment_carousel.html` |
 | `components/stream-step-summary.css` | `.stream-step-summary-*` | `components/stream_step_summary.html` |
 | `components/stream-timeline.css` | `.stream-timeline-list`, `.stream-timeline-step*` | `components/stream_timeline.html` |
-| `components/substep-shell.css` | `.substep*`, override modal | `components/substep_shell.html`, `substep_override_editor.html` |
+| `components/substep-shell.css` | `.substep*`, accordion shell | `components/substep_shell.html` |
+| `components/substep-override.css` | `.substep-override-*`, `.js-open-substep-override` | `substep_override_editor.html` |
 
 Other partials (`icons.html`, …) still live at `server/templates/` root until migrated one by one. Split reused styles into `components/` and page-specific styles into `pages/`.
 
@@ -66,7 +67,7 @@ Other partials (`icons.html`, …) still live at `server/templates/` root until 
 | `pages/platform_admin.html` | `pages/platform-admin.css` | `components/shared.css` |
 | `pages/login.html`, `pages/signup.html`, `pages/invite.html`, `pages/reset_*.html` | `components/forms.css` | `components/shared.css` |
 | `attachment_carousel.html` | `components/substep-body.css` | — |
-| `substep_override_editor.html` | `components/substep-shell.css` | — |
+| `substep_override_editor.html` | `components/substep-override.css` | — |
 
 ### `data-*` contract (templates → CSS / JS)
 

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -3,6 +3,7 @@
 @import url("./components/stream-step-summary.css");
 @import url("./components/stream-timeline.css");
 @import url("./components/substep-shell.css");
+@import url("./components/substep-override.css");
 @import url("./components/substep-body.css");
 @import url("./components/forms.css");
 @import url("./components/org-admin.css");

--- a/web/src/styles/components/shared.css
+++ b/web/src/styles/components/shared.css
@@ -21,6 +21,27 @@ svg.bi {
   height: 21px;
 }
 
+.stream-timeline-step-chevron,
+.substep-accordion-chevron {
+  width: 32px;
+  height: 32px;
+  color: var(--muted-foreground);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition:
+    transform 180ms ease,
+    color 180ms ease,
+    border-color 180ms ease;
+}
+
+.stream-timeline-step-chevron .icon-svg,
+.substep-accordion-chevron .icon-svg {
+  width: 18px;
+  height: 18px;
+}
+
 .icon-hidden {
   display: none;
 }

--- a/web/src/styles/components/stream-timeline.css
+++ b/web/src/styles/components/stream-timeline.css
@@ -30,28 +30,9 @@
   display: none;
 }
 
-.stream-timeline-step-chevron {
-  width: 32px;
-  height: 32px;
-  color: var(--muted-foreground);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  transition:
-    transform 180ms ease,
-    color 180ms ease,
-    border-color 180ms ease;
-}
-
 .stream-timeline-step[open] .stream-timeline-step-chevron {
   transform: rotate(180deg);
   color: var(--foreground);
-}
-
-.stream-timeline-step-chevron .icon-svg {
-  width: 18px;
-  height: 18px;
 }
 
 .stream-timeline-substeps {
@@ -81,5 +62,10 @@
     top: 0;
     background: var(--card);
     z-index: 10;
+  }
+
+  /* When a substep accordion opens, unstick the parent stream-timeline step summary. */
+  .stream-timeline-step[open]:has(.substep-accordion[open]) > .stream-timeline-step-summary {
+    position: static;
   }
 }

--- a/web/src/styles/components/substep-override.css
+++ b/web/src/styles/components/substep-override.css
@@ -1,0 +1,69 @@
+.substep-override-modal {
+  width: calc(100vw - 32px);
+  height: calc(100vh - 32px);
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--card);
+  color: var(--foreground);
+  overflow: hidden;
+}
+
+.substep-override-modal::backdrop {
+  background: var(--backdrop-fullscreen);
+}
+
+.substep-override-editor,
+.substep-override-loading {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  height: 100%;
+  min-height: 0;
+  padding: var(--space-5);
+  box-sizing: border-box;
+}
+
+.substep-override-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.substep-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-lg);
+  line-height: var(--leading-none);
+}
+
+.substep-override-reason {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.substep-override-frame {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  flex: 1 1 auto;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--card);
+}
+
+.js-open-substep-override {
+  display: inline-flex;
+  padding: 0;
+  background: none;
+  border: none;
+  color: var(--primary);
+  margin: 0;
+  font-size: var(--text-xs);
+}
+
+.js-open-substep-override:hover {
+  text-decoration: underline;
+}

--- a/web/src/styles/components/substep-shell.css
+++ b/web/src/styles/components/substep-shell.css
@@ -1,22 +1,3 @@
-.substep-accordion-chevron {
-  width: 32px;
-  height: 32px;
-  color: var(--muted-foreground);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  transition:
-    transform 180ms ease,
-    color 180ms ease,
-    border-color 180ms ease;
-}
-
-.substep-accordion-chevron .icon-svg {
-  width: 18px;
-  height: 18px;
-}
-
 .substep {
   border-radius: 4px;
   border: 1px solid var(--substep-done);
@@ -204,76 +185,6 @@
   gap: var(--space-3);
 }
 
-.substep-override-modal {
-  width: calc(100vw - 32px);
-  height: calc(100vh - 32px);
-  padding: 0;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  background: var(--card);
-  color: var(--foreground);
-  overflow: hidden;
-}
-
-.substep-override-modal::backdrop {
-  background: var(--backdrop-fullscreen);
-}
-
-.substep-override-editor,
-.substep-override-loading {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
-  height: 100%;
-  min-height: 0;
-  padding: var(--space-5);
-  box-sizing: border-box;
-}
-
-.substep-override-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--space-4);
-}
-
-.substep-head {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-size: var(--text-lg);
-  line-height: var(--leading-none);
-}
-
-.substep-override-reason {
-  display: grid;
-  gap: var(--space-2);
-}
-
-.substep-override-frame {
-  width: 100%;
-  height: 100%;
-  min-height: 0;
-  flex: 1 1 auto;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  background: var(--card);
-}
-
-.js-open-substep-override {
-  display: inline-flex;
-  padding: 0;
-  background: none;
-  border: none;
-  color: var(--primary);
-  margin: 0;
-  font-size: var(--text-xs);
-}
-
-.js-open-substep-override:hover {
-  text-decoration: underline;
-}
-
 @media (--sm-down) {
   .substep-accordion-summary {
     flex-wrap: wrap;
@@ -333,10 +244,5 @@
     position: sticky;
     top: 0;
     z-index: 10;
-  }
-
-  /* When a substep accordion opens, unstick the parent stream-timeline step summary. */
-  .stream-timeline-step[open]:has(.substep-accordion[open]) > .stream-timeline-step-summary {
-    position: static;
   }
 }


### PR DESCRIPTION
## Summary
- Extract `.substep-override-*` and `.js-open-substep-override` rules into new `substep-override.css`
- Move the stream-timeline step unstick `:has()` rule from `substep-shell.css` into `stream-timeline.css` under `@media (--md-down)`
- Deduplicate accordion chevron base styles via grouped selectors in `shared.css`; open-state rotations stay in their component modules
- Update `docs/css.md` component modules table and template↔CSS index

## Test plan
- [x] `task css:lint` — template inline styles, breakpoint guard, stylelint all pass
- [x] `cd server && go test ./cmd/server/ -count=1` — pass


Made with [Cursor](https://cursor.com)