### PR TITLE
Give org-admin settings sections distinct URLs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ See: `README.md`, `QUICKSTART.md`, `DOCKER.md`, `docs/css.md` (main app styling)
 - Stream dashboard is `/w/:key/` (lists stream instances for one stream). Legacy `/dashboard` and `/w/:key/dashboard` are not registered.
 - Admin consoles:
   - Platform admin: `/admin/orgs` (create/edit/delete orgs, upload logos, invite org admins)
-  - Org admin: `/org-admin/profile`, `/org-admin/roles`, `/org-admin/members` (legacy `GET /org-admin/users` redirects to members)
+  - Org admin: `/org-admin/profile`, `/org-admin/roles`, `/org-admin/members` (legacy `GET /org-admin/users` redirects to profile)
 - Platform admin is env-driven (`ADMIN_EMAIL`, `ADMIN_PASSWORD`). On startup the server ensures that account exists in Appwrite (`bootstrapPlatformAdminIdentity`). Cerbos policy `platform_admin_console` gates console access.
 - Auth/org state now lives in Appwrite:
   - orgs -> teams
@@ -25,7 +25,7 @@ See: `README.md`, `QUICKSTART.md`, `DOCKER.md`, `docs/css.md` (main app styling)
   - signup/login/reset -> Appwrite account/session/recovery flows
 - Global topbar now renders role-aware admin links on authenticated pages:
   - Platform admin sees `Orgs` (`/admin/orgs`)
-  - Org admin with org context sees `My Org` (`/org-admin/members`)
+  - Org admin with org context sees `My Org` (`/org-admin/profile`)
 - Workflow YAML supports `organizations`, `roles`, step-level `organization`, and substep `roles`.
 - Slug collisions on org and role creation now surface explicit `... slug already exists` errors in admin UIs.
 - Org admin members section (`/org-admin/members`; forms still `POST /org-admin/users`) supports:
@@ -136,7 +136,7 @@ Global routes are registered in `Server.newMux()` (`server/cmd/server/main.go`).
 - `GET/POST /login`, `GET/POST /signup`, `POST /logout`
 - `GET /invite/…`, `GET/POST /reset`, `GET/POST /reset/…`
 - `GET/POST /admin/orgs`, `GET/POST /admin/orgs/` (platform admin org console; logo at `/admin/orgs/logo/:id`)
-- `GET /org-admin/profile`, `/org-admin/roles`, `/org-admin/members` (org settings sections); `GET /org-admin/users` → members; `POST /org-admin/users`, `POST /org-admin/roles`; `/org-admin/formata-builder`, …
+- `GET /org-admin/profile`, `/org-admin/roles`, `/org-admin/members` (org settings sections); `GET /org-admin/users` → profile; `POST /org-admin/users`, `POST /org-admin/roles`; `/org-admin/formata-builder`, …
 - `GET /01/…` — public DPP Digital Link
 - `GET /events` — legacy SSE mux entry (production UI uses workflow-scoped path below)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ See: `README.md`, `QUICKSTART.md`, `DOCKER.md`, `docs/css.md` (main app styling)
 - Stream dashboard is `/w/:key/` (lists stream instances for one stream). Legacy `/dashboard` and `/w/:key/dashboard` are not registered.
 - Admin consoles:
   - Platform admin: `/admin/orgs` (create/edit/delete orgs, upload logos, invite org admins)
-  - Org admin: `/org-admin/roles`, `/org-admin/users`
+  - Org admin: `/org-admin/profile`, `/org-admin/roles`, `/org-admin/members` (legacy `GET /org-admin/users` redirects to members)
 - Platform admin is env-driven (`ADMIN_EMAIL`, `ADMIN_PASSWORD`). On startup the server ensures that account exists in Appwrite (`bootstrapPlatformAdminIdentity`). Cerbos policy `platform_admin_console` gates console access.
 - Auth/org state now lives in Appwrite:
   - orgs -> teams
@@ -25,10 +25,10 @@ See: `README.md`, `QUICKSTART.md`, `DOCKER.md`, `docs/css.md` (main app styling)
   - signup/login/reset -> Appwrite account/session/recovery flows
 - Global topbar now renders role-aware admin links on authenticated pages:
   - Platform admin sees `Orgs` (`/admin/orgs`)
-  - Org admin with org context sees `My Org` (`/org-admin/users`)
+  - Org admin with org context sees `My Org` (`/org-admin/members`)
 - Workflow YAML supports `organizations`, `roles`, step-level `organization`, and substep `roles`.
 - Slug collisions on org and role creation now surface explicit `... slug already exists` errors in admin UIs.
-- `/org-admin/users` now supports:
+- Org admin members section (`/org-admin/members`; forms still `POST /org-admin/users`) supports:
   - invites with zero-to-many roles (`roles` multi-select, `intent=invite`)
   - "Invites I sent" with derived statuses (`pending`, `accepted`, `expired`)
   - user role editing (`intent=set_roles`) and soft-delete (`intent=delete_user`) with self-protection checks.
@@ -136,7 +136,7 @@ Global routes are registered in `Server.newMux()` (`server/cmd/server/main.go`).
 - `GET/POST /login`, `GET/POST /signup`, `POST /logout`
 - `GET /invite/…`, `GET/POST /reset`, `GET/POST /reset/…`
 - `GET/POST /admin/orgs`, `GET/POST /admin/orgs/` (platform admin org console; logo at `/admin/orgs/logo/:id`)
-- `GET/POST /org-admin/roles`, `/org-admin/users`, `/org-admin/formata-builder`, …
+- `GET /org-admin/profile`, `/org-admin/roles`, `/org-admin/members` (org settings sections); `GET /org-admin/users` → members; `POST /org-admin/users`, `POST /org-admin/roles`; `/org-admin/formata-builder`, …
 - `GET /01/…` — public DPP Digital Link
 - `GET /events` — legacy SSE mux entry (production UI uses workflow-scoped path below)
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,6 +11,33 @@ tasks:
     cmds:
       - git submodule update --init --recursive
 
+  worktree:env:
+    desc: Symlink primary checkout .env into this (or given) worktree. Usage - task worktree:env [-- path]
+    cmds:
+      - bash deployment/scripts/worktree-env.sh {{.CLI_ARGS}}
+
+  worktree:add:
+    desc: Create .worktrees/<branch> worktree and symlink .env. Usage - task worktree:add -- <branch>
+    cmds:
+      - |
+          set -euo pipefail
+          branch="{{.CLI_ARGS}}"
+          if [ -z "${branch}" ]; then
+            echo "usage: task worktree:add -- <branch>" >&2
+            exit 1
+          fi
+          path=".worktrees/${branch}"
+          if [ -e "${path}" ]; then
+            echo "error: ${path} already exists" >&2
+            exit 1
+          fi
+          if git show-ref --verify --quiet "refs/heads/${branch}"; then
+            git worktree add "${path}" "${branch}"
+          else
+            git worktree add -b "${branch}" "${path}"
+          fi
+          bash deployment/scripts/worktree-env.sh "${path}"
+
   start:
     desc: Bring up infra and show status.
     cmds:

--- a/deployment/scripts/worktree-env.sh
+++ b/deployment/scripts/worktree-env.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Symlink the primary checkout's .env into a worktree (or any target root).
+# Usage:
+#   deployment/scripts/worktree-env.sh              # current git toplevel
+#   deployment/scripts/worktree-env.sh /path/to/wt  # explicit worktree root
+set -euo pipefail
+
+main_root="$(git worktree list --porcelain | awk '/^worktree / { print substr($0, 10); exit }')"
+if [[ -z "${main_root}" || ! -d "${main_root}" ]]; then
+  echo "error: could not resolve primary worktree root" >&2
+  exit 1
+fi
+
+target_root="${1:-$(git rev-parse --show-toplevel)}"
+if [[ -z "${target_root}" || ! -d "${target_root}" ]]; then
+  echo "error: target root does not exist: ${target_root:-<empty>}" >&2
+  exit 1
+fi
+
+src="${main_root}/.env"
+dst="${target_root}/.env"
+
+if [[ ! -f "${src}" ]]; then
+  echo "error: no .env in primary checkout (${main_root})" >&2
+  echo "copy .env.example to .env there first" >&2
+  exit 1
+fi
+
+if [[ -L "${dst}" ]]; then
+  current="$(readlink "${dst}")"
+  if [[ "${current}" == "${src}" ]]; then
+    echo "ok: ${dst} already linked to ${src}"
+    exit 0
+  fi
+  echo "error: ${dst} is a symlink to ${current}, not ${src}" >&2
+  exit 1
+fi
+
+if [[ -e "${dst}" ]]; then
+  echo "ok: ${dst} already exists (not replacing a real file)"
+  exit 0
+fi
+
+ln -s "${src}" "${dst}"
+echo "linked ${dst} -> ${src}"

--- a/server/cmd/server/admin_handler_identity_test.go
+++ b/server/cmd/server/admin_handler_identity_test.go
@@ -1906,8 +1906,8 @@ func TestHandleOrgAdminUsersCreateOrgWithIdentity(t *testing.T) {
 	if createSessionSecret != "session-1" || createName != "Fresh Org" {
 		t.Fatalf("create args = %q %q", createSessionSecret, createName)
 	}
-	if rec.Header().Get("Location") != "/org-admin/users" {
-		t.Fatalf("location = %q, want /org-admin/users", rec.Header().Get("Location"))
+	if rec.Header().Get("Location") != "/org-admin/members" {
+		t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
 	}
 }
 
@@ -2084,8 +2084,8 @@ func TestHandleOrgAdminUsersUpdateOrgWithIdentityLogo(t *testing.T) {
 	if deletedLogoFileID != "logo-old" {
 		t.Fatalf("deleted logo = %q, want logo-old", deletedLogoFileID)
 	}
-	if rec.Header().Get("Location") != "/org-admin/users" {
-		t.Fatalf("location = %q, want /org-admin/users", rec.Header().Get("Location"))
+	if rec.Header().Get("Location") != "/org-admin/profile" {
+		t.Fatalf("location = %q, want /org-admin/profile", rec.Header().Get("Location"))
 	}
 }
 
@@ -2325,8 +2325,11 @@ func TestHandleOrgAdminUsersSetRolesWithIdentity(t *testing.T) {
 
 	server.handleOrgAdminUsers(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if rec.Header().Get("Location") != "/org-admin/members" {
+		t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
 	}
 	if !hasIdentityLabel(users[1].Labels, identityOrgAdminLabel) || !containsRole(decodeIdentityRoleLabels(users[1].Labels), "approver") {
 		t.Fatalf("updated user labels = %#v", users[1].Labels)
@@ -2486,8 +2489,11 @@ func TestHandleOrgAdminUsersInviteWithIdentity(t *testing.T) {
 
 	server.handleOrgAdminUsers(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if rec.Header().Get("Location") != "/org-admin/members" {
+		t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
 	}
 	if inviteCalls != 1 || len(invitedRoles) != 1 || invitedRoles[0] != "approver" || !invitedAdmin {
 		t.Fatalf("invite call = %d roles=%#v admin=%v", inviteCalls, invitedRoles, invitedAdmin)
@@ -2537,8 +2543,11 @@ func TestHandleOrgAdminUsersInviteIdentityDuplicatePending(t *testing.T) {
 
 	server.handleOrgAdminUsers(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if rec.Header().Get("Location") != "/org-admin/members" {
+		t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
 	}
 	if inviteCalls != 0 {
 		t.Fatalf("invite calls = %d, want 0", inviteCalls)
@@ -2593,8 +2602,11 @@ func TestHandleOrgAdminUsersInviteIdentityExistingAndCrossOrg(t *testing.T) {
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	rec := httptest.NewRecorder()
 	server.handleOrgAdminUsers(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("existing member status = %d, want %d", rec.Code, http.StatusOK)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("existing member status = %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if rec.Header().Get("Location") != "/org-admin/members" {
+		t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
 	}
 	if len(updatedUsers["user-2"]) != 1 || updatedUsers["user-2"][0] != encodeIdentityRoleLabel("approver") {
 		t.Fatalf("updated user labels = %#v", updatedUsers)
@@ -2663,8 +2675,11 @@ func TestHandleOrgAdminUsersDeleteUserWithIdentity(t *testing.T) {
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	rec := httptest.NewRecorder()
 	server.handleOrgAdminUsers(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if rec.Header().Get("Location") != "/org-admin/members" {
+		t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
 	}
 	if len(deletedMemberships) != 1 || deletedMemberships[0] != "membership-2" {
 		t.Fatalf("deleted memberships = %#v", deletedMemberships)
@@ -2847,8 +2862,11 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminUsers(rec, req)
-		if rec.Code != http.StatusOK || updated != 1 {
-			t.Fatalf("pending update response = %d updated=%d body=%q", rec.Code, updated, rec.Body.String())
+		if rec.Code != http.StatusSeeOther || updated != 1 {
+			t.Fatalf("pending update response = %d updated=%d location=%q", rec.Code, updated, rec.Header().Get("Location"))
+		}
+		if rec.Header().Get("Location") != "/org-admin/members" {
+			t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
 		}
 	})
 
@@ -3754,8 +3772,11 @@ func TestHandleOrgAdminUsersIdentityAdditionalBranches(t *testing.T) {
 		getReq.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		getRec := httptest.NewRecorder()
 		server.handleOrgAdminUsers(getRec, getReq)
-		if getRec.Code != http.StatusOK || !strings.Contains(getRec.Body.String(), "ORG_ADMIN acme") {
-			t.Fatalf("get response = %d %q", getRec.Code, getRec.Body.String())
+		if getRec.Code != http.StatusSeeOther {
+			t.Fatalf("get status = %d, want %d", getRec.Code, http.StatusSeeOther)
+		}
+		if getRec.Header().Get("Location") != "/org-admin/members" {
+			t.Fatalf("get location = %q, want /org-admin/members", getRec.Header().Get("Location"))
 		}
 
 		postReq := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=unsupported"))

--- a/server/cmd/server/auth_reset_handler_test.go
+++ b/server/cmd/server/auth_reset_handler_test.go
@@ -398,7 +398,7 @@ func TestHandleResetPageHidesAdminTopbarLinks(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
 	body := rec.Body.String()
-	if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, `href="/org-admin/members"`) {
+	if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, `href="/org-admin/profile"`) {
 		t.Fatalf("expected reset page without admin nav links, got %q", body)
 	}
 }

--- a/server/cmd/server/auth_reset_handler_test.go
+++ b/server/cmd/server/auth_reset_handler_test.go
@@ -398,7 +398,7 @@ func TestHandleResetPageHidesAdminTopbarLinks(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
 	body := rec.Body.String()
-	if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, `href="/org-admin/users"`) {
+	if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, `href="/org-admin/members"`) {
 		t.Fatalf("expected reset page without admin nav links, got %q", body)
 	}
 }

--- a/server/cmd/server/auth_session_handler_test.go
+++ b/server/cmd/server/auth_session_handler_test.go
@@ -219,7 +219,7 @@ func TestHandleLoginPageHidesAdminTopbarLinks(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
 	body := rec.Body.String()
-	if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, `href="/org-admin/users"`) {
+	if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, `href="/org-admin/members"`) {
 		t.Fatalf("expected login page without admin nav links, got %q", body)
 	}
 }
@@ -581,8 +581,8 @@ func TestHandleSignupCreatesSessionAndRedirectsByOrgMembership(t *testing.T) {
 		if rec.Code != http.StatusSeeOther {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 		}
-		if rec.Header().Get("Location") != "/org-admin/users" {
-			t.Fatalf("location = %q, want /org-admin/users", rec.Header().Get("Location"))
+		if rec.Header().Get("Location") != "/org-admin/members" {
+			t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
 		}
 		if createdEmail != "new@example.com" || createdPassword != "secure-password" {
 			t.Fatalf("create account args = %q/%q", createdEmail, createdPassword)

--- a/server/cmd/server/auth_session_handler_test.go
+++ b/server/cmd/server/auth_session_handler_test.go
@@ -219,7 +219,7 @@ func TestHandleLoginPageHidesAdminTopbarLinks(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
 	body := rec.Body.String()
-	if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, `href="/org-admin/members"`) {
+	if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, `href="/org-admin/profile"`) {
 		t.Fatalf("expected login page without admin nav links, got %q", body)
 	}
 }
@@ -581,8 +581,8 @@ func TestHandleSignupCreatesSessionAndRedirectsByOrgMembership(t *testing.T) {
 		if rec.Code != http.StatusSeeOther {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 		}
-		if rec.Header().Get("Location") != "/org-admin/members" {
-			t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
+		if rec.Header().Get("Location") != "/org-admin/profile" {
+			t.Fatalf("location = %q, want /org-admin/profile", rec.Header().Get("Location"))
 		}
 		if createdEmail != "new@example.com" || createdPassword != "secure-password" {
 			t.Fatalf("create account args = %q/%q", createdEmail, createdPassword)

--- a/server/cmd/server/home_handler_test.go
+++ b/server/cmd/server/home_handler_test.go
@@ -660,18 +660,20 @@ func TestHandleWorkflowHomeRendersValidationState(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
 	body := rec.Body.String()
-	compactBody := strings.Join(strings.Fields(body), " ")
+	if !strings.Contains(body, `class="error`) {
+		t.Fatalf("expected error banner, got %q", body)
+	}
 	if !strings.Contains(body, "Stream configuration issue") {
-		t.Fatalf("expected validation panel heading, got %q", body)
+		t.Fatalf("expected validation heading inside error, got %q", body)
 	}
 	if !strings.Contains(body, "workflow references are invalid") {
 		t.Fatalf("expected validation error details, got %q", body)
 	}
-	if !strings.Contains(body, `action="/w/workflow/process/start"`) {
-		t.Fatalf("expected new stream form to remain present, got %q", body)
+	if strings.Contains(body, `class="home-workflow-grid"`) {
+		t.Fatalf("did not expect stream dashboard grid when config is invalid, got %q", body)
 	}
-	if !strings.Contains(compactBody, `class="btn btn-primary"`) || !strings.Contains(compactBody, `type="submit"`) || !strings.Contains(compactBody, `disabled`) || !strings.Contains(compactBody, `New instance`) {
-		t.Fatalf("expected new stream button to be disabled for invalid workflow, got %q", body)
+	if strings.Contains(body, `action="/w/workflow/process/start"`) || strings.Contains(body, "New instance") {
+		t.Fatalf("did not expect new instance controls when config is invalid, got %q", body)
 	}
 }
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -459,6 +459,7 @@ type PlatformAdminErrors struct {
 type OrgAdminView struct {
 	PageBase
 	Header                 PageHeaderView
+	ActivePanel            string
 	Organization           Organization
 	OrganizationLogoURL    string
 	NeedsOrganizationSetup bool
@@ -1296,7 +1297,7 @@ func (s *Server) logAndRenderPlatformAdminError(w http.ResponseWriter, r *http.R
 
 func (s *Server) logAndRenderOrgAdminError(w http.ResponseWriter, r *http.Request, user *AccountUser, orgSlug, inviteLink string, errs OrgAdminErrors, err error, message string, args ...interface{}) {
 	logRequestError(r, err, message, args...)
-	s.renderOrgAdminWithErrors(w, user, orgSlug, inviteLink, errs)
+	s.renderOrgAdminWithErrors(w, r, user, orgSlug, inviteLink, errs)
 }
 
 func workflowPath(key string) string {
@@ -2185,7 +2186,9 @@ func (s *Server) newMux() *http.ServeMux {
 	mux.HandleFunc("/invite/", s.handleInvite)
 	mux.HandleFunc("/reset", s.handleResetRequest)
 	mux.HandleFunc("/reset/", s.handleResetSet)
+	mux.HandleFunc("/org-admin/profile", s.handleOrgAdminPage)
 	mux.HandleFunc("/org-admin/roles", s.handleOrgAdminRoles)
+	mux.HandleFunc("/org-admin/members", s.handleOrgAdminPage)
 	mux.HandleFunc("/org-admin/logo/", s.handleOrgAdminLogo)
 	mux.HandleFunc("/org-admin/users", s.handleOrgAdminUsers)
 	mux.HandleFunc("/org-admin/formata-builder", s.handleOrgAdminFormataBuilder)
@@ -3610,11 +3613,27 @@ func (s *Server) handleAdminOrgs(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) renderOrgAdmin(w http.ResponseWriter, user *AccountUser, orgSlug, inviteLink, errMsg string) {
-	errs := OrgAdminErrors{
-		Organization: strings.TrimSpace(errMsg),
+func resolveOrgAdminActivePanel(r *http.Request, errs OrgAdminErrors, inviteLink string) string {
+	if strings.TrimSpace(errs.Role) != "" {
+		return "roles"
 	}
-	s.renderOrgAdminWithErrors(w, user, orgSlug, inviteLink, errs)
+	if strings.TrimSpace(errs.Users) != "" || strings.TrimSpace(errs.Invite) != "" || strings.TrimSpace(inviteLink) != "" {
+		return "members"
+	}
+	if strings.TrimSpace(errs.Organization) != "" {
+		return "profile"
+	}
+	if r != nil {
+		switch r.URL.Path {
+		case "/org-admin/roles":
+			return "roles"
+		case "/org-admin/members":
+			return "members"
+		case "/org-admin/profile":
+			return "profile"
+		}
+	}
+	return "profile"
 }
 
 func firstNonEmpty(values ...string) string {
@@ -3772,11 +3791,12 @@ func (s *Server) loadOrgAdminState(ctx context.Context, user *AccountUser, orgSl
 	return org, roles, orgUsers, nil, nil
 }
 
-func (s *Server) renderOrgAdminWithErrors(w http.ResponseWriter, user *AccountUser, orgSlug, inviteLink string, errs OrgAdminErrors) {
+func (s *Server) renderOrgAdminWithErrors(w http.ResponseWriter, r *http.Request, user *AccountUser, orgSlug, inviteLink string, errs OrgAdminErrors) {
 	errs.Organization = strings.TrimSpace(errs.Organization)
 	errs.Role = strings.TrimSpace(errs.Role)
 	errs.Invite = strings.TrimSpace(errs.Invite)
 	errs.Users = strings.TrimSpace(errs.Users)
+	activePanel := resolveOrgAdminActivePanel(r, errs, inviteLink)
 
 	if !userHasOrganizationContext(user) || strings.TrimSpace(orgSlug) == "" {
 		view := OrgAdminView{
@@ -3786,6 +3806,7 @@ func (s *Server) renderOrgAdminWithErrors(w http.ResponseWriter, user *AccountUs
 				Description: "Manage organization settings, roles, and members",
 				BackHref:    "/",
 			},
+			ActivePanel:            activePanel,
 			NeedsOrganizationSetup: true,
 			OrganizationError:      errs.Organization,
 			RoleError:              errs.Role,
@@ -3822,6 +3843,7 @@ func (s *Server) renderOrgAdminWithErrors(w http.ResponseWriter, user *AccountUs
 			Description: "Manage organization settings, roles, and members",
 			BackHref:    "/",
 		},
+		ActivePanel:            activePanel,
 		Organization:           org,
 		OrganizationLogoURL:    "/org-admin/logo/" + strings.TrimSpace(org.LogoAttachmentID),
 		NeedsOrganizationSetup: false,
@@ -3967,18 +3989,30 @@ func (s *Server) handlePlatformAdminLogo(w http.ResponseWriter, r *http.Request)
 	_, _ = w.Write(logo.Data)
 }
 
+func (s *Server) handleOrgAdminPage(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	admin, ok := s.requireOrgAdmin(w, r)
+	if !ok {
+		return
+	}
+	s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{})
+}
+
 func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 	user, ok := s.requireOrgAdmin(w, r)
 	if !ok {
 		return
 	}
 	if !userHasOrganizationContext(user) {
-		s.renderOrgAdminWithErrors(w, user, "", "", OrgAdminErrors{Organization: "create organization first"})
+		s.renderOrgAdminWithErrors(w, r, user, "", "", OrgAdminErrors{Organization: "create organization first"})
 		return
 	}
 	switch r.Method {
 	case http.MethodGet:
-		s.renderOrgAdmin(w, user, user.OrgSlug, "", "")
+		s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{})
 		return
 	case http.MethodPost:
 		if err := r.ParseForm(); err != nil {
@@ -4033,12 +4067,12 @@ func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 			name := strings.TrimSpace(r.FormValue("name"))
 			palette := strings.TrimSpace(r.FormValue("palette"))
 			if name == "" {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role name is required", RoleAction: "create", RolePalette: palette})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role name is required", RoleAction: "create", RolePalette: palette})
 				return
 			}
 			roleSlug := canonifyIdentityRoleSlug(name)
 			if roleSlug == "" {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: invalidRoleNameMessage, RoleAction: "create", RoleName: name, RolePalette: palette})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: invalidRoleNameMessage, RoleAction: "create", RoleName: name, RolePalette: palette})
 				return
 			}
 			if palette == "" {
@@ -4046,7 +4080,7 @@ func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 			}
 			for _, existingRole := range ensureOrgAdminRoleOption(rolesFromIdentityOrg(*org)) {
 				if strings.EqualFold(canonifyIdentityRoleSlug(existingRole.Slug), roleSlug) {
-					s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role slug already exists", RoleAction: "create", RoleName: name, RolePalette: palette})
+					s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role slug already exists", RoleAction: "create", RoleName: name, RolePalette: palette})
 					return
 				}
 			}
@@ -4057,7 +4091,7 @@ func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 			})
 			if _, err := s.identity.UpdateOrganization(r.Context(), sessionSecret, user.OrgSlug, org.Name, org.LogoFileID, updatedRoles); err != nil {
 				if isDuplicateSlugError(err) {
-					s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role slug already exists", RoleAction: "create", RoleName: name, RolePalette: palette})
+					s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role slug already exists", RoleAction: "create", RoleName: name, RolePalette: palette})
 					return
 				}
 				s.logAndRenderOrgAdminError(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "failed to create role", RoleAction: "create", RoleName: name, RolePalette: palette}, err, "failed to update organization %s with new role %s", user.OrgSlug, roleSlug)
@@ -4068,25 +4102,25 @@ func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 			name := strings.TrimSpace(r.FormValue("name"))
 			palette := strings.TrimSpace(r.FormValue("palette"))
 			if currentSlug == "" {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "edit"})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "edit"})
 				return
 			}
 			if name == "" {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role name is required", RoleAction: "edit", RoleSlug: currentSlug, RolePalette: palette})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role name is required", RoleAction: "edit", RoleSlug: currentSlug, RolePalette: palette})
 				return
 			}
 			targetRow := findRoleRow(currentSlug)
 			if targetRow == nil {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette})
 				return
 			}
 			if targetRow.InUse {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "remove the role from the users that have it before continuing with the action", RoleAction: "edit", RoleSlug: currentSlug, RoleName: targetRow.Name, RolePalette: targetRow.Palette})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "remove the role from the users that have it before continuing with the action", RoleAction: "edit", RoleSlug: currentSlug, RoleName: targetRow.Name, RolePalette: targetRow.Palette})
 				return
 			}
 			roleSlug := canonifyIdentityRoleSlug(name)
 			if roleSlug == "" {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: invalidRoleNameMessage, RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: invalidRoleNameMessage, RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette})
 				return
 			}
 			if palette == "" {
@@ -4097,7 +4131,7 @@ func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 			for idx := range updatedRoles {
 				if !containsRole([]string{updatedRoles[idx].Slug}, currentSlug) {
 					if strings.EqualFold(canonifyIdentityRoleSlug(updatedRoles[idx].Slug), roleSlug) {
-						s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role slug already exists", RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette})
+						s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role slug already exists", RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette})
 						return
 					}
 					continue
@@ -4110,12 +4144,12 @@ func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 				updatedRoles[idx].Border = ""
 			}
 			if !found {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette})
 				return
 			}
 			if _, err := s.identity.UpdateOrganization(r.Context(), sessionSecret, user.OrgSlug, org.Name, org.LogoFileID, updatedRoles); err != nil {
 				if isDuplicateSlugError(err) {
-					s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role slug already exists", RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette})
+					s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role slug already exists", RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette})
 					return
 				}
 				s.logAndRenderOrgAdminError(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "failed to update role", RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette}, err, "failed to update role %s in organization %s", currentSlug, user.OrgSlug)
@@ -4124,16 +4158,16 @@ func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 		case "delete_role":
 			currentSlug := strings.TrimSpace(r.FormValue("role_slug"))
 			if currentSlug == "" {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "delete"})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "delete"})
 				return
 			}
 			targetRow := findRoleRow(currentSlug)
 			if targetRow == nil {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "delete", RoleSlug: currentSlug})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "delete", RoleSlug: currentSlug})
 				return
 			}
 			if targetRow.InUse {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "remove the role from the users that have it before continuing with the action", RoleAction: "delete", RoleSlug: currentSlug, RoleName: targetRow.Name})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "remove the role from the users that have it before continuing with the action", RoleAction: "delete", RoleSlug: currentSlug, RoleName: targetRow.Name})
 				return
 			}
 			updatedRoles := make([]IdentityRole, 0, len(org.Roles))
@@ -4146,7 +4180,7 @@ func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 				updatedRoles = append(updatedRoles, role)
 			}
 			if !found {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "delete", RoleSlug: currentSlug})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "delete", RoleSlug: currentSlug})
 				return
 			}
 			if _, err := s.identity.UpdateOrganization(r.Context(), sessionSecret, user.OrgSlug, org.Name, org.LogoFileID, updatedRoles); err != nil {
@@ -4154,10 +4188,10 @@ func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		default:
-			s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "unsupported action"})
+			s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "unsupported action"})
 			return
 		}
-		http.Redirect(w, r, "/org-admin/users", http.StatusSeeOther)
+		http.Redirect(w, r, "/org-admin/roles", http.StatusSeeOther)
 		return
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -4173,8 +4207,12 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "identity unavailable", http.StatusServiceUnavailable)
 		return
 	}
+	if r.Method == http.MethodGet {
+		http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
+		return
+	}
 	if r.Method != http.MethodPost {
-		s.renderOrgAdmin(w, admin, admin.OrgSlug, "", "")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 	contentType := strings.ToLower(strings.TrimSpace(r.Header.Get("Content-Type")))
@@ -4182,7 +4220,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 		r.Body = http.MaxBytesReader(w, r.Body, organizationLogoMaxBytes())
 		if err := r.ParseMultipartForm(1 << 20); err != nil {
 			if isRequestTooLarge(err) {
-				s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "logo file too large"})
+				s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "logo file too large"})
 				return
 			}
 			logAndHTTPError(w, r, http.StatusBadRequest, "invalid form", err, "failed to parse org-admin multipart form")
@@ -4201,22 +4239,22 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 	}
 	if !userHasOrganizationContext(admin) {
 		if intent != "create_org" {
-			s.renderOrgAdminWithErrors(w, admin, "", "", OrgAdminErrors{Organization: "create organization first"})
+			s.renderOrgAdminWithErrors(w, r, admin, "", "", OrgAdminErrors{Organization: "create organization first"})
 			return
 		}
 		name := strings.TrimSpace(r.FormValue("name"))
 		if name == "" {
-			s.renderOrgAdminWithErrors(w, admin, "", "", OrgAdminErrors{Organization: "organization name is required"})
+			s.renderOrgAdminWithErrors(w, r, admin, "", "", OrgAdminErrors{Organization: "organization name is required"})
 			return
 		}
 		orgSlug := canonifySlug(name)
 		if existing, err := s.identity.GetOrganizationBySlug(r.Context(), orgSlug); err == nil && existing != nil {
-			s.renderOrgAdminWithErrors(w, admin, "", "", OrgAdminErrors{Organization: "organization slug already exists"})
+			s.renderOrgAdminWithErrors(w, r, admin, "", "", OrgAdminErrors{Organization: "organization slug already exists"})
 			return
 		}
 		logoUpload, logoErrMsg := s.readOrganizationLogoUpload(r)
 		if logoErrMsg != "" {
-			s.renderOrgAdminWithErrors(w, admin, "", "", OrgAdminErrors{Organization: logoErrMsg})
+			s.renderOrgAdminWithErrors(w, r, admin, "", "", OrgAdminErrors{Organization: logoErrMsg})
 			return
 		}
 		sessionSecret, err := sessionSecretFromRequest(r)
@@ -4227,7 +4265,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 		createdOrg, err := s.identity.CreateOrganization(r.Context(), sessionSecret, name)
 		if err != nil {
 			if isDuplicateSlugError(err) {
-				s.renderOrgAdminWithErrors(w, admin, "", "", OrgAdminErrors{Organization: "organization slug already exists"})
+				s.renderOrgAdminWithErrors(w, r, admin, "", "", OrgAdminErrors{Organization: "organization slug already exists"})
 				return
 			}
 			s.logAndRenderOrgAdminError(w, r, admin, "", "", OrgAdminErrors{Organization: "failed to create organization"}, err, "failed to create organization %s", name)
@@ -4249,17 +4287,17 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-		http.Redirect(w, r, "/org-admin/users", http.StatusSeeOther)
+		http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
 		return
 	}
 
 	switch intent {
 	case "create_org":
-		s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "organization already exists for your account"})
+		s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "organization already exists for your account"})
 	case "invite":
 		email := strings.ToLower(strings.TrimSpace(r.FormValue("email")))
 		if email == "" {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "email is required"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "email is required"})
 			return
 		}
 		org, err := s.identity.GetOrganizationBySlug(r.Context(), admin.OrgSlug)
@@ -4278,7 +4316,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 		}
 		for _, roleSlug := range selectedRoles {
 			if _, ok := allowed[strings.TrimSpace(roleSlug)]; !ok {
-				s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "role not found"})
+				s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "role not found"})
 				return
 			}
 		}
@@ -4312,7 +4350,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 					s.logAndRenderOrgAdminError(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "failed to update user roles"}, err, "failed to update labels for invited member %s in organization %s", membership.UserID, admin.OrgSlug)
 					return
 				}
-				s.renderOrgAdmin(w, admin, admin.OrgSlug, "", "")
+				http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
 				return
 			}
 			if roleSlugsKey(append(append([]string{}, membership.RoleSlugs...), func() []string {
@@ -4321,7 +4359,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 				}
 				return nil
 			}()...)) == roleSlugsKey(selectedRoles) {
-				s.renderOrgAdmin(w, admin, admin.OrgSlug, "", "")
+				http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
 				return
 			}
 			sessionSecret, err := sessionSecretFromRequest(r)
@@ -4333,13 +4371,13 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 				s.logAndRenderOrgAdminError(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "failed to create invite"}, err, "failed to update membership %s in organization %s", membership.ID, admin.OrgSlug)
 				return
 			}
-			s.renderOrgAdmin(w, admin, admin.OrgSlug, "", "")
+			http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
 			return
 		}
 		existingUser, err := s.identity.GetUserByEmail(r.Context(), email)
 		switch {
 		case err == nil && existingUser.OrgSlug != "" && !strings.EqualFold(strings.TrimSpace(existingUser.OrgSlug), strings.TrimSpace(admin.OrgSlug)):
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "email already belongs to another organization"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "email already belongs to another organization"})
 			return
 		case err == nil && strings.EqualFold(strings.TrimSpace(existingUser.OrgSlug), strings.TrimSpace(admin.OrgSlug)):
 			labels := make([]string, 0, len(businessRoles)+1)
@@ -4353,7 +4391,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 				s.logAndRenderOrgAdminError(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "failed to update user roles"}, err, "failed to update labels for existing user %s in organization %s", existingUser.ID, admin.OrgSlug)
 				return
 			}
-			s.renderOrgAdmin(w, admin, admin.OrgSlug, "", "")
+			http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
 			return
 		case err != nil && !errors.Is(err, ErrIdentityNotFound):
 			s.logAndRenderOrgAdminError(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "failed to load existing user"}, err, "failed to look up existing user %s during invite", email)
@@ -4368,11 +4406,11 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 			s.logAndRenderOrgAdminError(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "failed to create invite"}, err, "failed to create invite for %s in organization %s", email, admin.OrgSlug)
 			return
 		}
-		s.renderOrgAdmin(w, admin, admin.OrgSlug, "", "")
+		http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
 	case "update_org":
 		name := strings.TrimSpace(r.FormValue("name"))
 		if name == "" {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "organization name is required"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "organization name is required"})
 			return
 		}
 		org, err := s.identity.GetOrganizationBySlug(r.Context(), admin.OrgSlug)
@@ -4386,13 +4424,13 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 		targetOrgSlug := canonifySlug(name)
 		if targetOrgSlug != strings.TrimSpace(org.Slug) {
 			if existing, err := s.identity.GetOrganizationBySlug(r.Context(), targetOrgSlug); err == nil && existing != nil && strings.TrimSpace(existing.ID) != strings.TrimSpace(org.ID) {
-				s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "organization slug already exists"})
+				s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "organization slug already exists"})
 				return
 			}
 		}
 		logoUpload, logoErrMsg := s.readOrganizationLogoUpload(r)
 		if logoErrMsg != "" {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: logoErrMsg})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: logoErrMsg})
 			return
 		}
 		previousLogoFileID := strings.TrimSpace(org.LogoFileID)
@@ -4417,7 +4455,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 		updatedOrg, err := s.identity.UpdateOrganization(r.Context(), sessionSecret, admin.OrgSlug, name, logoFileID, append([]IdentityRole(nil), org.Roles...))
 		if err != nil {
 			if isDuplicateSlugError(err) {
-				s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "organization slug already exists"})
+				s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "organization slug already exists"})
 				return
 			}
 			s.logAndRenderOrgAdminError(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "failed to update organization"}, err, "failed to update organization %s", admin.OrgSlug)
@@ -4428,11 +4466,11 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 				log.Printf("failed to delete previous organization logo %q: %v", previousLogoFileID, err)
 			}
 		}
-		http.Redirect(w, r, "/org-admin/users", http.StatusSeeOther)
+		http.Redirect(w, r, "/org-admin/profile", http.StatusSeeOther)
 	case "set_roles":
 		userID := strings.TrimSpace(r.FormValue("userId"))
 		if userID == "" {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user is required"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user is required"})
 			return
 		}
 		org, err := s.identity.GetOrganizationBySlug(r.Context(), admin.OrgSlug)
@@ -4457,11 +4495,11 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if target == nil {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user not found"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user not found"})
 			return
 		}
 		if isPlatformAdminIdentityUser(*target) {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user not found"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user not found"})
 			return
 		}
 		selectedRoles := requestedRoleSlugs(r.Form)
@@ -4472,12 +4510,12 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 		}
 		for _, roleSlug := range selectedRoles {
 			if _, ok := allowed[strings.TrimSpace(roleSlug)]; !ok {
-				s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "role not found"})
+				s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "role not found"})
 				return
 			}
 		}
 		if firstNonEmpty(target.ID, target.Email) == firstNonEmpty(admin.IdentityUserID, admin.Email) && !containsRole(selectedRoles, "org-admin") {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "cannot remove org-admin from your own account"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "cannot remove org-admin from your own account"})
 			return
 		}
 		labels := make([]string, 0, len(target.Labels)+len(selectedRoles)+1)
@@ -4502,11 +4540,11 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 			s.logAndRenderOrgAdminError(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "failed to update user roles"}, err, "failed to update labels for user %s in organization %s", target.ID, admin.OrgSlug)
 			return
 		}
-		s.renderOrgAdmin(w, admin, admin.OrgSlug, "", "")
+		http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
 	case "delete_user":
 		userID := strings.TrimSpace(r.FormValue("userId"))
 		if userID == "" {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user is required"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user is required"})
 			return
 		}
 		memberships, err := s.identity.ListOrganizationMemberships(r.Context(), admin.OrgSlug)
@@ -4523,15 +4561,15 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if target == nil {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user not found"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user not found"})
 			return
 		}
 		if isPlatformAdminMembership(*target) {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user not found"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user not found"})
 			return
 		}
 		if firstNonEmpty(target.UserID, target.Email) == firstNonEmpty(admin.IdentityUserID, admin.Email) {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "cannot delete yourself"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "cannot delete yourself"})
 			return
 		}
 		sessionSecret, err := sessionSecretFromRequest(r)
@@ -4561,9 +4599,9 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-		s.renderOrgAdmin(w, admin, admin.OrgSlug, "", "")
+		http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
 	default:
-		s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "unsupported action"})
+		s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "unsupported action"})
 	}
 }
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -2481,7 +2481,7 @@ func (s *Server) handleSignup(w http.ResponseWriter, r *http.Request) {
 		}
 		redirectTarget := "/"
 		if strings.TrimSpace(identityUser.OrgSlug) == "" {
-			redirectTarget = "/org-admin/users"
+			redirectTarget = "/org-admin/members"
 		}
 		http.Redirect(w, r, redirectTarget, http.StatusSeeOther)
 		return

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -2481,7 +2481,7 @@ func (s *Server) handleSignup(w http.ResponseWriter, r *http.Request) {
 		}
 		redirectTarget := "/"
 		if strings.TrimSpace(identityUser.OrgSlug) == "" {
-			redirectTarget = "/org-admin/members"
+			redirectTarget = "/org-admin/profile"
 		}
 		http.Redirect(w, r, redirectTarget, http.StatusSeeOther)
 		return
@@ -4208,7 +4208,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if r.Method == http.MethodGet {
-		http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
+		http.Redirect(w, r, "/org-admin/profile", http.StatusSeeOther)
 		return
 	}
 	if r.Method != http.MethodPost {

--- a/server/cmd/server/org_admin_render_test.go
+++ b/server/cmd/server/org_admin_render_test.go
@@ -76,7 +76,7 @@ func TestRenderOrgAdminWithErrorsBranches(t *testing.T) {
 		server := &Server{tmpl: testTemplates(), now: func() time.Time { return now }}
 		rec := httptest.NewRecorder()
 
-		server.renderOrgAdminWithErrors(rec, &AccountUser{Email: "owner@example.com", RoleSlugs: []string{"org-admin"}, Status: "active"}, "", "/invite/token", OrgAdminErrors{
+		server.renderOrgAdminWithErrors(rec, nil, &AccountUser{Email: "owner@example.com", RoleSlugs: []string{"org-admin"}, Status: "active"}, "", "/invite/token", OrgAdminErrors{
 			Invite: " invite failed ",
 		})
 
@@ -101,7 +101,7 @@ func TestRenderOrgAdminWithErrorsBranches(t *testing.T) {
 		}
 		rec := httptest.NewRecorder()
 
-		server.renderOrgAdminWithErrors(rec, admin, "acme", "", OrgAdminErrors{})
+		server.renderOrgAdminWithErrors(rec, nil, admin, "acme", "", OrgAdminErrors{})
 
 		if rec.Code != http.StatusNotFound {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
@@ -133,7 +133,7 @@ func TestRenderOrgAdminWithErrorsBranches(t *testing.T) {
 		}
 		rec := httptest.NewRecorder()
 
-		server.renderOrgAdminWithErrors(rec, admin, "acme", "/invite/token", OrgAdminErrors{Users: " user error "})
+		server.renderOrgAdminWithErrors(rec, nil, admin, "acme", "/invite/token", OrgAdminErrors{Users: " user error "})
 
 		if rec.Code != http.StatusOK {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
@@ -175,7 +175,7 @@ func TestRenderOrgAdminWithErrorsBranches(t *testing.T) {
 		}
 		rec := httptest.NewRecorder()
 
-		server.renderOrgAdminWithErrors(rec, admin, "acme", "", OrgAdminErrors{})
+		server.renderOrgAdminWithErrors(rec, nil, admin, "acme", "", OrgAdminErrors{})
 
 		if rec.Code != http.StatusOK {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
@@ -191,7 +191,7 @@ func TestRenderOrgAdminWithErrorsBranches(t *testing.T) {
 		server := &Server{tmpl: tmpl, now: func() time.Time { return now }}
 		rec := httptest.NewRecorder()
 
-		server.renderOrgAdminWithErrors(rec, &AccountUser{Email: "owner@example.com"}, "", "", OrgAdminErrors{})
+		server.renderOrgAdminWithErrors(rec, nil, &AccountUser{Email: "owner@example.com"}, "", "", OrgAdminErrors{})
 
 		if rec.Code != http.StatusInternalServerError {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)

--- a/server/cmd/server/org_admin_section_urls_test.go
+++ b/server/cmd/server/org_admin_section_urls_test.go
@@ -57,7 +57,7 @@ func TestOrgAdminSectionURLHandlers(t *testing.T) {
 	now := time.Now().UTC()
 	server := orgAdminSectionURLTestServer(t, now)
 
-	t.Run("GET legacy users redirects to members", func(t *testing.T) {
+	t.Run("GET legacy users redirects to profile", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/org-admin/users", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -67,8 +67,8 @@ func TestOrgAdminSectionURLHandlers(t *testing.T) {
 		if rec.Code != http.StatusSeeOther {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 		}
-		if loc := rec.Header().Get("Location"); loc != "/org-admin/members" {
-			t.Fatalf("location = %q, want /org-admin/members", loc)
+		if loc := rec.Header().Get("Location"); loc != "/org-admin/profile" {
+			t.Fatalf("location = %q, want /org-admin/profile", loc)
 		}
 	})
 

--- a/server/cmd/server/org_admin_section_urls_test.go
+++ b/server/cmd/server/org_admin_section_urls_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func orgAdminSectionURLTestServer(t *testing.T, now time.Time) *Server {
+	t.Helper()
+	return &Server{
+		authorizer: fakeAuthorizer{},
+		store:      NewMemoryStore(),
+		identity: &fakeIdentityStore{
+			getSessionFunc: func(ctx context.Context, sessionSecret string) (IdentitySession, error) {
+				return fakeIdentitySession(sessionSecret, "user-1", now.Add(time.Hour)), nil
+			},
+			getCurrentUserFunc: func(ctx context.Context, sessionSecret string) (IdentityUser, error) {
+				return IdentityUser{
+					ID:         "user-1",
+					Email:      "owner@example.com",
+					OrgSlug:    "acme",
+					Labels:     []string{identityOrgAdminLabel},
+					IsOrgAdmin: true,
+					Status:     "active",
+				}, nil
+			},
+			getOrganizationBySlugFunc: func(ctx context.Context, slug string) (*IdentityOrg, error) {
+				org := IdentityOrg{
+					ID:    "team-1",
+					Slug:  "acme",
+					Name:  "Acme Org",
+					Roles: []IdentityRole{{Slug: "approver", Name: "Approver"}},
+				}
+				return &org, nil
+			},
+			listOrganizationUsersFunc: func(ctx context.Context, orgSlug string) ([]IdentityUser, error) {
+				return []IdentityUser{
+					{ID: "user-1", Email: "owner@example.com", OrgSlug: "acme", Labels: []string{identityOrgAdminLabel}, IsOrgAdmin: true, Status: "active"},
+				}, nil
+			},
+			listOrganizationMembershipsFunc: func(ctx context.Context, orgSlug string) ([]IdentityMembership, error) {
+				return nil, nil
+			},
+		},
+		tmpl:        parseTestTemplates(t),
+		enforceAuth: true,
+		now:         func() time.Time { return now },
+	}
+}
+
+func TestOrgAdminSectionURLHandlers(t *testing.T) {
+	now := time.Now().UTC()
+	server := orgAdminSectionURLTestServer(t, now)
+
+	t.Run("GET legacy users redirects to members", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/org-admin/users", nil)
+		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
+		rec := httptest.NewRecorder()
+
+		server.handleOrgAdminUsers(rec, req)
+
+		if rec.Code != http.StatusSeeOther {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
+		}
+		if loc := rec.Header().Get("Location"); loc != "/org-admin/members" {
+			t.Fatalf("location = %q, want /org-admin/members", loc)
+		}
+	})
+
+	t.Run("GET profile renders active profile panel", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/org-admin/profile", nil)
+		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
+		rec := httptest.NewRecorder()
+
+		server.handleOrgAdminPage(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+		}
+		body := rec.Body.String()
+		assertOrgAdminActivePanel(t, body, "profile")
+	})
+
+	t.Run("GET members renders active members panel", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/org-admin/members", nil)
+		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
+		rec := httptest.NewRecorder()
+
+		server.handleOrgAdminPage(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+		}
+		body := rec.Body.String()
+		assertOrgAdminActivePanel(t, body, "members")
+	})
+
+	t.Run("GET roles renders active roles panel", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/org-admin/roles", nil)
+		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
+		rec := httptest.NewRecorder()
+
+		server.handleOrgAdminRoles(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+		}
+		body := rec.Body.String()
+		assertOrgAdminActivePanel(t, body, "roles")
+	})
+}
+
+func TestResolveOrgAdminActivePanelFromPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{path: "/org-admin/profile", want: "profile"},
+		{path: "/org-admin/members", want: "members"},
+		{path: "/org-admin/roles", want: "roles"},
+		{path: "/org-admin/users", want: "profile"},
+	}
+	for _, tc := range tests {
+		req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+		if got := resolveOrgAdminActivePanel(req, OrgAdminErrors{}, ""); got != tc.want {
+			t.Fatalf("resolveOrgAdminActivePanel(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+func assertOrgAdminActivePanel(t *testing.T, body, panel string) {
+	t.Helper()
+
+	if !strings.Contains(body, `class="sidebar-nav-link is-active"`) {
+		t.Fatalf("expected active sidebar nav link for %q", panel)
+	}
+	if !strings.Contains(body, `href="/org-admin/`+panel+`"`) {
+		t.Fatalf("expected nav href for %q panel", panel)
+	}
+	if !strings.Contains(body, `data-org-admin-default-panel="`+panel+`"`) {
+		preview := body
+		if len(preview) > 400 {
+			preview = preview[:400]
+		}
+		t.Fatalf("expected default panel %q, got body prefix:\n%s", panel, preview)
+	}
+
+	panelID := `id="org-admin-panel-` + panel + `"` 
+	panelStart := strings.Index(body, panelID)
+	if panelStart == -1 {
+		t.Fatalf("expected %s section in body", panelID)
+	}
+	panelEnd := strings.Index(body[panelStart:], ">")
+	if panelEnd == -1 {
+		t.Fatalf("expected opening tag for %s", panelID)
+	}
+	panelTag := body[panelStart : panelStart+panelEnd+1]
+	if strings.Contains(panelTag, "hidden") {
+		t.Fatalf("active panel %q must not be hidden, got tag %q", panel, panelTag)
+	}
+
+	for _, other := range []string{"profile", "roles", "members"} {
+		if other == panel {
+			continue
+		}
+		otherID := `id="org-admin-panel-` + other + `"` 
+		otherStart := strings.Index(body, otherID)
+		if otherStart == -1 {
+			t.Fatalf("expected %s section in body", otherID)
+		}
+		otherEnd := strings.Index(body[otherStart:], ">")
+		if otherEnd == -1 {
+			t.Fatalf("expected opening tag for %s", otherID)
+		}
+		otherTag := body[otherStart : otherStart+otherEnd+1]
+		if !strings.Contains(otherTag, "hidden") {
+			t.Fatalf("inactive panel %q should be hidden, got tag %q", other, otherTag)
+		}
+	}
+}
+
+func TestOrgAdminActivePanelTemplateRendering(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+	base := OrgAdminView{
+		Header: PageHeaderView{
+			Title:    "Organization admin dashboard",
+			BackHref: "/",
+		},
+		Organization: Organization{Name: "Acme Org", Slug: "acme"},
+	}
+
+	for _, panel := range []string{"profile", "roles", "members"} {
+		t.Run(panel, func(t *testing.T) {
+			view := base
+			view.ActivePanel = panel
+			var out bytes.Buffer
+			if err := tmpl.ExecuteTemplate(&out, "org_admin_body", view); err != nil {
+				t.Fatalf("render org admin template: %v", err)
+			}
+			assertOrgAdminActivePanel(t, out.String(), panel)
+		})
+	}
+}

--- a/server/design/design.go
+++ b/server/design/design.go
@@ -476,7 +476,7 @@ var _ = Service("admin", func() {
 	Method("orgAdminUsers", func() {
 		Result(Empty)
 		HTTP(func() {
-			// Legacy entry: GET redirects to /org-admin/members.
+			// Legacy entry: GET redirects to /org-admin/profile.
 			GET("/org-admin/users")
 			Response(StatusSeeOther)
 			Response(StatusUnauthorized)

--- a/server/design/design.go
+++ b/server/design/design.go
@@ -449,11 +449,36 @@ var _ = Service("admin", func() {
 		})
 	})
 
+	Method("orgAdminProfile", func() {
+		Result(Empty)
+		HTTP(func() {
+			GET("/org-admin/profile")
+			Response(StatusOK)
+			Response(StatusUnauthorized)
+			Response(StatusForbidden)
+			Response(StatusServiceUnavailable)
+			Response(StatusInternalServerError)
+		})
+	})
+
+	Method("orgAdminMembers", func() {
+		Result(Empty)
+		HTTP(func() {
+			GET("/org-admin/members")
+			Response(StatusOK)
+			Response(StatusUnauthorized)
+			Response(StatusForbidden)
+			Response(StatusServiceUnavailable)
+			Response(StatusInternalServerError)
+		})
+	})
+
 	Method("orgAdminUsers", func() {
 		Result(Empty)
 		HTTP(func() {
+			// Legacy entry: GET redirects to /org-admin/members.
 			GET("/org-admin/users")
-			Response(StatusOK)
+			Response(StatusSeeOther)
 			Response(StatusUnauthorized)
 			Response(StatusForbidden)
 			Response(StatusServiceUnavailable)

--- a/server/templates/layout.html
+++ b/server/templates/layout.html
@@ -179,7 +179,7 @@
                       </a>
                     {{ end }}
                     {{ if .ShowMyOrgLink }}
-                      <a href="/org-admin/users" class="account-menu-item">
+                      <a href="/org-admin/members" class="account-menu-item">
                         {{ template "icon-users-group" . }}
                         My Org
                       </a>

--- a/server/templates/layout.html
+++ b/server/templates/layout.html
@@ -179,7 +179,7 @@
                       </a>
                     {{ end }}
                     {{ if .ShowMyOrgLink }}
-                      <a href="/org-admin/members" class="account-menu-item">
+                      <a href="/org-admin/profile" class="account-menu-item">
                         {{ template "icon-users-group" . }}
                         My Org
                       </a>

--- a/server/templates/pages/org_admin.html
+++ b/server/templates/pages/org_admin.html
@@ -1,4 +1,4 @@
-{{/* Used on /org-admin/users to render organization administration page */}}
+{{/* Used on /org-admin/profile, /org-admin/roles, and /org-admin/members */}}
 
 {{ define "org_admin_body" }}
 

--- a/server/templates/pages/org_admin.html
+++ b/server/templates/pages/org_admin.html
@@ -94,13 +94,7 @@
         <section
           class="panel org-admin-panel-main"
           data-org-admin-shell
-          data-org-admin-default-panel="{{ if .RoleError }}
-            roles
-          {{ else if or .UsersError .InviteError .InviteLink }}
-            members
-          {{ else }}
-            profile
-          {{ end }}"
+          data-org-admin-default-panel="{{ .ActivePanel }}"
         >
           <section
             class="org-admin-panel-section"

--- a/server/templates/pages/org_admin.html
+++ b/server/templates/pages/org_admin.html
@@ -51,11 +51,12 @@
             class="sidebar-nav"
             aria-label="Organization admin sections"
           >
-            <button
-              type="button"
-              class="sidebar-nav-link"
+            <a
+              href="/org-admin/profile"
+              class="sidebar-nav-link{{ if eq .ActivePanel "profile" }} is-active{{ end }}"
               data-org-admin-nav="profile"
               aria-controls="org-admin-panel-profile"
+              {{ if eq .ActivePanel "profile" }}aria-current="page"{{ end }}
             >
               <span class="sidebar-nav-title"
                 >Organization profile</span
@@ -63,29 +64,31 @@
               <span class="sidebar-nav-copy"
                 >Update your organization name and logo</span
               >
-            </button>
-            <button
-              type="button"
-              class="sidebar-nav-link"
+            </a>
+            <a
+              href="/org-admin/roles"
+              class="sidebar-nav-link{{ if eq .ActivePanel "roles" }} is-active{{ end }}"
               data-org-admin-nav="roles"
               aria-controls="org-admin-panel-roles"
+              {{ if eq .ActivePanel "roles" }}aria-current="page"{{ end }}
             >
               <span class="sidebar-nav-title">Roles</span>
               <span class="sidebar-nav-copy"
                 >Manage the role catalog for your organization</span
               >
-            </button>
-            <button
-              type="button"
-              class="sidebar-nav-link"
+            </a>
+            <a
+              href="/org-admin/members"
+              class="sidebar-nav-link{{ if eq .ActivePanel "members" }} is-active{{ end }}"
               data-org-admin-nav="members"
               aria-controls="org-admin-panel-members"
+              {{ if eq .ActivePanel "members" }}aria-current="page"{{ end }}
             >
               <span class="sidebar-nav-title">Members</span>
               <span class="sidebar-nav-copy"
                 >Invite people and update member access</span
               >
-            </button>
+            </a>
           </nav>
         {{ end }}
       </section>
@@ -100,6 +103,7 @@
             class="org-admin-panel-section"
             id="org-admin-panel-profile"
             data-org-admin-panel="profile"
+            {{ if ne .ActivePanel "profile" }}hidden{{ end }}
           >
             <div class="panel-heading">
               <h2>Organization profile</h2>
@@ -167,6 +171,7 @@
             class="org-admin-panel-section"
             id="org-admin-panel-roles"
             data-org-admin-panel="roles"
+            {{ if ne .ActivePanel "roles" }}hidden{{ end }}
           >
             <div class="panel-head-actions">
               <div class="panel-heading">
@@ -438,6 +443,7 @@
             class="org-admin-panel-section"
             id="org-admin-panel-members"
             data-org-admin-panel="members"
+            {{ if ne .ActivePanel "members" }}hidden{{ end }}
           >
             <div class="panel-head-actions">
               <div class="panel-heading">
@@ -858,10 +864,26 @@
   (function () {
     const orgAdminShell = document.querySelector("[data-org-admin-shell]");
     const orgAdminMobilePanelMedia = window.matchMedia("(max-width: 767px)");
-    const orgAdminStorageKey = "attesta_org_admin_panel";
     const orgAdminPanels = new Set(["profile", "roles", "members"]);
+    const orgAdminPanelPaths = {
+      profile: "/org-admin/profile",
+      roles: "/org-admin/roles",
+      members: "/org-admin/members",
+    };
+    const orgAdminPanelFromPath = (path) => {
+      switch (path) {
+        case "/org-admin/profile":
+          return "profile";
+        case "/org-admin/roles":
+          return "roles";
+        case "/org-admin/members":
+          return "members";
+        default:
+          return null;
+      }
+    };
     let activeOrgAdminPanel = "profile";
-    const setOrgAdminPanel = (panelName, persist = true) => {
+    const setOrgAdminPanel = (panelName) => {
       if (!orgAdminShell || !orgAdminPanels.has(panelName)) {
         return;
       }
@@ -871,21 +893,18 @@
         const currentName = panel.getAttribute("data-org-admin-panel");
         panel.hidden = currentName !== panelName;
       });
-      const navButtons = Array.from(document.querySelectorAll("[data-org-admin-nav]"));
-      navButtons.forEach((button) => {
-        const currentName = button.getAttribute("data-org-admin-nav");
+      const navLinks = Array.from(document.querySelectorAll("[data-org-admin-nav]"));
+      navLinks.forEach((link) => {
+        const currentName = link.getAttribute("data-org-admin-nav");
         const isActive = currentName === panelName;
-        button.classList.toggle("is-active", isActive);
-        button.setAttribute("aria-current", isActive ? "page" : "false");
+        link.classList.toggle("is-active", isActive);
+        if (isActive) {
+          link.setAttribute("aria-current", "page");
+        } else {
+          link.removeAttribute("aria-current");
+        }
       });
       orgAdminShell.setAttribute("data-org-admin-ready", "true");
-      if (!persist) {
-        return;
-      }
-      try {
-        window.sessionStorage.setItem(orgAdminStorageKey, panelName);
-      } catch (error) {
-      }
     };
     const focusOrgAdminPanel = () => {
       if (!orgAdminShell || !orgAdminMobilePanelMedia.matches) {
@@ -902,15 +921,9 @@
 
     if (orgAdminShell) {
       const preferredPanel = (() => {
-        try {
-          const storedPanel = window.sessionStorage.getItem(orgAdminStorageKey);
-          if (storedPanel && orgAdminPanels.has(storedPanel)) {
-            return storedPanel;
-          }
-        } catch (error) {
-        }
-        if (window.location.pathname === "/org-admin/roles") {
-          return "roles";
+        const pathPanel = orgAdminPanelFromPath(window.location.pathname);
+        if (pathPanel && orgAdminPanels.has(pathPanel)) {
+          return pathPanel;
         }
         const defaultPanel = (orgAdminShell.getAttribute("data-org-admin-default-panel") || "").trim();
         if (orgAdminPanels.has(defaultPanel)) {
@@ -918,22 +931,37 @@
         }
         return "profile";
       })();
-      Array.from(document.querySelectorAll("[data-org-admin-nav]")).forEach((button) => {
-        button.addEventListener("click", () => {
-          const panelName = (button.getAttribute("data-org-admin-nav") || "").trim();
+      Array.from(document.querySelectorAll("[data-org-admin-nav]")).forEach((link) => {
+        link.addEventListener("click", (event) => {
+          event.preventDefault();
+          const panelName = (link.getAttribute("data-org-admin-nav") || "").trim();
+          if (!orgAdminPanels.has(panelName)) {
+            return;
+          }
           setOrgAdminPanel(panelName);
+          const path = orgAdminPanelPaths[panelName];
+          if (window.location.pathname === path) {
+            window.history.replaceState({ orgAdminPanel: panelName }, "", path);
+          } else {
+            window.history.pushState({ orgAdminPanel: panelName }, "", path);
+          }
           focusOrgAdminPanel();
         });
       });
-      Array.from(document.querySelectorAll("[data-org-admin-shell] form")).forEach((form) => {
-        form.addEventListener("submit", () => {
-          try {
-            window.sessionStorage.setItem(orgAdminStorageKey, activeOrgAdminPanel);
-          } catch (error) {
-          }
-        });
+      window.addEventListener("popstate", (event) => {
+        const statePanel = event.state && event.state.orgAdminPanel;
+        const panelName =
+          (statePanel && orgAdminPanels.has(statePanel) && statePanel) ||
+          orgAdminPanelFromPath(window.location.pathname) ||
+          preferredPanel;
+        setOrgAdminPanel(panelName);
+        focusOrgAdminPanel();
       });
-      setOrgAdminPanel(preferredPanel, false);
+      setOrgAdminPanel(preferredPanel);
+      const preferredPath = orgAdminPanelPaths[preferredPanel];
+      if (preferredPath) {
+        window.history.replaceState({ orgAdminPanel: preferredPanel }, "", preferredPath);
+      }
     }
 
     const rolePalettePickers = Array.from(document.querySelectorAll("[data-role-palette-picker]"));

--- a/server/templates/pages/stream.html
+++ b/server/templates/pages/stream.html
@@ -3,178 +3,171 @@
 {{ define "home_body" }}
   <div class="stack u-max-w-7xl u-mx-auto">
     {{ template "page_header" .Header }}
-    <div class="home-workflow-grid" data-home-root>
-      <section class="panel panel-sticky">
-        <div class="panel-heading">
-          <h2>Streams</h2>
-          <p>Jump to instances by status</p>
-        </div>
-        <nav class="sidebar-nav" aria-label="Stream status sections">
-          {{ range .ProcessGroups }}
-            {{ if eq .Status "available" }}
-              <button
-                type="button"
-                class="sidebar-nav-link is-active"
-                data-home-nav="{{ .Status }}"
-                aria-controls="{{ .PanelID }}"
-                aria-current="page"
-                aria-label="Available streams"
-                title="Streams waiting for your input"
-              >
-                <span class="sidebar-nav-title"> Available </span>
-              </button>
-            {{ else if eq .Status "active" }}
-              <button
-                type="button"
-                class="sidebar-nav-link"
-                data-home-nav="{{ .Status }}"
-                aria-controls="{{ .PanelID }}"
-                aria-current="false"
-                aria-label="Active streams"
-                title="Streams waiting for someone else input"
-              >
-                <span class="sidebar-nav-title"> Active </span>
-              </button>
-            {{ else if eq .Status "done" }}
-              <button
-                type="button"
-                class="sidebar-nav-link"
-                data-home-nav="{{ .Status }}"
-                aria-controls="{{ .PanelID }}"
-                aria-current="false"
-                aria-label="Completed streams"
-                title="Streams completed successfully"
-              >
-                <span class="sidebar-nav-title"> Done </span>
-              </button>
-            {{ else if eq .Status "terminated" }}
-              <button
-                type="button"
-                class="sidebar-nav-link"
-                data-home-nav="{{ .Status }}"
-                aria-controls="{{ .PanelID }}"
-                aria-current="false"
-                aria-label="Terminated streams"
-                title="Streams terminated before completion"
-              >
-                <span class="sidebar-nav-title"> Terminated </span>
-              </button>
-            {{ end }}
-          {{ end }}
-        </nav>
-      </section>
-
-      <div class="home-workflow-panel-main">
-        <div class="panel-head-actions">
+    {{ if .Error }}
+      <div class="error error--rich">
+        <h3>Stream configuration issue</h3>
+        <p>
+          This stream cannot start new processes until its organization and role
+          references are fixed.
+        </p>
+        <div class="error-detail">{{ .Error }}</div>
+      </div>
+    {{ else }}
+      <div class="home-workflow-grid" data-home-root>
+        <section class="panel panel-sticky">
           <div class="panel-heading">
-            <h2>Stream instances</h2>
-            <p>View and manage all instances of this stream</p>
+            <h2>Streams</h2>
+            <p>Jump to instances by status</p>
           </div>
-          <div class="panel-actions">
-            <button
-              class="btn btn-secondary"
-              type="button"
-              data-home-nav="preview"
-              onclick="document.getElementById('stream-preview-dialog').showModal()"
-            >
-              {{ template "icon-eye" . }}
-              View preview
-            </button>
-            <button
-              class="btn btn-primary"
-              type="button"
-              onclick="document.getElementById('new-instance-dialog').showModal()"
-              {{ if .Error }}disabled{{ end }}
-            >
-              {{ template "icon-play" . }}
-              New instance
-            </button>
-          </div>
-        </div>
-        <dialog id="new-instance-dialog" class="dialog">
-          <div class="dialog-card">
-            <header class="dialog-head">
-              <div>
-                <h3 class="dialog-title">New instance</h3>
-                <p class="dialog-subtitle">
-                  Give this stream instance a brief name
-                </p>
-              </div>
-              <button
-                type="button"
-                class="btn btn-ghost btn-icon dialog-close"
-                onclick="document.getElementById('new-instance-dialog').close()"
-              >
-                {{ template "icon-close" . }}
-              </button>
-            </header>
-            <form
-              method="post"
-              action="{{ .WorkflowPath }}/process/start"
-              class="input-form"
-            >
-              <div class="form-field">
-                <label for="instance-name">Instance name</label>
-                <input
-                  id="instance-name"
-                  name="name"
-                  type="text"
-                  maxlength="80"
-                  autocomplete="off"
-                />
-              </div>
-              <div class="dialog-actions">
-                <button class="btn btn-primary" type="submit">
-                  {{ template "icon-play" . }}
-                  Start instance
+          <nav class="sidebar-nav" aria-label="Stream status sections">
+            {{ range .ProcessGroups }}
+              {{ if eq .Status "available" }}
+                <button
+                  type="button"
+                  class="sidebar-nav-link is-active"
+                  data-home-nav="{{ .Status }}"
+                  aria-controls="{{ .PanelID }}"
+                  aria-current="page"
+                  aria-label="Available streams"
+                  title="Streams waiting for your input"
+                >
+                  <span class="sidebar-nav-title"> Available </span>
                 </button>
-              </div>
-            </form>
-          </div>
-        </dialog>
-        <dialog
-          id="stream-preview-dialog"
-          class="dialog"
-        >
-          <div class="dialog-card">
-            <header class="dialog-head">
-              <div>
-                <h3 class="dialog-title">Stream preview</h3>
-                <p class="dialog-subtitle">
-                  Inspect the stream timeline and form structure in read-only
-                  mode
-                </p>
-              </div>
+              {{ else if eq .Status "active" }}
+                <button
+                  type="button"
+                  class="sidebar-nav-link"
+                  data-home-nav="{{ .Status }}"
+                  aria-controls="{{ .PanelID }}"
+                  aria-current="false"
+                  aria-label="Active streams"
+                  title="Streams waiting for someone else input"
+                >
+                  <span class="sidebar-nav-title"> Active </span>
+                </button>
+              {{ else if eq .Status "done" }}
+                <button
+                  type="button"
+                  class="sidebar-nav-link"
+                  data-home-nav="{{ .Status }}"
+                  aria-controls="{{ .PanelID }}"
+                  aria-current="false"
+                  aria-label="Completed streams"
+                  title="Streams completed successfully"
+                >
+                  <span class="sidebar-nav-title"> Done </span>
+                </button>
+              {{ else if eq .Status "terminated" }}
+                <button
+                  type="button"
+                  class="sidebar-nav-link"
+                  data-home-nav="{{ .Status }}"
+                  aria-controls="{{ .PanelID }}"
+                  aria-current="false"
+                  aria-label="Terminated streams"
+                  title="Streams terminated before completion"
+                >
+                  <span class="sidebar-nav-title"> Terminated </span>
+                </button>
+              {{ end }}
+            {{ end }}
+          </nav>
+        </section>
+
+        <div class="home-workflow-panel-main">
+          <div class="panel-head-actions">
+            <div class="panel-heading">
+              <h2>Stream instances</h2>
+              <p>View and manage all instances of this stream</p>
+            </div>
+            <div class="panel-actions">
               <button
+                class="btn btn-secondary"
                 type="button"
-                class="btn btn-ghost btn-icon dialog-close"
-                onclick="document.getElementById('stream-preview-dialog').close()"
+                data-home-nav="preview"
+                onclick="document.getElementById('stream-preview-dialog').showModal()"
               >
-                {{ template "icon-close" . }}
+                {{ template "icon-eye" . }}
+                View preview
               </button>
-            </header>
-            <div class="stream-preview-body">
-              {{ template "stream_timeline" .Preview.StreamTimeline }}
+              <button
+                class="btn btn-primary"
+                type="button"
+                onclick="document.getElementById('new-instance-dialog').showModal()"
+              >
+                {{ template "icon-play" . }}
+                New instance
+              </button>
             </div>
           </div>
-        </dialog>
-        <div class="stream-status-sections">
-          {{ if .Error }}
-            <section
-              class="panel instances-panel"
-              id="home-panel-instances"
-              data-home-panel="instances"
-            >
-              <div class="panel-heading">
-                <h3>Stream configuration issue</h3>
-                <p>
-                  This stream cannot start new processes until its organization
-                  and role references are fixed.
-                </p>
+          <dialog id="new-instance-dialog" class="dialog">
+            <div class="dialog-card">
+              <header class="dialog-head">
+                <div>
+                  <h3 class="dialog-title">New instance</h3>
+                  <p class="dialog-subtitle">
+                    Give this stream instance a brief name
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-icon dialog-close"
+                  onclick="document.getElementById('new-instance-dialog').close()"
+                >
+                  {{ template "icon-close" . }}
+                </button>
+              </header>
+              <form
+                method="post"
+                action="{{ .WorkflowPath }}/process/start"
+                class="input-form"
+              >
+                <div class="form-field">
+                  <label for="instance-name">Instance name</label>
+                  <input
+                    id="instance-name"
+                    name="name"
+                    type="text"
+                    maxlength="80"
+                    autocomplete="off"
+                  />
+                </div>
+                <div class="dialog-actions">
+                  <button class="btn btn-primary" type="submit">
+                    {{ template "icon-play" . }}
+                    Start instance
+                  </button>
+                </div>
+              </form>
+            </div>
+          </dialog>
+          <dialog
+            id="stream-preview-dialog"
+            class="dialog"
+          >
+            <div class="dialog-card">
+              <header class="dialog-head">
+                <div>
+                  <h3 class="dialog-title">Stream preview</h3>
+                  <p class="dialog-subtitle">
+                    Inspect the stream timeline and form structure in read-only
+                    mode
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-icon dialog-close"
+                  onclick="document.getElementById('stream-preview-dialog').close()"
+                >
+                  {{ template "icon-close" . }}
+                </button>
+              </header>
+              <div class="stream-preview-body">
+                {{ template "stream_timeline" .Preview.StreamTimeline }}
               </div>
-              <div class="error">{{ .Error }}</div>
-            </section>
-          {{ else }}
+            </div>
+          </dialog>
+          <div class="stream-status-sections">
             {{ range .ProcessGroups }}
               <section
                 class="stream-status-section"
@@ -319,83 +312,83 @@
                 {{ end }}
               </section>
             {{ end }}
-          {{ end }}
+          </div>
         </div>
       </div>
-    </div>
 
-    <script>
-      (function () {
-        const homeRoot = document.querySelector("[data-home-root]");
-        if (!homeRoot) {
-          return;
-        }
-
-        const panels = Array.from(homeRoot.querySelectorAll("[data-home-panel]"));
-        const statusPanelNames = panels.map((panel) =>
-          (panel.getAttribute("data-home-panel") || "").trim(),
-        );
-
-        const defaultPanelName = statusPanelNames.includes("available")
-          ? "available"
-          : statusPanelNames[0] || "";
-
-        const initialPanelName = () => {
-          const hashPanelID = window.location.hash.replace(/^#/, "");
-          if (hashPanelID) {
-            const hashPanel = panels.find((panel) => panel.id === hashPanelID);
-            if (hashPanel) {
-              return (hashPanel.getAttribute("data-home-panel") || "").trim();
-            }
+      <script>
+        (function () {
+          const homeRoot = document.querySelector("[data-home-root]");
+          if (!homeRoot) {
+            return;
           }
 
-          const params = new URLSearchParams(window.location.search);
-          const queryPanel = statusPanelNames.find((panelName) => {
-            return (
-              params.has(panelName + "_page") || params.has(panelName + "_sort")
-            );
-          });
-          return queryPanel || defaultPanelName;
-        };
-
-        const showPanel = (panelName) => {
-          if (!statusPanelNames.includes(panelName)) {
-            panelName = defaultPanelName;
-          }
-
-          const buttons = Array.from(
-            homeRoot.querySelectorAll("[data-home-nav]"),
+          const panels = Array.from(homeRoot.querySelectorAll("[data-home-panel]"));
+          const statusPanelNames = panels.map((panel) =>
+            (panel.getAttribute("data-home-panel") || "").trim(),
           );
-          buttons.forEach((button) => {
-            const currentName = button.getAttribute("data-home-nav");
-            const isActive = currentName === panelName;
-            button.classList.toggle("is-active", isActive);
-            button.setAttribute("aria-current", isActive ? "page" : "false");
-          });
 
-          panels.forEach((panel) => {
-            const currentName = panel.getAttribute("data-home-panel");
-            panel.hidden = currentName !== panelName;
-          });
-        };
+          const defaultPanelName = statusPanelNames.includes("available")
+            ? "available"
+            : statusPanelNames[0] || "";
 
-        Array.from(homeRoot.querySelectorAll("[data-home-nav]")).forEach(
-          (button) => {
-            button.addEventListener("click", () => {
-              const panelName = (
-                button.getAttribute("data-home-nav") || ""
-              ).trim();
-              if (panelName === "preview") {
-                return;
+          const initialPanelName = () => {
+            const hashPanelID = window.location.hash.replace(/^#/, "");
+            if (hashPanelID) {
+              const hashPanel = panels.find((panel) => panel.id === hashPanelID);
+              if (hashPanel) {
+                return (hashPanel.getAttribute("data-home-panel") || "").trim();
               }
-              showPanel(panelName);
-            });
-          },
-        );
+            }
 
-        showPanel(initialPanelName());
-      })();
-    </script>
+            const params = new URLSearchParams(window.location.search);
+            const queryPanel = statusPanelNames.find((panelName) => {
+              return (
+                params.has(panelName + "_page") || params.has(panelName + "_sort")
+              );
+            });
+            return queryPanel || defaultPanelName;
+          };
+
+          const showPanel = (panelName) => {
+            if (!statusPanelNames.includes(panelName)) {
+              panelName = defaultPanelName;
+            }
+
+            const buttons = Array.from(
+              homeRoot.querySelectorAll("[data-home-nav]"),
+            );
+            buttons.forEach((button) => {
+              const currentName = button.getAttribute("data-home-nav");
+              const isActive = currentName === panelName;
+              button.classList.toggle("is-active", isActive);
+              button.setAttribute("aria-current", isActive ? "page" : "false");
+            });
+
+            panels.forEach((panel) => {
+              const currentName = panel.getAttribute("data-home-panel");
+              panel.hidden = currentName !== panelName;
+            });
+          };
+
+          Array.from(homeRoot.querySelectorAll("[data-home-nav]")).forEach(
+            (button) => {
+              button.addEventListener("click", () => {
+                const panelName = (
+                  button.getAttribute("data-home-nav") || ""
+                ).trim();
+                if (panelName === "preview") {
+                  return;
+                }
+                showPanel(panelName);
+              });
+            },
+          );
+
+          showPanel(initialPanelName());
+        })();
+      </script>
+    {{ end }}
   </div>
 {{ end }}
 

--- a/web/src/styles/components/shared.css
+++ b/web/src/styles/components/shared.css
@@ -139,6 +139,22 @@ svg.bi {
   white-space: pre-line;
 }
 
+.error--rich {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  white-space: normal;
+}
+
+.error--rich > :is(h1, h2, h3, h4, h5, h6, p) {
+  margin: 0;
+}
+
+.error--rich > .error-detail {
+  margin-top: var(--space-2);
+  white-space: pre-line;
+}
+
 .confirmation {
   background: var(--success-muted);
   color: var(--success-muted-foreground);

--- a/web/src/styles/components/sidebar-nav.css
+++ b/web/src/styles/components/sidebar-nav.css
@@ -20,6 +20,7 @@
   flex-direction: column;
   padding: var(--space-2) var(--space-3);
   text-align: left;
+  text-decoration: none;
   border-radius: 4px;
   border: 1px solid transparent;
   background: transparent;

--- a/web/src/styles/components/sidebar-nav.css
+++ b/web/src/styles/components/sidebar-nav.css
@@ -39,7 +39,9 @@
 }
 
 .sidebar-nav-link:hover,
+.sidebar-nav-link:focus,
 .sidebar-nav-link.is-active {
+  text-decoration: none;
   background: color-mix(in srgb, var(--primary) 8%, var(--background));
 }
 

--- a/web/src/styles/components/sidebar-nav.css
+++ b/web/src/styles/components/sidebar-nav.css
@@ -2,7 +2,7 @@
  * Sidebar nav — section switcher tiles (CSS-only component).
  *
  * nav.sidebar-nav
- *   button.sidebar-nav-link[.is-active]
+ *   a.sidebar-nav-link[.is-active]   (or button, on pages that still use buttons)
  *     span.sidebar-nav-title
  *     span.sidebar-nav-copy?   (optional subtitle)
  */


### PR DESCRIPTION
## Summary
- Org settings sidebar sections now map to `/org-admin/profile`, `/org-admin/roles`, and `/org-admin/members`, with soft client-side switching via the History API (no full reload on click).
- Legacy `GET /org-admin/users` redirects to `/org-admin/members`; POSTs still use `/org-admin/users` and `/org-admin/roles`, with success redirects landing on the matching section.
- Server-driven `ActivePanel` selects the visible panel (including error overrides); inactive panels are hidden on first paint.

## Test plan
- [ ] Open My Org → lands on `/org-admin/members`
- [ ] Click Profile / Roles / Members → URL updates without full reload; back/forward restores panel
- [ ] Hard-refresh each section URL → correct panel is active
- [ ] Visit `/org-admin/users` → redirected to `/org-admin/members`
- [ ] Create/edit/delete role → stays on `/org-admin/roles` after success
- [ ] Update org profile → lands on `/org-admin/profile`
- [ ] Invite / edit member roles → lands on `/org-admin/members`
- [ ] `go test ./cmd/server/ -run 'OrgAdmin|HandleOrgAdmin|RenderOrgAdmin|AuthSession|AuthReset' -count=1`

## Notes
- OpenAPI/`server/design/design.go` still documents `GET /org-admin/users` as 200; not updated in this PR (nit).
- Form validation errors that re-render on `/org-admin/users` may rewrite the URL client-side; refresh can drop inline errors (pre-existing PRG gap class).