### PR TITLE
feat(ui): restyle app chrome, process/DPP panels, and shared layouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ See: `README.md`, `QUICKSTART.md`, `DOCKER.md`, `docs/css.md` (main app styling)
 - Stream dashboard is `/w/:key/` (lists stream instances for one stream). Legacy `/dashboard` and `/w/:key/dashboard` are not registered.
 - Admin consoles:
   - Platform admin: `/admin/orgs` (create/edit/delete orgs, upload logos, invite org admins)
-  - Org admin: `/org-admin/roles`, `/org-admin/users`
+  - Org admin: `/org-admin/profile`, `/org-admin/roles`, `/org-admin/members` (legacy `GET /org-admin/users` redirects to profile)
 - Platform admin is env-driven (`ADMIN_EMAIL`, `ADMIN_PASSWORD`). On startup the server ensures that account exists in Appwrite (`bootstrapPlatformAdminIdentity`). Cerbos policy `platform_admin_console` gates console access.
 - Auth/org state now lives in Appwrite:
   - orgs -> teams
@@ -25,10 +25,10 @@ See: `README.md`, `QUICKSTART.md`, `DOCKER.md`, `docs/css.md` (main app styling)
   - signup/login/reset -> Appwrite account/session/recovery flows
 - Global topbar now renders role-aware admin links on authenticated pages:
   - Platform admin sees `Orgs` (`/admin/orgs`)
-  - Org admin with org context sees `My Org` (`/org-admin/users`)
+  - Org admin with org context sees `My Org` (`/org-admin/profile`)
 - Workflow YAML supports `organizations`, `roles`, step-level `organization`, and substep `roles`.
 - Slug collisions on org and role creation now surface explicit `... slug already exists` errors in admin UIs.
-- `/org-admin/users` now supports:
+- Org admin members section (`/org-admin/members`; forms still `POST /org-admin/users`) supports:
   - invites with zero-to-many roles (`roles` multi-select, `intent=invite`)
   - "Invites I sent" with derived statuses (`pending`, `accepted`, `expired`)
   - user role editing (`intent=set_roles`) and soft-delete (`intent=delete_user`) with self-protection checks.
@@ -136,7 +136,7 @@ Global routes are registered in `Server.newMux()` (`server/cmd/server/main.go`).
 - `GET/POST /login`, `GET/POST /signup`, `POST /logout`
 - `GET /invite/…`, `GET/POST /reset`, `GET/POST /reset/…`
 - `GET/POST /admin/orgs`, `GET/POST /admin/orgs/` (platform admin org console; logo at `/admin/orgs/logo/:id`)
-- `GET/POST /org-admin/roles`, `/org-admin/users`, `/org-admin/formata-builder`, …
+- `GET /org-admin/profile`, `/org-admin/roles`, `/org-admin/members` (org settings sections); `GET /org-admin/users` → profile; `POST /org-admin/users`, `POST /org-admin/roles`; `/org-admin/formata-builder`, …
 - `GET /01/…` — public DPP Digital Link
 - `GET /events` — legacy SSE mux entry (production UI uses workflow-scoped path below)
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,6 +11,33 @@ tasks:
     cmds:
       - git submodule update --init --recursive
 
+  worktree:env:
+    desc: Symlink primary checkout .env into this (or given) worktree. Usage - task worktree:env [-- path]
+    cmds:
+      - bash deployment/scripts/worktree-env.sh {{.CLI_ARGS}}
+
+  worktree:add:
+    desc: Create .worktrees/<branch> worktree and symlink .env. Usage - task worktree:add -- <branch>
+    cmds:
+      - |
+          set -euo pipefail
+          branch="{{.CLI_ARGS}}"
+          if [ -z "${branch}" ]; then
+            echo "usage: task worktree:add -- <branch>" >&2
+            exit 1
+          fi
+          path=".worktrees/${branch}"
+          if [ -e "${path}" ]; then
+            echo "error: ${path} already exists" >&2
+            exit 1
+          fi
+          if git show-ref --verify --quiet "refs/heads/${branch}"; then
+            git worktree add "${path}" "${branch}"
+          else
+            git worktree add -b "${branch}" "${path}"
+          fi
+          bash deployment/scripts/worktree-env.sh "${path}"
+
   start:
     desc: Bring up infra and show status.
     cmds:

--- a/deployment/scripts/worktree-env.sh
+++ b/deployment/scripts/worktree-env.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Symlink the primary checkout's .env into a worktree (or any target root).
+# Usage:
+#   deployment/scripts/worktree-env.sh              # current git toplevel
+#   deployment/scripts/worktree-env.sh /path/to/wt  # explicit worktree root
+set -euo pipefail
+
+main_root="$(git worktree list --porcelain | awk '/^worktree / { print substr($0, 10); exit }')"
+if [[ -z "${main_root}" || ! -d "${main_root}" ]]; then
+  echo "error: could not resolve primary worktree root" >&2
+  exit 1
+fi
+
+target_root="${1:-$(git rev-parse --show-toplevel)}"
+if [[ -z "${target_root}" || ! -d "${target_root}" ]]; then
+  echo "error: target root does not exist: ${target_root:-<empty>}" >&2
+  exit 1
+fi
+
+src="${main_root}/.env"
+dst="${target_root}/.env"
+
+if [[ ! -f "${src}" ]]; then
+  echo "error: no .env in primary checkout (${main_root})" >&2
+  echo "copy .env.example to .env there first" >&2
+  exit 1
+fi
+
+if [[ -L "${dst}" ]]; then
+  current="$(readlink "${dst}")"
+  if [[ "${current}" == "${src}" ]]; then
+    echo "ok: ${dst} already linked to ${src}"
+    exit 0
+  fi
+  echo "error: ${dst} is a symlink to ${current}, not ${src}" >&2
+  exit 1
+fi
+
+if [[ -e "${dst}" ]]; then
+  echo "ok: ${dst} already exists (not replacing a real file)"
+  exit 0
+fi
+
+ln -s "${src}" "${dst}"
+echo "linked ${dst} -> ${src}"

--- a/docs/css.md
+++ b/docs/css.md
@@ -15,7 +15,7 @@ Styles load in this order from `web/src/styles.css`:
 | Role palette | `role-palette.css` | `data-role-palette` and `data-stream-status` attribute maps |
 | Reset | `reset.css` | `*`, `body`, `a`, `button`, heading defaults, focus rings, reduced motion |
 | Utilities | `utilities.css` | `u-*` spacing/typography/layout primitives |
-| Layout | `layout/index.css` | Barrel: `chrome.css` (topbar, nav, stack, footer), `grids.css` (page grids), `responsive.css` (shell breakpoint tweaks) |
+| Layout | `layout/index.css` | Barrel: `chrome.css` (topbar, nav, stack, footer), `grids.css` (page grids + `.rail-layout`), `responsive.css` (shell breakpoint tweaks) |
 | Components | `components.css` | Barrel importing `components/*.css` (panel, dialog, page-header, stream-card, stream-instance-card, substep-shell, stream-timeline, forms, org-admin, stream, shared) |
 | Pages | `pages.css` | Barrel importing `pages/*.css` (DPP, home, stream, process, org-admin shell, platform admin) |
 
@@ -98,10 +98,11 @@ Other partials (`icons.html`, …) still live at `server/templates/` root until 
 | `components/stream_instance_card.html` | `components/stream-instance-card.css` | `components/stream.css` (`.status-tag*`) |
 | Inline panel sections (process, stream, dpp, org_admin, platform_admin) | `components/panel.css` | `components/button.css`, `components/shared.css` (`.muted`); optional `.panel-sticky` |
 | Inline dialog modals (process, stream, home, org_admin, platform_admin, substep_body) | `components/dialog.css` | `pages/stream.css` (#stream-preview-dialog), `components/org-admin.css` (role pill), `components/substep-body.css` (active-role spacing), `components/forms.css` |
-| Inline sidebar nav (stream, org_admin) | `components/sidebar-nav.css` | `components/panel.css` (`.panel-sticky`) |
+| Inline sidebar nav (stream, org_admin) | `components/sidebar-nav.css` | `components/panel.css` (`.panel-sticky`), `layout/grids.css` (`.rail-layout`) |
+| Inline rail shell (stream, org_admin) | `layout/grids.css` (`.rail-layout`) | `components/panel.css` (`.panel-sticky`), `components/sidebar-nav.css` |
 | Inline list rows (org_admin roles/users, platform_admin orgs) | `components/list-row.css` | `components/button.css`; domain: `org-admin.css` (`.user-email`, `.user-tags`), `pages/platform-admin.css` (copy/status) |
 | `pages/home.html` | `pages/home.css` | `components/stream-card.css`, `components/dialog.css`, `components/stream.css`, `layout/index.css` |
-| `pages/stream.html` | `pages/home.css`, `pages/stream.css` | `components/dialog.css`, `components/sidebar-nav.css`, `components/panel.css`, `components/stream-instance-card.css`, `components/stream.css`, `components/stream-timeline.css`, `role-palette.css` |
+| `pages/stream.html` | `pages/home.css`, `pages/stream.css` | `layout/grids.css` (`.rail-layout`), `components/dialog.css`, `components/sidebar-nav.css`, `components/panel.css`, `components/stream-instance-card.css`, `components/stream.css`, `components/stream-timeline.css`, `role-palette.css` |
 | `pages/process.html` | `pages/process.css` | `components/dialog.css`, `components/substep-shell.css`, `components/stream-timeline.css`, `components/substep-body.css`, `layout/responsive.css` (`.layout-stack-separator`), `role-palette.css` |
 | `components/stream_step_summary.html` | `components/stream-step-summary.css` | — |
 | `components/stream_timeline.html` | `components/stream-timeline.css` | `components/stream-step-summary.css`, `components/substep-body.css`, `role-palette.css` |
@@ -109,7 +110,7 @@ Other partials (`icons.html`, …) still live at `server/templates/` root until 
 | `components/substep_shell.html` | `components/substep-shell.css` | `components/substep-body.css`, `role-palette.css` |
 | `components/substep_body.html` | `components/substep-body.css` | `components/dialog.css`, `components/forms.css`, `role-palette.css` |
 | `pages/dpp.html` | `pages/dpp.css` | `components/dpp_history_step.html`, `components/stream-timeline.css`, `components/stream-step-summary.css`, `components/substep-shell.css`, `components/substep-body.css`, `role-palette.css` |
-| `pages/org_admin.html` | `pages/org-admin-page.css` | `components/dialog.css`, `components/sidebar-nav.css`, `components/panel.css`, `components/org-admin.css`, `role-palette.css` |
+| `pages/org_admin.html` | `pages/org-admin-page.css` | `layout/grids.css` (`.rail-layout`), `components/dialog.css`, `components/sidebar-nav.css`, `components/panel.css`, `components/org-admin.css`, `role-palette.css` |
 | `pages/platform_admin.html` | `pages/platform-admin.css` | `components/dialog.css`, `components/shared.css` |
 | `pages/login.html`, `pages/signup.html`, `pages/invite.html`, `pages/reset_*.html` | `components/forms.css` | `components/button.css`, `components/shared.css` |
 | `attachment_carousel.html` | `components/substep-body.css` | — |
@@ -353,7 +354,8 @@ All other dynamic theming uses `data-*` attributes (`data-role-palette`, `data-s
 | Class | Use |
 |-------|-----|
 | `.panel`, `.panel-heading`, `.panel-head-actions`, `.panel-block` | Card sections — see `panel.css` header for markup tree (CSS-only component) |
-| `.panel-sticky` | Optional sticky rail modifier on `.panel` (active at `--xl-up`) |
+| `.panel-sticky` | Optional sticky rail modifier on `.panel` (active at `--md-up`) |
+| `.rail-layout`, `.rail-layout-ready`, `.rail-layout-main` | Sticky sidebar + main shell — see `layout/grids.css` (row at `--md-up`) |
 | `.sidebar-nav`, `.sidebar-nav-link`, `.sidebar-nav-title`, `.sidebar-nav-copy` | Section switcher tiles — see `sidebar-nav.css` header |
 | `.dialog`, `.dialog-card`, `.dialog-head`, `.dialog-actions`, … | Modal shells — see `dialog.css` header (CSS-only component) |
 | `.list-rows`, `.list-row`, `.list-row-main`, `.list-row-actions` | Admin list rows with actions — see `list-row.css` header |

--- a/docs/css.md
+++ b/docs/css.md
@@ -160,7 +160,7 @@ Behavior hooks use a `js-*` class prefix alongside `data-*` where needed; do not
 - **Stylesheet modules** use `@media (--sm-down) { … }` (or other aliases). Do **not** repeat `@custom-media` or write `@media (width … 640px)` in component/page CSS.
 - **PostCSS:** `postcss-custom-media` (see `web/postcss.config.js`) expands aliases at build time; Vite runs PostCSS on the bundled CSS.
 
-**JS sync:** when JavaScript needs the same threshold as CSS, use the equivalent `matchMedia` query. Example: `--xl-down` `(width < 1280px)` ↔ `matchMedia("(max-width: 1279px)")` (as in `org_admin.html` for mobile panel switching). Keep JS literals aligned with the table above when adding new breakpoint checks.
+**JS sync:** when JavaScript needs the same threshold as CSS, use the equivalent `matchMedia` query. Example: `--md-down` `(width < 768px)` ↔ `matchMedia("(max-width: 767px)")` (as in `org_admin.html` for mobile panel scrolling). Keep JS literals aligned with the table above when adding new breakpoint checks.
 
 ### Font tokens
 

--- a/docs/css.md
+++ b/docs/css.md
@@ -221,6 +221,11 @@ Canonical spacing tokens in `tokens.css` — a Tailwind-aligned scale on a 4px g
 | `--space-5` | `1.25rem` | 20 | Panel padding, section margins/gaps |
 | `--space-6` | `1.5rem` | 24 | Stack default gap |
 | `--space-7` | `1.75rem` | 28 | Large section rhythm |
+| `--space-8` | `2rem` | 32 | Section gaps, chrome padding |
+| `--space-9` | `2.25rem` | 36 | Generous section rhythm |
+| `--space-10` | `2.5rem` | 40 | Page-level spacing |
+| `--space-11` | `2.75rem` | 44 | Wide section rhythm |
+| `--space-12` | `3rem` | 48 | Multi-column grid gaps |
 
 The scale is monotonic: `--space-N` is always larger than `--space-(N-1)`. Do not reintroduce off-grid values (6/10/14/18px) or non-monotonic indices.
 

--- a/server/cmd/server/admin_handler_identity_test.go
+++ b/server/cmd/server/admin_handler_identity_test.go
@@ -1906,8 +1906,8 @@ func TestHandleOrgAdminUsersCreateOrgWithIdentity(t *testing.T) {
 	if createSessionSecret != "session-1" || createName != "Fresh Org" {
 		t.Fatalf("create args = %q %q", createSessionSecret, createName)
 	}
-	if rec.Header().Get("Location") != "/org-admin/users" {
-		t.Fatalf("location = %q, want /org-admin/users", rec.Header().Get("Location"))
+	if rec.Header().Get("Location") != "/org-admin/members" {
+		t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
 	}
 }
 
@@ -2084,8 +2084,8 @@ func TestHandleOrgAdminUsersUpdateOrgWithIdentityLogo(t *testing.T) {
 	if deletedLogoFileID != "logo-old" {
 		t.Fatalf("deleted logo = %q, want logo-old", deletedLogoFileID)
 	}
-	if rec.Header().Get("Location") != "/org-admin/users" {
-		t.Fatalf("location = %q, want /org-admin/users", rec.Header().Get("Location"))
+	if rec.Header().Get("Location") != "/org-admin/profile" {
+		t.Fatalf("location = %q, want /org-admin/profile", rec.Header().Get("Location"))
 	}
 }
 
@@ -2325,8 +2325,11 @@ func TestHandleOrgAdminUsersSetRolesWithIdentity(t *testing.T) {
 
 	server.handleOrgAdminUsers(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if rec.Header().Get("Location") != "/org-admin/members" {
+		t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
 	}
 	if !hasIdentityLabel(users[1].Labels, identityOrgAdminLabel) || !containsRole(decodeIdentityRoleLabels(users[1].Labels), "approver") {
 		t.Fatalf("updated user labels = %#v", users[1].Labels)
@@ -2486,8 +2489,11 @@ func TestHandleOrgAdminUsersInviteWithIdentity(t *testing.T) {
 
 	server.handleOrgAdminUsers(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if rec.Header().Get("Location") != "/org-admin/members" {
+		t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
 	}
 	if inviteCalls != 1 || len(invitedRoles) != 1 || invitedRoles[0] != "approver" || !invitedAdmin {
 		t.Fatalf("invite call = %d roles=%#v admin=%v", inviteCalls, invitedRoles, invitedAdmin)
@@ -2537,8 +2543,11 @@ func TestHandleOrgAdminUsersInviteIdentityDuplicatePending(t *testing.T) {
 
 	server.handleOrgAdminUsers(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if rec.Header().Get("Location") != "/org-admin/members" {
+		t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
 	}
 	if inviteCalls != 0 {
 		t.Fatalf("invite calls = %d, want 0", inviteCalls)
@@ -2593,8 +2602,11 @@ func TestHandleOrgAdminUsersInviteIdentityExistingAndCrossOrg(t *testing.T) {
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	rec := httptest.NewRecorder()
 	server.handleOrgAdminUsers(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("existing member status = %d, want %d", rec.Code, http.StatusOK)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("existing member status = %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if rec.Header().Get("Location") != "/org-admin/members" {
+		t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
 	}
 	if len(updatedUsers["user-2"]) != 1 || updatedUsers["user-2"][0] != encodeIdentityRoleLabel("approver") {
 		t.Fatalf("updated user labels = %#v", updatedUsers)
@@ -2663,8 +2675,11 @@ func TestHandleOrgAdminUsersDeleteUserWithIdentity(t *testing.T) {
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	rec := httptest.NewRecorder()
 	server.handleOrgAdminUsers(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if rec.Header().Get("Location") != "/org-admin/members" {
+		t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
 	}
 	if len(deletedMemberships) != 1 || deletedMemberships[0] != "membership-2" {
 		t.Fatalf("deleted memberships = %#v", deletedMemberships)
@@ -2847,8 +2862,11 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminUsers(rec, req)
-		if rec.Code != http.StatusOK || updated != 1 {
-			t.Fatalf("pending update response = %d updated=%d body=%q", rec.Code, updated, rec.Body.String())
+		if rec.Code != http.StatusSeeOther || updated != 1 {
+			t.Fatalf("pending update response = %d updated=%d location=%q", rec.Code, updated, rec.Header().Get("Location"))
+		}
+		if rec.Header().Get("Location") != "/org-admin/members" {
+			t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
 		}
 	})
 
@@ -3754,8 +3772,11 @@ func TestHandleOrgAdminUsersIdentityAdditionalBranches(t *testing.T) {
 		getReq.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		getRec := httptest.NewRecorder()
 		server.handleOrgAdminUsers(getRec, getReq)
-		if getRec.Code != http.StatusOK || !strings.Contains(getRec.Body.String(), "ORG_ADMIN acme") {
-			t.Fatalf("get response = %d %q", getRec.Code, getRec.Body.String())
+		if getRec.Code != http.StatusSeeOther {
+			t.Fatalf("get status = %d, want %d", getRec.Code, http.StatusSeeOther)
+		}
+		if getRec.Header().Get("Location") != "/org-admin/members" {
+			t.Fatalf("get location = %q, want /org-admin/members", getRec.Header().Get("Location"))
 		}
 
 		postReq := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=unsupported"))

--- a/server/cmd/server/auth_reset_handler_test.go
+++ b/server/cmd/server/auth_reset_handler_test.go
@@ -398,7 +398,7 @@ func TestHandleResetPageHidesAdminTopbarLinks(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
 	body := rec.Body.String()
-	if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, `href="/org-admin/users"`) {
+	if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, `href="/org-admin/profile"`) {
 		t.Fatalf("expected reset page without admin nav links, got %q", body)
 	}
 }

--- a/server/cmd/server/auth_session_handler_test.go
+++ b/server/cmd/server/auth_session_handler_test.go
@@ -219,7 +219,7 @@ func TestHandleLoginPageHidesAdminTopbarLinks(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
 	body := rec.Body.String()
-	if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, `href="/org-admin/users"`) {
+	if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, `href="/org-admin/profile"`) {
 		t.Fatalf("expected login page without admin nav links, got %q", body)
 	}
 }
@@ -581,8 +581,8 @@ func TestHandleSignupCreatesSessionAndRedirectsByOrgMembership(t *testing.T) {
 		if rec.Code != http.StatusSeeOther {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 		}
-		if rec.Header().Get("Location") != "/org-admin/users" {
-			t.Fatalf("location = %q, want /org-admin/users", rec.Header().Get("Location"))
+		if rec.Header().Get("Location") != "/org-admin/profile" {
+			t.Fatalf("location = %q, want /org-admin/profile", rec.Header().Get("Location"))
 		}
 		if createdEmail != "new@example.com" || createdPassword != "secure-password" {
 			t.Fatalf("create account args = %q/%q", createdEmail, createdPassword)

--- a/server/cmd/server/components.go
+++ b/server/cmd/server/components.go
@@ -238,6 +238,14 @@ type StreamTimelineSubstepView struct {
 	HideStatus bool
 }
 
+// StreamTerminationDetailsView is the view model for templates/components/stream_termination_details.html.
+type StreamTerminationDetailsView struct {
+	EndedAtHuman string
+	EndedBy      string
+	SubstepID    string
+	Reason       string
+}
+
 // StreamInstanceDetailView is the HTMX/SSE partial payload for stream instance detail content.
 type StreamInstanceDetailView struct {
 	WorkflowKey       string
@@ -257,7 +265,7 @@ type StreamInstanceDetailView struct {
 	TerminateAction   string
 	TerminateSubstep  string
 	TerminateRoles    []SubstepRoleOption
-	Termination       *ProcessTerminationView
+	Termination       *StreamTerminationDetailsView
 }
 
 func (v StreamInstanceDetailView) StreamTimeline() StreamTimelineView {

--- a/server/cmd/server/dialog_markup_test.go
+++ b/server/cmd/server/dialog_markup_test.go
@@ -46,7 +46,7 @@ func TestStreamPageNewInstanceDialogMarkup(t *testing.T) {
 		`class="dialog-subtitle"`,
 		`class="dialog-actions"`,
 		`class="dialog-title">New instance</h3>`,
-		"Give this stream instance a brief name.",
+		"Give this stream instance a brief name",
 		`class="btn btn-ghost btn-icon dialog-close"`,
 	} {
 		if !strings.Contains(dialog, want) {
@@ -98,7 +98,7 @@ func TestPlatformAdminCreateOrgDialogMarkup(t *testing.T) {
 		`class="dialog-title"`,
 		`class="dialog-subtitle"`,
 		`class="dialog-title">New organization</h3>`,
-		"Add a new organization to the platform.",
+		"Add a new organization to the platform",
 		`class="btn btn-ghost btn-icon dialog-close"`,
 		"Create organization",
 	} {

--- a/server/cmd/server/dpp.go
+++ b/server/cmd/server/dpp.go
@@ -294,7 +294,7 @@ func buildDPPTraceabilitySubstep(ctx timelineSubstepBuildContext) TimelineSubste
 		reason = "Stream ended early"
 		detailMessage = state.terminationReason
 		if detailMessage == "" {
-			detailMessage = "No reason provided."
+			detailMessage = "No reason provided"
 		}
 	case "skipped":
 		reason = "Stream ended early"

--- a/server/cmd/server/dpp_handler_test.go
+++ b/server/cmd/server/dpp_handler_test.go
@@ -129,7 +129,7 @@ func TestHandleDigitalLinkDPPHTMLTemplateIncludesMarkers(t *testing.T) {
 		t.Fatalf("expected status %d, got %d", http.StatusOK, rr.Code)
 	}
 	body := rr.Body.String()
-	if !strings.Contains(body, "GTIN|") || !strings.Contains(body, "Lot|") || !strings.Contains(body, "Serial|") {
+	if !strings.Contains(body, "GTIN: ") || !strings.Contains(body, "Lot: ") || !strings.Contains(body, "Serial: ") {
 		t.Fatalf("expected identifiers in body, got %q", body)
 	}
 	if !strings.Contains(body, "Merkle root:") {

--- a/server/cmd/server/home_handler_test.go
+++ b/server/cmd/server/home_handler_test.go
@@ -660,18 +660,20 @@ func TestHandleWorkflowHomeRendersValidationState(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
 	body := rec.Body.String()
-	compactBody := strings.Join(strings.Fields(body), " ")
+	if !strings.Contains(body, `class="error`) {
+		t.Fatalf("expected error banner, got %q", body)
+	}
 	if !strings.Contains(body, "Stream configuration issue") {
-		t.Fatalf("expected validation panel heading, got %q", body)
+		t.Fatalf("expected validation heading inside error, got %q", body)
 	}
 	if !strings.Contains(body, "workflow references are invalid") {
 		t.Fatalf("expected validation error details, got %q", body)
 	}
-	if !strings.Contains(body, `action="/w/workflow/process/start"`) {
-		t.Fatalf("expected new stream form to remain present, got %q", body)
+	if strings.Contains(body, `class="home-workflow-grid"`) {
+		t.Fatalf("did not expect stream dashboard grid when config is invalid, got %q", body)
 	}
-	if !strings.Contains(compactBody, `class="btn btn-primary"`) || !strings.Contains(compactBody, `type="submit"`) || !strings.Contains(compactBody, `disabled`) || !strings.Contains(compactBody, `New instance`) {
-		t.Fatalf("expected new stream button to be disabled for invalid workflow, got %q", body)
+	if strings.Contains(body, `action="/w/workflow/process/start"`) || strings.Contains(body, "New instance") {
+		t.Fatalf("did not expect new instance controls when config is invalid, got %q", body)
 	}
 }
 

--- a/server/cmd/server/home_handler_test.go
+++ b/server/cmd/server/home_handler_test.go
@@ -669,7 +669,7 @@ func TestHandleWorkflowHomeRendersValidationState(t *testing.T) {
 	if !strings.Contains(body, "workflow references are invalid") {
 		t.Fatalf("expected validation error details, got %q", body)
 	}
-	if strings.Contains(body, `class="home-workflow-grid"`) {
+	if strings.Contains(body, `class="rail-layout`) || strings.Contains(body, `class="home-workflow-grid"`) {
 		t.Fatalf("did not expect stream dashboard grid when config is invalid, got %q", body)
 	}
 	if strings.Contains(body, `action="/w/workflow/process/start"`) || strings.Contains(body, "New instance") {

--- a/server/cmd/server/layout_fonts_test.go
+++ b/server/cmd/server/layout_fonts_test.go
@@ -20,7 +20,7 @@ func TestLayoutLoadsGoogleFontsWithSwap(t *testing.T) {
 		`fonts.googleapis.com/css2?`,
 		`family=Inter:wght@400;500;600;700`,
 		`family=Space+Grotesk:wght@600;700`,
-		`family=JetBrains+Mono:wght@500`,
+		`family=JetBrains+Mono:wght@400;500`,
 		`display=swap`,
 	} {
 		if !strings.Contains(body, want) {

--- a/server/cmd/server/list_row_markup_test.go
+++ b/server/cmd/server/list_row_markup_test.go
@@ -12,7 +12,7 @@ func TestOrgAdminListRowMarkup(t *testing.T) {
 	view := OrgAdminView{
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Create and manage roles and users",
+			Description: "Switch between organization settings, roles, and members.",
 			BackHref:    "/",
 		},
 		Organization: Organization{Name: "Acme Org", Slug: "acme-org"},

--- a/server/cmd/server/list_row_markup_test.go
+++ b/server/cmd/server/list_row_markup_test.go
@@ -12,7 +12,7 @@ func TestOrgAdminListRowMarkup(t *testing.T) {
 	view := OrgAdminView{
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Switch between organization settings, roles, and members.",
+			Description: "Manage organization settings, roles, and members.",
 			BackHref:    "/",
 		},
 		Organization: Organization{Name: "Acme Org", Slug: "acme-org"},

--- a/server/cmd/server/list_row_markup_test.go
+++ b/server/cmd/server/list_row_markup_test.go
@@ -12,7 +12,7 @@ func TestOrgAdminListRowMarkup(t *testing.T) {
 	view := OrgAdminView{
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Manage organization settings, roles, and members.",
+			Description: "Manage organization settings, roles, and members",
 			BackHref:    "/",
 		},
 		Organization: Organization{Name: "Acme Org", Slug: "acme-org"},

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -3819,7 +3819,7 @@ func (s *Server) renderOrgAdminWithErrors(w http.ResponseWriter, user *AccountUs
 		PageBase: s.pageBaseForUser(user, "org_admin_body", "", ""),
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Switch between organization settings, roles, and members.",
+			Description: "Manage organization settings, roles, and members.",
 			BackHref:    "/",
 		},
 		Organization:           org,

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -2023,7 +2023,7 @@ func (s *Server) handleHome(w http.ResponseWriter, r *http.Request) {
 	}
 	view := HomeWorkflowPickerView{
 		WorkflowPickerView: WorkflowPickerView{
-			PageBase:             s.pageBaseForUser(user, "home_picker_body", "", ""),
+			PageBase: s.pageBaseForUser(user, "home_picker_body", "", ""),
 			Header: PageHeaderView{
 				Title:       "Choose a stream",
 				Description: "Select a stream to start or continue process tracking.",
@@ -3316,7 +3316,7 @@ func (s *Server) platformAdminView(user *AccountUser, confirmation string, errs 
 	}
 	rows := platformAdminOrganizationRows(context.Background(), pagedOrganizations, s.identity)
 	return PlatformAdminView{
-		PageBase:                 s.pageBaseForUser(user, "platform_admin_body", "", ""),
+		PageBase: s.pageBaseForUser(user, "platform_admin_body", "", ""),
 		Header: PageHeaderView{
 			Title:       "Platform admin dashboard",
 			Description: "Create and manage organizations",
@@ -3780,10 +3780,10 @@ func (s *Server) renderOrgAdminWithErrors(w http.ResponseWriter, user *AccountUs
 
 	if !userHasOrganizationContext(user) || strings.TrimSpace(orgSlug) == "" {
 		view := OrgAdminView{
-			PageBase:               s.pageBaseForUser(user, "org_admin_body", "", ""),
+			PageBase: s.pageBaseForUser(user, "org_admin_body", "", ""),
 			Header: PageHeaderView{
 				Title:       "Organization admin dashboard",
-				Description: "Create and manage roles and users",
+				Description: "Manage organization settings, roles, and members.",
 				BackHref:    "/",
 			},
 			NeedsOrganizationSetup: true,
@@ -3816,13 +3816,13 @@ func (s *Server) renderOrgAdminWithErrors(w http.ResponseWriter, user *AccountUs
 	roleRows := buildOrgAdminRoleRows(roles, orgUsers, orgInvites)
 
 	view := OrgAdminView{
-		PageBase:               s.pageBaseForUser(user, "org_admin_body", "", ""),
+		PageBase: s.pageBaseForUser(user, "org_admin_body", "", ""),
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Create and manage roles and users",
+			Description: "Switch between organization settings, roles, and members.",
 			BackHref:    "/",
 		},
-		Organization: org,
+		Organization:           org,
 		OrganizationLogoURL:    "/org-admin/logo/" + strings.TrimSpace(org.LogoAttachmentID),
 		NeedsOrganizationSetup: false,
 		OrganizationError:      errs.Organization,
@@ -4830,7 +4830,7 @@ func (s *Server) handleWorkflowHome(w http.ResponseWriter, r *http.Request) {
 	preview.HideStatus = true
 
 	view := HomeView{
-		PageBase:            s.pageBaseForUser(user, "home_body", workflowKey, cfg.Workflow.Name),
+		PageBase: s.pageBaseForUser(user, "home_body", workflowKey, cfg.Workflow.Name),
 		Header: PageHeaderView{
 			Title:       cfg.Workflow.Name,
 			Description: strings.TrimSpace(cfg.Workflow.Description),
@@ -5042,7 +5042,6 @@ func (s *Server) handleProcessPage(w http.ResponseWriter, r *http.Request, proce
 	}
 }
 
-
 func (s *Server) buildProcessPageView(ctx context.Context, pageBase PageBase, cfg RuntimeConfig, workflowKey string, process *Process, actor Actor, selectedSubstepID, message string, onlyRole bool) ProcessPageView {
 	detail := s.buildStreamInstanceDetailView(ctx, cfg, workflowKey, process, actor, selectedSubstepID, message, onlyRole)
 	processID := ""
@@ -5134,9 +5133,6 @@ func actorFromAccountUser(user *AccountUser, workflowKey string) Actor {
 	return actor
 }
 
-
-
-
 func (s *Server) applyDoneByIdentityFallbackToDPPTraceability(ctx context.Context, traceability []TimelineStep) []TimelineStep {
 	if len(traceability) == 0 {
 		return traceability
@@ -5224,7 +5220,7 @@ func (s *Server) handleDigitalLinkDPP(w http.ResponseWriter, r *http.Request) {
 	traceability = publicDPPTraceabilityAttachmentURLs(traceability, link)
 	traceability = s.applyDoneByIdentityFallbackToDPPTraceability(r.Context(), traceability)
 	view := DPPPageView{
-		PageBase:     s.pageBase("dpp_body", workflowKey, cfg.Workflow.Name),
+		PageBase: s.pageBase("dpp_body", workflowKey, cfg.Workflow.Name),
 		Header: PageHeaderView{
 			Title:       "Digital Product Passport",
 			Description: "GS1 Digital Link landing page for product and stream traceability.",
@@ -6688,7 +6684,6 @@ func organizationNameMap(cfg RuntimeConfig) map[string]string {
 	return out
 }
 
-
 func organizationLogoURLMap(ctx context.Context, identity IdentityStore) map[string]string {
 	if identity == nil {
 		return map[string]string{}
@@ -7096,9 +7091,6 @@ func nextAvailableSubstep(def WorkflowDef, process *Process) (WorkflowSub, bool)
 	}
 	return WorkflowSub{}, false
 }
-
-
-
 
 func flattenDisplayValues(inputKey string, raw interface{}) []SubstepKV {
 	key := strings.TrimSpace(inputKey)

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -2026,7 +2026,7 @@ func (s *Server) handleHome(w http.ResponseWriter, r *http.Request) {
 			PageBase: s.pageBaseForUser(user, "home_picker_body", "", ""),
 			Header: PageHeaderView{
 				Title:       "Choose a stream",
-				Description: "Select a stream to start or continue process tracking.",
+				Description: "Select a stream to start or continue process tracking",
 			},
 			Workflows:            options,
 			ShowCreateStreamCard: showCreateStreamCard,
@@ -3783,7 +3783,7 @@ func (s *Server) renderOrgAdminWithErrors(w http.ResponseWriter, user *AccountUs
 			PageBase: s.pageBaseForUser(user, "org_admin_body", "", ""),
 			Header: PageHeaderView{
 				Title:       "Organization admin dashboard",
-				Description: "Manage organization settings, roles, and members.",
+				Description: "Manage organization settings, roles, and members",
 				BackHref:    "/",
 			},
 			NeedsOrganizationSetup: true,
@@ -3819,7 +3819,7 @@ func (s *Server) renderOrgAdminWithErrors(w http.ResponseWriter, user *AccountUs
 		PageBase: s.pageBaseForUser(user, "org_admin_body", "", ""),
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Manage organization settings, roles, and members.",
+			Description: "Manage organization settings, roles, and members",
 			BackHref:    "/",
 		},
 		Organization:           org,
@@ -5223,7 +5223,7 @@ func (s *Server) handleDigitalLinkDPP(w http.ResponseWriter, r *http.Request) {
 		PageBase: s.pageBase("dpp_body", workflowKey, cfg.Workflow.Name),
 		Header: PageHeaderView{
 			Title:       "Digital Product Passport",
-			Description: "GS1 Digital Link landing page for product and stream traceability.",
+			Description: "GS1 Digital Link landing page for product and stream traceability",
 		},
 		ProcessID:    process.ID.Hex(),
 		DigitalLink:  link,

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -459,6 +459,7 @@ type PlatformAdminErrors struct {
 type OrgAdminView struct {
 	PageBase
 	Header                 PageHeaderView
+	ActivePanel            string
 	Organization           Organization
 	OrganizationLogoURL    string
 	NeedsOrganizationSetup bool
@@ -1296,7 +1297,7 @@ func (s *Server) logAndRenderPlatformAdminError(w http.ResponseWriter, r *http.R
 
 func (s *Server) logAndRenderOrgAdminError(w http.ResponseWriter, r *http.Request, user *AccountUser, orgSlug, inviteLink string, errs OrgAdminErrors, err error, message string, args ...interface{}) {
 	logRequestError(r, err, message, args...)
-	s.renderOrgAdminWithErrors(w, user, orgSlug, inviteLink, errs)
+	s.renderOrgAdminWithErrors(w, r, user, orgSlug, inviteLink, errs)
 }
 
 func workflowPath(key string) string {
@@ -2185,7 +2186,9 @@ func (s *Server) newMux() *http.ServeMux {
 	mux.HandleFunc("/invite/", s.handleInvite)
 	mux.HandleFunc("/reset", s.handleResetRequest)
 	mux.HandleFunc("/reset/", s.handleResetSet)
+	mux.HandleFunc("/org-admin/profile", s.handleOrgAdminPage)
 	mux.HandleFunc("/org-admin/roles", s.handleOrgAdminRoles)
+	mux.HandleFunc("/org-admin/members", s.handleOrgAdminPage)
 	mux.HandleFunc("/org-admin/logo/", s.handleOrgAdminLogo)
 	mux.HandleFunc("/org-admin/users", s.handleOrgAdminUsers)
 	mux.HandleFunc("/org-admin/formata-builder", s.handleOrgAdminFormataBuilder)
@@ -2478,7 +2481,7 @@ func (s *Server) handleSignup(w http.ResponseWriter, r *http.Request) {
 		}
 		redirectTarget := "/"
 		if strings.TrimSpace(identityUser.OrgSlug) == "" {
-			redirectTarget = "/org-admin/users"
+			redirectTarget = "/org-admin/profile"
 		}
 		http.Redirect(w, r, redirectTarget, http.StatusSeeOther)
 		return
@@ -3610,11 +3613,27 @@ func (s *Server) handleAdminOrgs(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) renderOrgAdmin(w http.ResponseWriter, user *AccountUser, orgSlug, inviteLink, errMsg string) {
-	errs := OrgAdminErrors{
-		Organization: strings.TrimSpace(errMsg),
+func resolveOrgAdminActivePanel(r *http.Request, errs OrgAdminErrors, inviteLink string) string {
+	if strings.TrimSpace(errs.Role) != "" {
+		return "roles"
 	}
-	s.renderOrgAdminWithErrors(w, user, orgSlug, inviteLink, errs)
+	if strings.TrimSpace(errs.Users) != "" || strings.TrimSpace(errs.Invite) != "" || strings.TrimSpace(inviteLink) != "" {
+		return "members"
+	}
+	if strings.TrimSpace(errs.Organization) != "" {
+		return "profile"
+	}
+	if r != nil {
+		switch r.URL.Path {
+		case "/org-admin/roles":
+			return "roles"
+		case "/org-admin/members":
+			return "members"
+		case "/org-admin/profile":
+			return "profile"
+		}
+	}
+	return "profile"
 }
 
 func firstNonEmpty(values ...string) string {
@@ -3772,11 +3791,12 @@ func (s *Server) loadOrgAdminState(ctx context.Context, user *AccountUser, orgSl
 	return org, roles, orgUsers, nil, nil
 }
 
-func (s *Server) renderOrgAdminWithErrors(w http.ResponseWriter, user *AccountUser, orgSlug, inviteLink string, errs OrgAdminErrors) {
+func (s *Server) renderOrgAdminWithErrors(w http.ResponseWriter, r *http.Request, user *AccountUser, orgSlug, inviteLink string, errs OrgAdminErrors) {
 	errs.Organization = strings.TrimSpace(errs.Organization)
 	errs.Role = strings.TrimSpace(errs.Role)
 	errs.Invite = strings.TrimSpace(errs.Invite)
 	errs.Users = strings.TrimSpace(errs.Users)
+	activePanel := resolveOrgAdminActivePanel(r, errs, inviteLink)
 
 	if !userHasOrganizationContext(user) || strings.TrimSpace(orgSlug) == "" {
 		view := OrgAdminView{
@@ -3786,6 +3806,7 @@ func (s *Server) renderOrgAdminWithErrors(w http.ResponseWriter, user *AccountUs
 				Description: "Manage organization settings, roles, and members",
 				BackHref:    "/",
 			},
+			ActivePanel:            activePanel,
 			NeedsOrganizationSetup: true,
 			OrganizationError:      errs.Organization,
 			RoleError:              errs.Role,
@@ -3822,6 +3843,7 @@ func (s *Server) renderOrgAdminWithErrors(w http.ResponseWriter, user *AccountUs
 			Description: "Manage organization settings, roles, and members",
 			BackHref:    "/",
 		},
+		ActivePanel:            activePanel,
 		Organization:           org,
 		OrganizationLogoURL:    "/org-admin/logo/" + strings.TrimSpace(org.LogoAttachmentID),
 		NeedsOrganizationSetup: false,
@@ -3967,18 +3989,30 @@ func (s *Server) handlePlatformAdminLogo(w http.ResponseWriter, r *http.Request)
 	_, _ = w.Write(logo.Data)
 }
 
+func (s *Server) handleOrgAdminPage(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	admin, ok := s.requireOrgAdmin(w, r)
+	if !ok {
+		return
+	}
+	s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{})
+}
+
 func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 	user, ok := s.requireOrgAdmin(w, r)
 	if !ok {
 		return
 	}
 	if !userHasOrganizationContext(user) {
-		s.renderOrgAdminWithErrors(w, user, "", "", OrgAdminErrors{Organization: "create organization first"})
+		s.renderOrgAdminWithErrors(w, r, user, "", "", OrgAdminErrors{Organization: "create organization first"})
 		return
 	}
 	switch r.Method {
 	case http.MethodGet:
-		s.renderOrgAdmin(w, user, user.OrgSlug, "", "")
+		s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{})
 		return
 	case http.MethodPost:
 		if err := r.ParseForm(); err != nil {
@@ -4033,12 +4067,12 @@ func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 			name := strings.TrimSpace(r.FormValue("name"))
 			palette := strings.TrimSpace(r.FormValue("palette"))
 			if name == "" {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role name is required", RoleAction: "create", RolePalette: palette})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role name is required", RoleAction: "create", RolePalette: palette})
 				return
 			}
 			roleSlug := canonifyIdentityRoleSlug(name)
 			if roleSlug == "" {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: invalidRoleNameMessage, RoleAction: "create", RoleName: name, RolePalette: palette})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: invalidRoleNameMessage, RoleAction: "create", RoleName: name, RolePalette: palette})
 				return
 			}
 			if palette == "" {
@@ -4046,7 +4080,7 @@ func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 			}
 			for _, existingRole := range ensureOrgAdminRoleOption(rolesFromIdentityOrg(*org)) {
 				if strings.EqualFold(canonifyIdentityRoleSlug(existingRole.Slug), roleSlug) {
-					s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role slug already exists", RoleAction: "create", RoleName: name, RolePalette: palette})
+					s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role slug already exists", RoleAction: "create", RoleName: name, RolePalette: palette})
 					return
 				}
 			}
@@ -4057,7 +4091,7 @@ func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 			})
 			if _, err := s.identity.UpdateOrganization(r.Context(), sessionSecret, user.OrgSlug, org.Name, org.LogoFileID, updatedRoles); err != nil {
 				if isDuplicateSlugError(err) {
-					s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role slug already exists", RoleAction: "create", RoleName: name, RolePalette: palette})
+					s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role slug already exists", RoleAction: "create", RoleName: name, RolePalette: palette})
 					return
 				}
 				s.logAndRenderOrgAdminError(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "failed to create role", RoleAction: "create", RoleName: name, RolePalette: palette}, err, "failed to update organization %s with new role %s", user.OrgSlug, roleSlug)
@@ -4068,25 +4102,25 @@ func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 			name := strings.TrimSpace(r.FormValue("name"))
 			palette := strings.TrimSpace(r.FormValue("palette"))
 			if currentSlug == "" {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "edit"})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "edit"})
 				return
 			}
 			if name == "" {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role name is required", RoleAction: "edit", RoleSlug: currentSlug, RolePalette: palette})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role name is required", RoleAction: "edit", RoleSlug: currentSlug, RolePalette: palette})
 				return
 			}
 			targetRow := findRoleRow(currentSlug)
 			if targetRow == nil {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette})
 				return
 			}
 			if targetRow.InUse {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "remove the role from the users that have it before continuing with the action", RoleAction: "edit", RoleSlug: currentSlug, RoleName: targetRow.Name, RolePalette: targetRow.Palette})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "remove the role from the users that have it before continuing with the action", RoleAction: "edit", RoleSlug: currentSlug, RoleName: targetRow.Name, RolePalette: targetRow.Palette})
 				return
 			}
 			roleSlug := canonifyIdentityRoleSlug(name)
 			if roleSlug == "" {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: invalidRoleNameMessage, RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: invalidRoleNameMessage, RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette})
 				return
 			}
 			if palette == "" {
@@ -4097,7 +4131,7 @@ func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 			for idx := range updatedRoles {
 				if !containsRole([]string{updatedRoles[idx].Slug}, currentSlug) {
 					if strings.EqualFold(canonifyIdentityRoleSlug(updatedRoles[idx].Slug), roleSlug) {
-						s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role slug already exists", RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette})
+						s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role slug already exists", RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette})
 						return
 					}
 					continue
@@ -4110,12 +4144,12 @@ func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 				updatedRoles[idx].Border = ""
 			}
 			if !found {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette})
 				return
 			}
 			if _, err := s.identity.UpdateOrganization(r.Context(), sessionSecret, user.OrgSlug, org.Name, org.LogoFileID, updatedRoles); err != nil {
 				if isDuplicateSlugError(err) {
-					s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role slug already exists", RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette})
+					s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role slug already exists", RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette})
 					return
 				}
 				s.logAndRenderOrgAdminError(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "failed to update role", RoleAction: "edit", RoleSlug: currentSlug, RoleName: name, RolePalette: palette}, err, "failed to update role %s in organization %s", currentSlug, user.OrgSlug)
@@ -4124,16 +4158,16 @@ func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 		case "delete_role":
 			currentSlug := strings.TrimSpace(r.FormValue("role_slug"))
 			if currentSlug == "" {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "delete"})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "delete"})
 				return
 			}
 			targetRow := findRoleRow(currentSlug)
 			if targetRow == nil {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "delete", RoleSlug: currentSlug})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "delete", RoleSlug: currentSlug})
 				return
 			}
 			if targetRow.InUse {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "remove the role from the users that have it before continuing with the action", RoleAction: "delete", RoleSlug: currentSlug, RoleName: targetRow.Name})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "remove the role from the users that have it before continuing with the action", RoleAction: "delete", RoleSlug: currentSlug, RoleName: targetRow.Name})
 				return
 			}
 			updatedRoles := make([]IdentityRole, 0, len(org.Roles))
@@ -4146,7 +4180,7 @@ func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 				updatedRoles = append(updatedRoles, role)
 			}
 			if !found {
-				s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "delete", RoleSlug: currentSlug})
+				s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "role not found", RoleAction: "delete", RoleSlug: currentSlug})
 				return
 			}
 			if _, err := s.identity.UpdateOrganization(r.Context(), sessionSecret, user.OrgSlug, org.Name, org.LogoFileID, updatedRoles); err != nil {
@@ -4154,10 +4188,10 @@ func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		default:
-			s.renderOrgAdminWithErrors(w, user, user.OrgSlug, "", OrgAdminErrors{Role: "unsupported action"})
+			s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "unsupported action"})
 			return
 		}
-		http.Redirect(w, r, "/org-admin/users", http.StatusSeeOther)
+		http.Redirect(w, r, "/org-admin/roles", http.StatusSeeOther)
 		return
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -4173,8 +4207,12 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "identity unavailable", http.StatusServiceUnavailable)
 		return
 	}
+	if r.Method == http.MethodGet {
+		http.Redirect(w, r, "/org-admin/profile", http.StatusSeeOther)
+		return
+	}
 	if r.Method != http.MethodPost {
-		s.renderOrgAdmin(w, admin, admin.OrgSlug, "", "")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 	contentType := strings.ToLower(strings.TrimSpace(r.Header.Get("Content-Type")))
@@ -4182,7 +4220,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 		r.Body = http.MaxBytesReader(w, r.Body, organizationLogoMaxBytes())
 		if err := r.ParseMultipartForm(1 << 20); err != nil {
 			if isRequestTooLarge(err) {
-				s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "logo file too large"})
+				s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "logo file too large"})
 				return
 			}
 			logAndHTTPError(w, r, http.StatusBadRequest, "invalid form", err, "failed to parse org-admin multipart form")
@@ -4201,22 +4239,22 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 	}
 	if !userHasOrganizationContext(admin) {
 		if intent != "create_org" {
-			s.renderOrgAdminWithErrors(w, admin, "", "", OrgAdminErrors{Organization: "create organization first"})
+			s.renderOrgAdminWithErrors(w, r, admin, "", "", OrgAdminErrors{Organization: "create organization first"})
 			return
 		}
 		name := strings.TrimSpace(r.FormValue("name"))
 		if name == "" {
-			s.renderOrgAdminWithErrors(w, admin, "", "", OrgAdminErrors{Organization: "organization name is required"})
+			s.renderOrgAdminWithErrors(w, r, admin, "", "", OrgAdminErrors{Organization: "organization name is required"})
 			return
 		}
 		orgSlug := canonifySlug(name)
 		if existing, err := s.identity.GetOrganizationBySlug(r.Context(), orgSlug); err == nil && existing != nil {
-			s.renderOrgAdminWithErrors(w, admin, "", "", OrgAdminErrors{Organization: "organization slug already exists"})
+			s.renderOrgAdminWithErrors(w, r, admin, "", "", OrgAdminErrors{Organization: "organization slug already exists"})
 			return
 		}
 		logoUpload, logoErrMsg := s.readOrganizationLogoUpload(r)
 		if logoErrMsg != "" {
-			s.renderOrgAdminWithErrors(w, admin, "", "", OrgAdminErrors{Organization: logoErrMsg})
+			s.renderOrgAdminWithErrors(w, r, admin, "", "", OrgAdminErrors{Organization: logoErrMsg})
 			return
 		}
 		sessionSecret, err := sessionSecretFromRequest(r)
@@ -4227,7 +4265,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 		createdOrg, err := s.identity.CreateOrganization(r.Context(), sessionSecret, name)
 		if err != nil {
 			if isDuplicateSlugError(err) {
-				s.renderOrgAdminWithErrors(w, admin, "", "", OrgAdminErrors{Organization: "organization slug already exists"})
+				s.renderOrgAdminWithErrors(w, r, admin, "", "", OrgAdminErrors{Organization: "organization slug already exists"})
 				return
 			}
 			s.logAndRenderOrgAdminError(w, r, admin, "", "", OrgAdminErrors{Organization: "failed to create organization"}, err, "failed to create organization %s", name)
@@ -4249,17 +4287,17 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-		http.Redirect(w, r, "/org-admin/users", http.StatusSeeOther)
+		http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
 		return
 	}
 
 	switch intent {
 	case "create_org":
-		s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "organization already exists for your account"})
+		s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "organization already exists for your account"})
 	case "invite":
 		email := strings.ToLower(strings.TrimSpace(r.FormValue("email")))
 		if email == "" {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "email is required"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "email is required"})
 			return
 		}
 		org, err := s.identity.GetOrganizationBySlug(r.Context(), admin.OrgSlug)
@@ -4278,7 +4316,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 		}
 		for _, roleSlug := range selectedRoles {
 			if _, ok := allowed[strings.TrimSpace(roleSlug)]; !ok {
-				s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "role not found"})
+				s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "role not found"})
 				return
 			}
 		}
@@ -4312,7 +4350,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 					s.logAndRenderOrgAdminError(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "failed to update user roles"}, err, "failed to update labels for invited member %s in organization %s", membership.UserID, admin.OrgSlug)
 					return
 				}
-				s.renderOrgAdmin(w, admin, admin.OrgSlug, "", "")
+				http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
 				return
 			}
 			if roleSlugsKey(append(append([]string{}, membership.RoleSlugs...), func() []string {
@@ -4321,7 +4359,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 				}
 				return nil
 			}()...)) == roleSlugsKey(selectedRoles) {
-				s.renderOrgAdmin(w, admin, admin.OrgSlug, "", "")
+				http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
 				return
 			}
 			sessionSecret, err := sessionSecretFromRequest(r)
@@ -4333,13 +4371,13 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 				s.logAndRenderOrgAdminError(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "failed to create invite"}, err, "failed to update membership %s in organization %s", membership.ID, admin.OrgSlug)
 				return
 			}
-			s.renderOrgAdmin(w, admin, admin.OrgSlug, "", "")
+			http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
 			return
 		}
 		existingUser, err := s.identity.GetUserByEmail(r.Context(), email)
 		switch {
 		case err == nil && existingUser.OrgSlug != "" && !strings.EqualFold(strings.TrimSpace(existingUser.OrgSlug), strings.TrimSpace(admin.OrgSlug)):
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "email already belongs to another organization"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "email already belongs to another organization"})
 			return
 		case err == nil && strings.EqualFold(strings.TrimSpace(existingUser.OrgSlug), strings.TrimSpace(admin.OrgSlug)):
 			labels := make([]string, 0, len(businessRoles)+1)
@@ -4353,7 +4391,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 				s.logAndRenderOrgAdminError(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "failed to update user roles"}, err, "failed to update labels for existing user %s in organization %s", existingUser.ID, admin.OrgSlug)
 				return
 			}
-			s.renderOrgAdmin(w, admin, admin.OrgSlug, "", "")
+			http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
 			return
 		case err != nil && !errors.Is(err, ErrIdentityNotFound):
 			s.logAndRenderOrgAdminError(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "failed to load existing user"}, err, "failed to look up existing user %s during invite", email)
@@ -4368,11 +4406,11 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 			s.logAndRenderOrgAdminError(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "failed to create invite"}, err, "failed to create invite for %s in organization %s", email, admin.OrgSlug)
 			return
 		}
-		s.renderOrgAdmin(w, admin, admin.OrgSlug, "", "")
+		http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
 	case "update_org":
 		name := strings.TrimSpace(r.FormValue("name"))
 		if name == "" {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "organization name is required"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "organization name is required"})
 			return
 		}
 		org, err := s.identity.GetOrganizationBySlug(r.Context(), admin.OrgSlug)
@@ -4386,13 +4424,13 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 		targetOrgSlug := canonifySlug(name)
 		if targetOrgSlug != strings.TrimSpace(org.Slug) {
 			if existing, err := s.identity.GetOrganizationBySlug(r.Context(), targetOrgSlug); err == nil && existing != nil && strings.TrimSpace(existing.ID) != strings.TrimSpace(org.ID) {
-				s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "organization slug already exists"})
+				s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "organization slug already exists"})
 				return
 			}
 		}
 		logoUpload, logoErrMsg := s.readOrganizationLogoUpload(r)
 		if logoErrMsg != "" {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: logoErrMsg})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: logoErrMsg})
 			return
 		}
 		previousLogoFileID := strings.TrimSpace(org.LogoFileID)
@@ -4417,7 +4455,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 		updatedOrg, err := s.identity.UpdateOrganization(r.Context(), sessionSecret, admin.OrgSlug, name, logoFileID, append([]IdentityRole(nil), org.Roles...))
 		if err != nil {
 			if isDuplicateSlugError(err) {
-				s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "organization slug already exists"})
+				s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "organization slug already exists"})
 				return
 			}
 			s.logAndRenderOrgAdminError(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Organization: "failed to update organization"}, err, "failed to update organization %s", admin.OrgSlug)
@@ -4428,11 +4466,11 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 				log.Printf("failed to delete previous organization logo %q: %v", previousLogoFileID, err)
 			}
 		}
-		http.Redirect(w, r, "/org-admin/users", http.StatusSeeOther)
+		http.Redirect(w, r, "/org-admin/profile", http.StatusSeeOther)
 	case "set_roles":
 		userID := strings.TrimSpace(r.FormValue("userId"))
 		if userID == "" {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user is required"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user is required"})
 			return
 		}
 		org, err := s.identity.GetOrganizationBySlug(r.Context(), admin.OrgSlug)
@@ -4457,11 +4495,11 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if target == nil {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user not found"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user not found"})
 			return
 		}
 		if isPlatformAdminIdentityUser(*target) {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user not found"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user not found"})
 			return
 		}
 		selectedRoles := requestedRoleSlugs(r.Form)
@@ -4472,12 +4510,12 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 		}
 		for _, roleSlug := range selectedRoles {
 			if _, ok := allowed[strings.TrimSpace(roleSlug)]; !ok {
-				s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "role not found"})
+				s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "role not found"})
 				return
 			}
 		}
 		if firstNonEmpty(target.ID, target.Email) == firstNonEmpty(admin.IdentityUserID, admin.Email) && !containsRole(selectedRoles, "org-admin") {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "cannot remove org-admin from your own account"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "cannot remove org-admin from your own account"})
 			return
 		}
 		labels := make([]string, 0, len(target.Labels)+len(selectedRoles)+1)
@@ -4502,11 +4540,11 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 			s.logAndRenderOrgAdminError(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "failed to update user roles"}, err, "failed to update labels for user %s in organization %s", target.ID, admin.OrgSlug)
 			return
 		}
-		s.renderOrgAdmin(w, admin, admin.OrgSlug, "", "")
+		http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
 	case "delete_user":
 		userID := strings.TrimSpace(r.FormValue("userId"))
 		if userID == "" {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user is required"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user is required"})
 			return
 		}
 		memberships, err := s.identity.ListOrganizationMemberships(r.Context(), admin.OrgSlug)
@@ -4523,15 +4561,15 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if target == nil {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user not found"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user not found"})
 			return
 		}
 		if isPlatformAdminMembership(*target) {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user not found"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "user not found"})
 			return
 		}
 		if firstNonEmpty(target.UserID, target.Email) == firstNonEmpty(admin.IdentityUserID, admin.Email) {
-			s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "cannot delete yourself"})
+			s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "cannot delete yourself"})
 			return
 		}
 		sessionSecret, err := sessionSecretFromRequest(r)
@@ -4561,9 +4599,9 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-		s.renderOrgAdmin(w, admin, admin.OrgSlug, "", "")
+		http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
 	default:
-		s.renderOrgAdminWithErrors(w, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "unsupported action"})
+		s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "unsupported action"})
 	}
 }
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -580,7 +580,7 @@ type DPPPageView struct {
 	Traceability []TimelineStep
 	Integrity    DPPIntegrityView
 	Export       NotarizedProcessExport
-	Termination  *ProcessTerminationView
+	Termination  *StreamTerminationDetailsView
 }
 
 type ProcessTerminationView struct {
@@ -5273,7 +5273,7 @@ func (s *Server) handleDigitalLinkDPP(w http.ResponseWriter, r *http.Request) {
 		Traceability: traceability,
 		Integrity:    buildDPPIntegrityView(export.Merkle),
 		Export:       export,
-		Termination:  processTerminationView(process.Termination),
+		Termination:  s.buildStreamTerminationDetailsView(r.Context(), cfg.Workflow, Actor{}, process.Termination),
 	}
 	if err := s.tmpl.ExecuteTemplate(w, "dpp.html", view); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/server/cmd/server/org_admin_render_test.go
+++ b/server/cmd/server/org_admin_render_test.go
@@ -76,7 +76,7 @@ func TestRenderOrgAdminWithErrorsBranches(t *testing.T) {
 		server := &Server{tmpl: testTemplates(), now: func() time.Time { return now }}
 		rec := httptest.NewRecorder()
 
-		server.renderOrgAdminWithErrors(rec, &AccountUser{Email: "owner@example.com", RoleSlugs: []string{"org-admin"}, Status: "active"}, "", "/invite/token", OrgAdminErrors{
+		server.renderOrgAdminWithErrors(rec, nil, &AccountUser{Email: "owner@example.com", RoleSlugs: []string{"org-admin"}, Status: "active"}, "", "/invite/token", OrgAdminErrors{
 			Invite: " invite failed ",
 		})
 
@@ -101,7 +101,7 @@ func TestRenderOrgAdminWithErrorsBranches(t *testing.T) {
 		}
 		rec := httptest.NewRecorder()
 
-		server.renderOrgAdminWithErrors(rec, admin, "acme", "", OrgAdminErrors{})
+		server.renderOrgAdminWithErrors(rec, nil, admin, "acme", "", OrgAdminErrors{})
 
 		if rec.Code != http.StatusNotFound {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
@@ -133,7 +133,7 @@ func TestRenderOrgAdminWithErrorsBranches(t *testing.T) {
 		}
 		rec := httptest.NewRecorder()
 
-		server.renderOrgAdminWithErrors(rec, admin, "acme", "/invite/token", OrgAdminErrors{Users: " user error "})
+		server.renderOrgAdminWithErrors(rec, nil, admin, "acme", "/invite/token", OrgAdminErrors{Users: " user error "})
 
 		if rec.Code != http.StatusOK {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
@@ -175,7 +175,7 @@ func TestRenderOrgAdminWithErrorsBranches(t *testing.T) {
 		}
 		rec := httptest.NewRecorder()
 
-		server.renderOrgAdminWithErrors(rec, admin, "acme", "", OrgAdminErrors{})
+		server.renderOrgAdminWithErrors(rec, nil, admin, "acme", "", OrgAdminErrors{})
 
 		if rec.Code != http.StatusOK {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
@@ -191,7 +191,7 @@ func TestRenderOrgAdminWithErrorsBranches(t *testing.T) {
 		server := &Server{tmpl: tmpl, now: func() time.Time { return now }}
 		rec := httptest.NewRecorder()
 
-		server.renderOrgAdminWithErrors(rec, &AccountUser{Email: "owner@example.com"}, "", "", OrgAdminErrors{})
+		server.renderOrgAdminWithErrors(rec, nil, &AccountUser{Email: "owner@example.com"}, "", "", OrgAdminErrors{})
 
 		if rec.Code != http.StatusInternalServerError {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)

--- a/server/cmd/server/org_admin_section_urls_test.go
+++ b/server/cmd/server/org_admin_section_urls_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func orgAdminSectionURLTestServer(t *testing.T, now time.Time) *Server {
+	t.Helper()
+	return &Server{
+		authorizer: fakeAuthorizer{},
+		store:      NewMemoryStore(),
+		identity: &fakeIdentityStore{
+			getSessionFunc: func(ctx context.Context, sessionSecret string) (IdentitySession, error) {
+				return fakeIdentitySession(sessionSecret, "user-1", now.Add(time.Hour)), nil
+			},
+			getCurrentUserFunc: func(ctx context.Context, sessionSecret string) (IdentityUser, error) {
+				return IdentityUser{
+					ID:         "user-1",
+					Email:      "owner@example.com",
+					OrgSlug:    "acme",
+					Labels:     []string{identityOrgAdminLabel},
+					IsOrgAdmin: true,
+					Status:     "active",
+				}, nil
+			},
+			getOrganizationBySlugFunc: func(ctx context.Context, slug string) (*IdentityOrg, error) {
+				org := IdentityOrg{
+					ID:    "team-1",
+					Slug:  "acme",
+					Name:  "Acme Org",
+					Roles: []IdentityRole{{Slug: "approver", Name: "Approver"}},
+				}
+				return &org, nil
+			},
+			listOrganizationUsersFunc: func(ctx context.Context, orgSlug string) ([]IdentityUser, error) {
+				return []IdentityUser{
+					{ID: "user-1", Email: "owner@example.com", OrgSlug: "acme", Labels: []string{identityOrgAdminLabel}, IsOrgAdmin: true, Status: "active"},
+				}, nil
+			},
+			listOrganizationMembershipsFunc: func(ctx context.Context, orgSlug string) ([]IdentityMembership, error) {
+				return nil, nil
+			},
+		},
+		tmpl:        parseTestTemplates(t),
+		enforceAuth: true,
+		now:         func() time.Time { return now },
+	}
+}
+
+func TestOrgAdminSectionURLHandlers(t *testing.T) {
+	now := time.Now().UTC()
+	server := orgAdminSectionURLTestServer(t, now)
+
+	t.Run("GET legacy users redirects to profile", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/org-admin/users", nil)
+		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
+		rec := httptest.NewRecorder()
+
+		server.handleOrgAdminUsers(rec, req)
+
+		if rec.Code != http.StatusSeeOther {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
+		}
+		if loc := rec.Header().Get("Location"); loc != "/org-admin/profile" {
+			t.Fatalf("location = %q, want /org-admin/profile", loc)
+		}
+	})
+
+	t.Run("GET profile renders active profile panel", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/org-admin/profile", nil)
+		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
+		rec := httptest.NewRecorder()
+
+		server.handleOrgAdminPage(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+		}
+		body := rec.Body.String()
+		assertOrgAdminActivePanel(t, body, "profile")
+	})
+
+	t.Run("GET members renders active members panel", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/org-admin/members", nil)
+		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
+		rec := httptest.NewRecorder()
+
+		server.handleOrgAdminPage(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+		}
+		body := rec.Body.String()
+		assertOrgAdminActivePanel(t, body, "members")
+	})
+
+	t.Run("GET roles renders active roles panel", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/org-admin/roles", nil)
+		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
+		rec := httptest.NewRecorder()
+
+		server.handleOrgAdminRoles(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+		}
+		body := rec.Body.String()
+		assertOrgAdminActivePanel(t, body, "roles")
+	})
+}
+
+func TestResolveOrgAdminActivePanelFromPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{path: "/org-admin/profile", want: "profile"},
+		{path: "/org-admin/members", want: "members"},
+		{path: "/org-admin/roles", want: "roles"},
+		{path: "/org-admin/users", want: "profile"},
+	}
+	for _, tc := range tests {
+		req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+		if got := resolveOrgAdminActivePanel(req, OrgAdminErrors{}, ""); got != tc.want {
+			t.Fatalf("resolveOrgAdminActivePanel(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+func assertOrgAdminActivePanel(t *testing.T, body, panel string) {
+	t.Helper()
+
+	if !strings.Contains(body, `class="sidebar-nav-link is-active"`) {
+		t.Fatalf("expected active sidebar nav link for %q", panel)
+	}
+	if !strings.Contains(body, `href="/org-admin/`+panel+`"`) {
+		t.Fatalf("expected nav href for %q panel", panel)
+	}
+	if !strings.Contains(body, `data-org-admin-default-panel="`+panel+`"`) {
+		preview := body
+		if len(preview) > 400 {
+			preview = preview[:400]
+		}
+		t.Fatalf("expected default panel %q, got body prefix:\n%s", panel, preview)
+	}
+
+	panelID := `id="org-admin-panel-` + panel + `"` 
+	panelStart := strings.Index(body, panelID)
+	if panelStart == -1 {
+		t.Fatalf("expected %s section in body", panelID)
+	}
+	panelEnd := strings.Index(body[panelStart:], ">")
+	if panelEnd == -1 {
+		t.Fatalf("expected opening tag for %s", panelID)
+	}
+	panelTag := body[panelStart : panelStart+panelEnd+1]
+	if strings.Contains(panelTag, "hidden") {
+		t.Fatalf("active panel %q must not be hidden, got tag %q", panel, panelTag)
+	}
+
+	for _, other := range []string{"profile", "roles", "members"} {
+		if other == panel {
+			continue
+		}
+		otherID := `id="org-admin-panel-` + other + `"` 
+		otherStart := strings.Index(body, otherID)
+		if otherStart == -1 {
+			t.Fatalf("expected %s section in body", otherID)
+		}
+		otherEnd := strings.Index(body[otherStart:], ">")
+		if otherEnd == -1 {
+			t.Fatalf("expected opening tag for %s", otherID)
+		}
+		otherTag := body[otherStart : otherStart+otherEnd+1]
+		if !strings.Contains(otherTag, "hidden") {
+			t.Fatalf("inactive panel %q should be hidden, got tag %q", other, otherTag)
+		}
+	}
+}
+
+func TestOrgAdminActivePanelTemplateRendering(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+	base := OrgAdminView{
+		Header: PageHeaderView{
+			Title:    "Organization admin dashboard",
+			BackHref: "/",
+		},
+		Organization: Organization{Name: "Acme Org", Slug: "acme"},
+	}
+
+	for _, panel := range []string{"profile", "roles", "members"} {
+		t.Run(panel, func(t *testing.T) {
+			view := base
+			view.ActivePanel = panel
+			var out bytes.Buffer
+			if err := tmpl.ExecuteTemplate(&out, "org_admin_body", view); err != nil {
+				t.Fatalf("render org admin template: %v", err)
+			}
+			assertOrgAdminActivePanel(t, out.String(), panel)
+		})
+	}
+}

--- a/server/cmd/server/org_admin_template_role_style_test.go
+++ b/server/cmd/server/org_admin_template_role_style_test.go
@@ -12,7 +12,7 @@ func TestOrgAdminTemplateRolePillRendersCSSVariables(t *testing.T) {
 	view := OrgAdminView{
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Manage organization settings, roles, and members.",
+			Description: "Manage organization settings, roles, and members",
 			BackHref:    "/",
 		},
 		Roles: []Role{
@@ -94,7 +94,7 @@ func TestOrgAdminTemplateLastInviteCopyButton(t *testing.T) {
 	view := OrgAdminView{
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Manage organization settings, roles, and members.",
+			Description: "Manage organization settings, roles, and members",
 			BackHref:    "/",
 		},
 		InviteLink: "/invite/token-pending",

--- a/server/cmd/server/org_admin_template_role_style_test.go
+++ b/server/cmd/server/org_admin_template_role_style_test.go
@@ -12,7 +12,7 @@ func TestOrgAdminTemplateRolePillRendersCSSVariables(t *testing.T) {
 	view := OrgAdminView{
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Switch between organization settings, roles, and members.",
+			Description: "Manage organization settings, roles, and members.",
 			BackHref:    "/",
 		},
 		Roles: []Role{
@@ -94,7 +94,7 @@ func TestOrgAdminTemplateLastInviteCopyButton(t *testing.T) {
 	view := OrgAdminView{
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Switch between organization settings, roles, and members.",
+			Description: "Manage organization settings, roles, and members.",
 			BackHref:    "/",
 		},
 		InviteLink: "/invite/token-pending",

--- a/server/cmd/server/org_admin_template_role_style_test.go
+++ b/server/cmd/server/org_admin_template_role_style_test.go
@@ -12,7 +12,7 @@ func TestOrgAdminTemplateRolePillRendersCSSVariables(t *testing.T) {
 	view := OrgAdminView{
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Create and manage roles and users",
+			Description: "Switch between organization settings, roles, and members.",
 			BackHref:    "/",
 		},
 		Roles: []Role{
@@ -94,7 +94,7 @@ func TestOrgAdminTemplateLastInviteCopyButton(t *testing.T) {
 	view := OrgAdminView{
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Create and manage roles and users",
+			Description: "Switch between organization settings, roles, and members.",
 			BackHref:    "/",
 		},
 		InviteLink: "/invite/token-pending",

--- a/server/cmd/server/org_admin_template_role_usage_test.go
+++ b/server/cmd/server/org_admin_template_role_usage_test.go
@@ -12,7 +12,7 @@ func TestOrgAdminTemplateRoleUsageStates(t *testing.T) {
 	view := OrgAdminView{
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Switch between organization settings, roles, and members.",
+			Description: "Manage organization settings, roles, and members.",
 			BackHref:    "/",
 		},
 		RoleRows: []OrgAdminRoleRow{

--- a/server/cmd/server/org_admin_template_role_usage_test.go
+++ b/server/cmd/server/org_admin_template_role_usage_test.go
@@ -12,7 +12,7 @@ func TestOrgAdminTemplateRoleUsageStates(t *testing.T) {
 	view := OrgAdminView{
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Create and manage roles and users",
+			Description: "Switch between organization settings, roles, and members.",
 			BackHref:    "/",
 		},
 		RoleRows: []OrgAdminRoleRow{

--- a/server/cmd/server/org_admin_template_role_usage_test.go
+++ b/server/cmd/server/org_admin_template_role_usage_test.go
@@ -12,7 +12,7 @@ func TestOrgAdminTemplateRoleUsageStates(t *testing.T) {
 	view := OrgAdminView{
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Manage organization settings, roles, and members.",
+			Description: "Manage organization settings, roles, and members",
 			BackHref:    "/",
 		},
 		RoleRows: []OrgAdminRoleRow{

--- a/server/cmd/server/org_admin_template_sidebar_test.go
+++ b/server/cmd/server/org_admin_template_sidebar_test.go
@@ -12,7 +12,7 @@ func TestOrgAdminTemplateRendersSidebarPanels(t *testing.T) {
 	view := OrgAdminView{
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Create and manage roles and users",
+			Description: "Switch between organization settings, roles, and members.",
 			BackHref:    "/",
 		},
 		Organization: Organization{

--- a/server/cmd/server/org_admin_template_sidebar_test.go
+++ b/server/cmd/server/org_admin_template_sidebar_test.go
@@ -12,7 +12,7 @@ func TestOrgAdminTemplateRendersSidebarPanels(t *testing.T) {
 	view := OrgAdminView{
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Manage organization settings, roles, and members.",
+			Description: "Manage organization settings, roles, and members",
 			BackHref:    "/",
 		},
 		Organization: Organization{

--- a/server/cmd/server/org_admin_template_sidebar_test.go
+++ b/server/cmd/server/org_admin_template_sidebar_test.go
@@ -12,7 +12,7 @@ func TestOrgAdminTemplateRendersSidebarPanels(t *testing.T) {
 	view := OrgAdminView{
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Switch between organization settings, roles, and members.",
+			Description: "Manage organization settings, roles, and members.",
 			BackHref:    "/",
 		},
 		Organization: Organization{

--- a/server/cmd/server/page_header_test.go
+++ b/server/cmd/server/page_header_test.go
@@ -45,7 +45,7 @@ func TestPageHeaderTemplateOmitsBackLinkWhenUnset(t *testing.T) {
 	var out bytes.Buffer
 	header := PageHeaderView{
 		Title:       "Choose a stream",
-		Description: "Select a stream to start or continue process tracking.",
+		Description: "Select a stream to start or continue process tracking",
 	}
 	if err := tmpl.ExecuteTemplate(&out, "page_header", header); err != nil {
 		t.Fatalf("render page_header template: %v", err)

--- a/server/cmd/server/panel_markup_test.go
+++ b/server/cmd/server/panel_markup_test.go
@@ -236,6 +236,7 @@ func TestStreamHomeBodyPanelMarkup(t *testing.T) {
 	body := out.String()
 
 	for _, want := range []string{
+		`class="rail-layout rail-layout-ready"`,
 		`class="panel panel-sticky"`,
 		`class="sidebar-nav"`,
 		`class="sidebar-nav-link is-active"`,
@@ -263,14 +264,19 @@ func TestStreamHomeBodyPanelMarkup(t *testing.T) {
 		t.Fatalf("expected sidebar before instances header; panel-heading before panel-actions inside panel-head-actions")
 	}
 
-	mainStart := strings.Index(body, `class="home-workflow-panel-main"`)
+	railIdx := strings.Index(body, `class="rail-layout rail-layout-ready"`)
+	if railIdx == -1 || !(railIdx < sidebarIdx) {
+		t.Fatalf("expected rail-layout wrapping sticky sidebar")
+	}
+
+	mainStart := strings.Index(body, `class="rail-layout-main home-workflow-panel-main"`)
 	mainEnd := strings.Index(body, `class="stream-status-sections"`)
 	if mainStart == -1 || mainEnd == -1 || mainStart >= mainEnd {
-		t.Fatal("expected home-workflow-panel-main wrapping instances header")
+		t.Fatal("expected rail-layout-main wrapping instances header")
 	}
 	mainBlock := body[mainStart:mainEnd]
 	if strings.Contains(mainBlock, `<section class="panel"`) || strings.Contains(mainBlock, `<section class="panel `) {
-		t.Fatalf("home-workflow-panel-main must not wrap instances header in section.panel, got:\n%s", mainBlock)
+		t.Fatalf("rail-layout-main must not wrap instances header in section.panel, got:\n%s", mainBlock)
 	}
 }
 

--- a/server/cmd/server/panel_markup_test.go
+++ b/server/cmd/server/panel_markup_test.go
@@ -87,35 +87,37 @@ func TestProcessTerminationDetailsPanelMarkup(t *testing.T) {
 	tmpl := parseTestTemplates(t)
 
 	var out bytes.Buffer
-	view := StreamInstanceDetailView{
-		Termination: &ProcessTerminationView{
-			Reason:       "Pilot ended early",
-			EndedAtHuman: "5 Mar 2026 at 14:30 UTC",
-			EndedBy:      "appwrite:user-1",
-			SubstepID:    "2.1",
-		},
+	view := StreamTerminationDetailsView{
+		Reason:       "Pilot ended early",
+		EndedAtHuman: "5 Mar 2026 at 14:30 UTC",
+		EndedBy:      "user-1",
+		SubstepID:    "2.1",
 	}
-	if err := tmpl.ExecuteTemplate(&out, "process_termination_details", view); err != nil {
-		t.Fatalf("render process_termination_details: %v", err)
+	if err := tmpl.ExecuteTemplate(&out, "stream_termination_details", view); err != nil {
+		t.Fatalf("render stream_termination_details: %v", err)
 	}
 	body := out.String()
 
 	for _, want := range []string{
-		`class="panel"`,
-		`class="panel-heading"`,
-		"<h2>Stream ended early</h2>",
-		"Ended at",
+		`class="warning warning--rich stream-termination-details"`,
+		`class="stream-termination-details-title"`,
+		"Stream ended early",
+		`d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"`,
+		">Ended at</dt>",
 		"5 Mar 2026 at 14:30 UTC",
-		"while substep 2.1 was available",
+		">Ended by</dt>",
+		"user-1",
+		">Current substep</dt>",
+		"2.1",
 		"Pilot ended early",
 	} {
 		if !strings.Contains(body, want) {
-			t.Fatalf("expected %q in process_termination_details markup, got:\n%s", want, body)
+			t.Fatalf("expected %q in stream_termination_details markup, got:\n%s", want, body)
 		}
 	}
 
-	if strings.Contains(body, `class="panel-head-actions"`) {
-		t.Fatalf("heading-only panel must not use panel-head-actions, got:\n%s", body)
+	if strings.Contains(body, `class="panel"`) || strings.Contains(body, `class="panel-heading"`) {
+		t.Fatalf("termination details must use warning banner, not panel, got:\n%s", body)
 	}
 }
 
@@ -149,27 +151,38 @@ func TestDPPBodyPanelMarkup(t *testing.T) {
 
 	for _, want := range []string{
 		`class="panel"`,
+		`class="dpp-overview"`,
 		`class="panel-head-actions"`,
 		`class="panel-heading"`,
 		"<h2>Demo workflow</h2>",
 		`class="btn btn-primary js-share-link"`,
 		"Share DPP link",
-		"GTIN|09506000134352",
-		"Serial|SN1",
+		"GTIN: 09506000134352",
+		"Serial: SN1",
+		`class="dpp-history"`,
+		"<h2>History</h2>",
+		`class="dpp-integrity"`,
+		"<h2>Integrity</h2>",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("expected %q in dpp_body markup, got:\n%s", want, body)
 		}
 	}
 
+	overviewIdx := strings.Index(body, `class="dpp-overview"`)
 	headIdx := strings.Index(body, `class="panel-head-actions"`)
 	headingIdx := strings.Index(body, `class="panel-heading"`)
 	btnIdx := strings.Index(body, `class="btn btn-primary js-share-link"`)
-	if headIdx == -1 || headingIdx == -1 || btnIdx == -1 {
-		t.Fatal("expected panel-head-actions, panel-heading, and action button")
+	historyIdx := strings.Index(body, `class="dpp-history"`)
+	integrityIdx := strings.Index(body, `class="dpp-integrity"`)
+	if overviewIdx == -1 || headIdx == -1 || headingIdx == -1 || btnIdx == -1 {
+		t.Fatal("expected dpp-overview, panel-head-actions, panel-heading, and action button")
 	}
-	if !(headIdx < headingIdx && headingIdx < btnIdx) {
+	if !(overviewIdx < headIdx && headIdx < headingIdx && headingIdx < btnIdx) {
 		t.Fatalf("expected panel-heading before action button inside panel-head-actions block")
+	}
+	if historyIdx == -1 || integrityIdx == -1 || !(overviewIdx < historyIdx && historyIdx < integrityIdx) {
+		t.Fatalf("expected dpp-overview, then dpp-history, then dpp-integrity section wrappers")
 	}
 }
 

--- a/server/cmd/server/panel_markup_test.go
+++ b/server/cmd/server/panel_markup_test.go
@@ -280,7 +280,7 @@ func TestOrgAdminRolesPanelMarkup(t *testing.T) {
 	view := OrgAdminView{
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Create and manage roles and users",
+			Description: "Switch between organization settings, roles, and members.",
 			BackHref:    "/",
 		},
 		Organization: Organization{

--- a/server/cmd/server/panel_markup_test.go
+++ b/server/cmd/server/panel_markup_test.go
@@ -25,7 +25,7 @@ func TestProcessDownloadsPanelMarkup(t *testing.T) {
 		`class="panel-head-actions"`,
 		`class="panel-heading"`,
 		"<h2>Downloads</h2>",
-		"Export attachments and notarized data for this stream.",
+		"Export attachments and notarized data for this stream",
 		`class="btn btn-secondary js-download-link"`,
 	} {
 		if !strings.Contains(body, want) {
@@ -63,7 +63,7 @@ func TestProcessDPPPanelMarkup(t *testing.T) {
 		`class="panel-head-actions"`,
 		`class="panel-heading"`,
 		"<h2>Digital Product Passport</h2>",
-		"GS1 Digital Link and DPP data for this stream.",
+		"GS1 Digital Link and DPP data for this stream",
 		`class="btn btn-primary"`,
 		"View DPP data",
 	} {
@@ -243,7 +243,7 @@ func TestStreamHomeBodyPanelMarkup(t *testing.T) {
 		`class="panel-head-actions"`,
 		`class="panel-actions"`,
 		"<h2>Stream instances</h2>",
-		"View and manage all instances of this stream.",
+		"View and manage all instances of this stream",
 		"View preview",
 		"New instance",
 	} {
@@ -280,7 +280,7 @@ func TestOrgAdminRolesPanelMarkup(t *testing.T) {
 	view := OrgAdminView{
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Manage organization settings, roles, and members.",
+			Description: "Manage organization settings, roles, and members",
 			BackHref:    "/",
 		},
 		Organization: Organization{

--- a/server/cmd/server/panel_markup_test.go
+++ b/server/cmd/server/panel_markup_test.go
@@ -280,7 +280,7 @@ func TestOrgAdminRolesPanelMarkup(t *testing.T) {
 	view := OrgAdminView{
 		Header: PageHeaderView{
 			Title:       "Organization admin dashboard",
-			Description: "Switch between organization settings, roles, and members.",
+			Description: "Manage organization settings, roles, and members.",
 			BackHref:    "/",
 		},
 		Organization: Organization{

--- a/server/cmd/server/stream_card_test.go
+++ b/server/cmd/server/stream_card_test.go
@@ -13,7 +13,7 @@ func TestStreamCardTemplateRendersCoreFields(t *testing.T) {
 	card := StreamCardView{
 		Key:         "demo",
 		Name:        "Demo Stream",
-		Description: "Track a pilot batch end to end.",
+		Description: "Track a pilot batch end to end",
 		Counts: WorkflowProcessCounts{
 			NotStarted: 2,
 			Started:    1,
@@ -41,7 +41,7 @@ func TestStreamCardTemplateRendersCoreFields(t *testing.T) {
 		`class="btn btn-ghost btn-icon stream-card-menu-trigger"`,
 		`href="/w/demo/"`,
 		"Demo Stream",
-		"Track a pilot batch end to end.",
+		"Track a pilot batch end to end",
 		"<td>2</td>",
 		"<td>1</td>",
 		"<td>3</td>",

--- a/server/cmd/server/stream_instance_detail.go
+++ b/server/cmd/server/stream_instance_detail.go
@@ -38,8 +38,7 @@ func (s *Server) buildStreamInstanceDetailView(ctx context.Context, cfg RuntimeC
 		view.SelectedBody = &action
 	}
 	if process != nil && process.Termination != nil {
-		view.Termination = processTerminationView(process.Termination)
-		view.Termination = s.applyDoneByEmailToTermination(ctx, cfg.Workflow, actor, view.Termination)
+		view.Termination = s.buildStreamTerminationDetailsView(ctx, cfg.Workflow, actor, process.Termination)
 	}
 
 	if processDone {
@@ -99,4 +98,48 @@ func (s *Server) applyDoneByEmailToTermination(ctx context.Context, def Workflow
 		mapped.EndedBy = identity.fallbackID
 	}
 	return &mapped
+}
+
+func terminationEndedByDisplay(endedBy string) string {
+	trimmed := strings.TrimSpace(endedBy)
+	if userID, ok := parseAppwriteActorID(trimmed); ok {
+		return userID
+	}
+	return trimmed
+}
+
+func (s *Server) applyDoneByIdentityFallbackToTermination(ctx context.Context, termination *ProcessTerminationView) *ProcessTerminationView {
+	if termination == nil {
+		return nil
+	}
+	identity, ok := s.lookupUserIdentityByActorID(ctx, termination.EndedBy, map[string]userIdentityView{})
+	if !ok {
+		return termination
+	}
+	mapped := *termination
+	if strings.TrimSpace(identity.fallbackID) != "" {
+		mapped.EndedBy = identity.fallbackID
+	}
+	return &mapped
+}
+
+func (s *Server) buildStreamTerminationDetailsView(ctx context.Context, def WorkflowDef, viewer Actor, termination *ProcessTermination) *StreamTerminationDetailsView {
+	if termination == nil {
+		return nil
+	}
+	view := processTerminationView(termination)
+	if strings.TrimSpace(viewer.OrgSlug) == "" {
+		view = s.applyDoneByIdentityFallbackToTermination(ctx, view)
+	} else {
+		view = s.applyDoneByEmailToTermination(ctx, def, viewer, view)
+	}
+	if view == nil {
+		return nil
+	}
+	return &StreamTerminationDetailsView{
+		EndedAtHuman: view.EndedAtHuman,
+		EndedBy:      terminationEndedByDisplay(view.EndedBy),
+		SubstepID:    view.SubstepID,
+		Reason:       view.Reason,
+	}
 }

--- a/server/cmd/server/stream_instance_detail_test.go
+++ b/server/cmd/server/stream_instance_detail_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"context"
+	"strings"
 	"testing"
+	"time"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
@@ -83,5 +86,35 @@ func TestApplyDoneByEmailHelpersNoopOnEmptyInput(t *testing.T) {
 	}
 	if got := server.applyDoneByEmailToTermination(t.Context(), def, Actor{OrgSlug: "org-a"}, nil); got != nil {
 		t.Fatalf("expected nil passthrough for nil termination, got %#v", got)
+	}
+}
+
+func TestBuildStreamTerminationDetailsViewResolvesIdentityByContext(t *testing.T) {
+	server := &Server{
+		identity: &fakeIdentityStore{
+			getUserByIDFunc: func(ctx context.Context, userID string) (IdentityUser, error) {
+				return IdentityUser{ID: userID, Email: "ended@example.com", Status: "active"}, nil
+			},
+		},
+	}
+	def := WorkflowDef{Steps: []WorkflowStep{{StepID: "1", OrganizationSlug: "org-a"}}}
+	termination := &ProcessTermination{
+		Reason:    "supplier cancelled",
+		EndedAt:   time.Date(2026, 3, 6, 9, 15, 0, 0, time.UTC),
+		Actor:     &Actor{ID: "appwrite:user-1", Role: "dep1"},
+		SubstepID: "1.2",
+	}
+
+	orgView := server.buildStreamTerminationDetailsView(t.Context(), def, Actor{OrgSlug: "org-a"}, termination)
+	if orgView == nil || orgView.EndedBy != "ended@example.com" {
+		t.Fatalf("org viewer endedBy = %#v, want email", orgView)
+	}
+
+	publicView := server.buildStreamTerminationDetailsView(t.Context(), def, Actor{}, termination)
+	if publicView == nil || publicView.EndedBy != "user-1" {
+		t.Fatalf("public viewer endedBy = %#v, want stripped user id", publicView)
+	}
+	if strings.Contains(publicView.EndedBy, "appwrite:") {
+		t.Fatalf("public viewer endedBy must not include appwrite prefix, got %q", publicView.EndedBy)
 	}
 }

--- a/server/cmd/server/stream_termination_details_test.go
+++ b/server/cmd/server/stream_termination_details_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestStreamTerminationDetailsTemplateRendersFields(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+
+	var out bytes.Buffer
+	view := StreamTerminationDetailsView{
+		EndedAtHuman: "5 Mar 2026 at 14:30 UTC",
+		EndedBy:      "operator@example.com",
+		SubstepID:    "2.1",
+		Reason:       "Pilot ended early",
+	}
+	if err := tmpl.ExecuteTemplate(&out, "stream_termination_details", view); err != nil {
+		t.Fatalf("render stream_termination_details template: %v", err)
+	}
+	body := out.String()
+
+	for _, want := range []string{
+		`class="warning warning--rich stream-termination-details"`,
+		`class="stream-termination-details-title"`,
+		"Stream ended early",
+		`d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"`,
+		`class="stream-termination-details-fields"`,
+		">Ended at</dt>",
+		"5 Mar 2026 at 14:30 UTC",
+		">Ended by</dt>",
+		"operator@example.com",
+		">Current substep</dt>",
+		"2.1",
+		">Reason</dt>",
+		"Pilot ended early",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in rendered termination details, got:\n%s", want, body)
+		}
+	}
+
+	if strings.Contains(body, `class="panel"`) {
+		t.Fatalf("termination details must use warning banner, not panel, got:\n%s", body)
+	}
+}
+
+func TestStreamTerminationDetailsTemplateShowsMissingReason(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+
+	var out bytes.Buffer
+	view := StreamTerminationDetailsView{
+		EndedAtHuman: "5 Mar 2026 at 14:30 UTC",
+		EndedBy:      "user-1",
+		SubstepID:    "1.2",
+	}
+	if err := tmpl.ExecuteTemplate(&out, "stream_termination_details", view); err != nil {
+		t.Fatalf("render stream_termination_details template: %v", err)
+	}
+	body := out.String()
+
+	if !strings.Contains(body, `class="muted">No reason provided</dd>`) {
+		t.Fatalf("expected muted missing-reason copy, got:\n%s", body)
+	}
+}
+
+func TestStreamTerminationDetailsTemplateOmitsEmptyOptionalFields(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+
+	var out bytes.Buffer
+	view := StreamTerminationDetailsView{
+		Reason: "Supplier cancelled",
+	}
+	if err := tmpl.ExecuteTemplate(&out, "stream_termination_details", view); err != nil {
+		t.Fatalf("render stream_termination_details template: %v", err)
+	}
+	body := out.String()
+
+	for _, absent := range []string{
+		">Ended at</dt>",
+		">Ended by</dt>",
+		">Current substep</dt>",
+	} {
+		if strings.Contains(body, absent) {
+			t.Fatalf("expected no %q block, got:\n%s", absent, body)
+		}
+	}
+}

--- a/server/cmd/server/stream_timeline_test.go
+++ b/server/cmd/server/stream_timeline_test.go
@@ -133,7 +133,7 @@ func TestStreamTimelineTemplateRendersMissingBodyMessage(t *testing.T) {
 	}
 	body := out.String()
 
-	if !strings.Contains(body, "No data form configured for this substep.") {
+	if !strings.Contains(body, "No data form configured for this substep") {
 		t.Fatalf("expected missing-action fallback copy, got: %s", body)
 	}
 }

--- a/server/cmd/server/substep_shell_test.go
+++ b/server/cmd/server/substep_shell_test.go
@@ -253,7 +253,7 @@ func TestSubstepShellTemplateRendersMissingBodyMessage(t *testing.T) {
 	}
 	body := out.String()
 
-	if !strings.Contains(body, "No data form configured for this substep.") {
+	if !strings.Contains(body, "No data form configured for this substep") {
 		t.Fatalf("expected missing-body fallback copy, got: %s", body)
 	}
 }

--- a/server/cmd/server/substep_views_builder.go
+++ b/server/cmd/server/substep_views_builder.go
@@ -99,7 +99,7 @@ func buildSubstepViews(def WorkflowDef, process *Process, workflowKey string, ac
 			reason = "Stream ended early"
 			detailMessage = terminationReason
 			if detailMessage == "" {
-				detailMessage = "No reason provided."
+				detailMessage = "No reason provided"
 			}
 		} else if status == "skipped" {
 			reason = "Stream ended early"

--- a/server/cmd/server/substep_views_builder_test.go
+++ b/server/cmd/server/substep_views_builder_test.go
@@ -132,7 +132,7 @@ func TestBuildSubstepViewsTerminatedStreamWithoutReason(t *testing.T) {
 
 	actions := buildSubstepViews(cfg.Workflow, process, "workflow", Actor{RoleSlugs: []string{"dep1"}}, false, map[roleMetaKey]RoleMeta{}, nil)
 	action := findSubstepView(t, actions, "1.1")
-	if action.DetailMessage != "No reason provided." {
+	if action.DetailMessage != "No reason provided" {
 		t.Fatalf("detail = %q, want no reason message", action.DetailMessage)
 	}
 }

--- a/server/config/secondary.yaml
+++ b/server/config/secondary.yaml
@@ -159,5 +159,5 @@ dpp:
   serialInputKey: ""
   serialStrategy: process_id_hex
   productName: Gallium shipment audit
-  productDescription: Shipment intake, inspection, and approval with traceable checkpoints.
+  productDescription: Shipment intake, inspection, and approval with traceable checkpoints
   ownerName: Attesta Demo Operator

--- a/server/config/stream.yaml
+++ b/server/config/stream.yaml
@@ -1,6 +1,6 @@
 workflow:
   name: Indium recycling audit
-  description: Shipment intake, inspection, and approval with traceable checkpoints.
+  description: Shipment intake, inspection, and approval with traceable checkpoints
   steps:
     - id: "1"
       title: Collection and dismantling of indium waste
@@ -489,5 +489,5 @@ dpp:
   serialInputKey: ""
   serialStrategy: process_id_hex
   productName: Indium recycling audit
-  productDescription: Shipment intake, inspection, and approval with traceable checkpoints.
+  productDescription: Shipment intake, inspection, and approval with traceable checkpoints
   ownerName: Attesta Demo Operator

--- a/server/config/workflow.yaml
+++ b/server/config/workflow.yaml
@@ -1,6 +1,6 @@
 workflow:
   name: Gallium recycling notarization
-  description: Workflow for intake, refinement, and QA of recycled gallium batches with notarized checkpoints.
+  description: Workflow for intake, refinement, and QA of recycled gallium batches with notarized checkpoints
   steps:
     - id: "1"
       title: Incoming intake
@@ -299,5 +299,5 @@ dpp:
   serialInputKey: ""
   serialStrategy: ""
   productName: Recycled Gallium Batch
-  productDescription: Gallium intake and refinement process with notarized checkpoints.
+  productDescription: Gallium intake and refinement process with notarized checkpoints
   ownerName: Attesta Demo Operator

--- a/server/design/design.go
+++ b/server/design/design.go
@@ -449,11 +449,36 @@ var _ = Service("admin", func() {
 		})
 	})
 
+	Method("orgAdminProfile", func() {
+		Result(Empty)
+		HTTP(func() {
+			GET("/org-admin/profile")
+			Response(StatusOK)
+			Response(StatusUnauthorized)
+			Response(StatusForbidden)
+			Response(StatusServiceUnavailable)
+			Response(StatusInternalServerError)
+		})
+	})
+
+	Method("orgAdminMembers", func() {
+		Result(Empty)
+		HTTP(func() {
+			GET("/org-admin/members")
+			Response(StatusOK)
+			Response(StatusUnauthorized)
+			Response(StatusForbidden)
+			Response(StatusServiceUnavailable)
+			Response(StatusInternalServerError)
+		})
+	})
+
 	Method("orgAdminUsers", func() {
 		Result(Empty)
 		HTTP(func() {
+			// Legacy entry: GET redirects to /org-admin/profile.
 			GET("/org-admin/users")
-			Response(StatusOK)
+			Response(StatusSeeOther)
 			Response(StatusUnauthorized)
 			Response(StatusForbidden)
 			Response(StatusServiceUnavailable)

--- a/server/templates/attachment_carousel.html
+++ b/server/templates/attachment_carousel.html
@@ -40,7 +40,7 @@
               {{ else }}
                 <div class="substep-body-attachment-preview-fallback">
                   <strong>Preview unavailable</strong>
-                  <span>Use download to open {{ $attachment.Filename }}.</span>
+                  <span>Use download to open {{ $attachment.Filename }}</span>
                 </div>
               {{ end }}
             </div>

--- a/server/templates/components/stream_termination_details.html
+++ b/server/templates/components/stream_termination_details.html
@@ -1,0 +1,40 @@
+{{/* Early stream termination warning banner with stacked metadata fields. */}}
+
+{{ define "stream_termination_details" }}
+  {{ if . }}
+    <div class="warning warning--rich stream-termination-details">
+      <h3 class="stream-termination-details-title">
+        {{ template "icon-warning" . }}
+        Stream ended early
+      </h3>
+      <dl class="stream-termination-details-fields">
+        {{ if .EndedAtHuman }}
+          <div class="stream-termination-details-field">
+            <dt class="field-label">Ended at</dt>
+            <dd>{{ .EndedAtHuman }}</dd>
+          </div>
+        {{ end }}
+        {{ if .EndedBy }}
+          <div class="stream-termination-details-field">
+            <dt class="field-label">Ended by</dt>
+            <dd>{{ .EndedBy }}</dd>
+          </div>
+        {{ end }}
+        {{ if .SubstepID }}
+          <div class="stream-termination-details-field">
+            <dt class="field-label">Current substep</dt>
+            <dd>{{ .SubstepID }}</dd>
+          </div>
+        {{ end }}
+        <div class="stream-termination-details-field">
+          <dt class="field-label">Reason</dt>
+          {{ if .Reason }}
+            <dd>{{ .Reason }}</dd>
+          {{ else }}
+            <dd class="muted">No reason provided</dd>
+          {{ end }}
+        </div>
+      </dl>
+    </div>
+  {{ end }}
+{{ end }}

--- a/server/templates/components/substep_body.html
+++ b/server/templates/components/substep_body.html
@@ -135,7 +135,7 @@
           <div>
             <h3 class="dialog-title">Complete as</h3>
             <p class="dialog-subtitle">
-              Choose the role to use for this submission.
+              Choose the role to use for this submission
             </p>
           </div>
           <button

--- a/server/templates/components/substep_shell.html
+++ b/server/templates/components/substep_shell.html
@@ -46,7 +46,7 @@
           {{ template "substep_body" . }}
         {{ else }}
           <p class="muted">
-            No data form configured for this substep.
+            No data form configured for this substep
           </p>
         {{ end }}
       </div>

--- a/server/templates/icons.html
+++ b/server/templates/icons.html
@@ -656,6 +656,26 @@
   </svg>
 {{ end }}
 
+{{ define "icon-warning" }}
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="icon-svg icon-svg-md"
+    aria-hidden="true"
+  >
+    <path
+      d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+    />
+    <path d="M12 9v4" />
+    <path d="M12 17h.01" />
+  </svg>
+{{ end }}
+
 {{ define "icon-loading" }}
   <svg
     xmlns="http://www.w3.org/2000/svg"

--- a/server/templates/icons.html
+++ b/server/templates/icons.html
@@ -467,10 +467,36 @@
   </svg>
 {{ end }}
 
+{{ define "icon-copy" }}
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    data-copy-icon-default
+    class="icon-svg icon-svg-md"
+    aria-hidden="true"
+  >
+    <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+    <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+  </svg>
+{{ end }}
+
 {{ define "icon-copy-done" }}
   <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
     data-copy-icon-done
     class="icon-svg icon-svg-md icon-hidden"
+    aria-hidden="true"
   >
     <path d="m12 15 2 2 4-4" />
     <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />

--- a/server/templates/layout.html
+++ b/server/templates/layout.html
@@ -96,7 +96,7 @@
       <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
       <link
         rel="stylesheet"
-        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@500&family=Space+Grotesk:wght@600;700&display=swap"
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Space+Grotesk:wght@600;700&display=swap"
       />
       <script
         src="https://unpkg.com/htmx.org@1.9.12"

--- a/server/templates/layout.html
+++ b/server/templates/layout.html
@@ -224,31 +224,33 @@
         {{ end }}
       </main>
       <footer class="site-footer">
-        <p>
-          © 2025-2026 Forkbomb bv (forkbomb.eu) — The Forkbomb Company. Licensed
-          under the GNU AGPLv3.
-        </p>
-        <p>
-          CLOSER (Circular raw materiaLs for european Open Strategic autonomy on
-          chips and microElectronics pRoduction, Project No. 101161109) is
-          funded by the European Union under the Interregional Innovation
-          Investments (I3) Instrument of the European Regional Development Fund,
-          managed by the European Innovation Council and SMEs Executive Agency
-          (EISMEA).
-        </p>
-        <p>
-          Even Closer (Project No. 101228240) is funded by the European Union
-          under the Interregional Innovation Investments (I3) Instrument of the
-          European Regional Development Fund, managed by the European Innovation
-          Council and SMEs Executive Agency (EISMEA).
-        </p>
-        <p>
-          This repository/website is part of CLOSER and Even Closer projects and has
-	  received funding from the European Union. Views and opinions expressed are
-          those of the author(s) only and do not necessarily reflect those of
-          the European Union or EISMEA. Neither the European Union nor the
-          granting authority can be held responsible for them.
-        </p>
+        <div class="u-mx-auto u-max-w-7xl muted">
+          <p>
+            © 2025-2026 Forkbomb bv (forkbomb.eu) — The Forkbomb Company. Licensed
+            under the GNU AGPLv3.
+          </p>
+          <p>
+            CLOSER (Circular raw materiaLs for european Open Strategic autonomy on
+            chips and microElectronics pRoduction, Project No. 101161109) is
+            funded by the European Union under the Interregional Innovation
+            Investments (I3) Instrument of the European Regional Development Fund,
+            managed by the European Innovation Council and SMEs Executive Agency
+            (EISMEA).
+          </p>
+          <p>
+            Even Closer (Project No. 101228240) is funded by the European Union
+            under the Interregional Innovation Investments (I3) Instrument of the
+            European Regional Development Fund, managed by the European Innovation
+            Council and SMEs Executive Agency (EISMEA).
+          </p>
+          <p>
+            This repository/website is part of CLOSER and Even Closer projects and has
+            received funding from the European Union. Views and opinions expressed are
+            those of the author(s) only and do not necessarily reflect those of
+            the European Union or EISMEA. Neither the European Union nor the
+            granting authority can be held responsible for them.
+          </p>
+        </div>
       </footer>
     </body>
   </html>

--- a/server/templates/layout.html
+++ b/server/templates/layout.html
@@ -179,7 +179,7 @@
                       </a>
                     {{ end }}
                     {{ if .ShowMyOrgLink }}
-                      <a href="/org-admin/users" class="account-menu-item">
+                      <a href="/org-admin/profile" class="account-menu-item">
                         {{ template "icon-users-group" . }}
                         My Org
                       </a>

--- a/server/templates/pages/dpp.html
+++ b/server/templates/pages/dpp.html
@@ -1,73 +1,52 @@
 {{/* Used on /01/09506000134352/10/defaultProduct/21/.StreamID to render Digital Product Passport */}}
 
 {{ define "dpp_body" }}
-  <div class="stack u-max-w-7xl u-mx-auto">
+  <div class="stack dpp-page u-mx-auto">
     {{ template "page_header" .Header }}
     <section class="panel">
-      <div class="panel-head-actions">
-        <div class="panel-heading">
-          <h2>{{ .Workflow.Name }}</h2>
-          {{ if .Workflow.Description }}
-            <p>{{ .Workflow.Description }}</p>
-          {{ end }}
+      <div class="dpp-overview">
+        <div class="panel-head-actions">
+          <div class="panel-heading">
+            <h2>{{ .Workflow.Name }}</h2>
+            {{ if .Workflow.Description }}
+              <p>{{ .Workflow.Description }}</p>
+            {{ end }}
+          </div>
+          <button
+            type="button"
+            class="btn btn-primary js-share-link"
+            data-share-url="{{ .DigitalLink }}"
+            data-share-label="DPP link"
+          >
+            {{ template "icon-share" . }}
+            Share DPP link
+          </button>
         </div>
-        <button
-          type="button"
-          class="btn btn-primary js-share-link"
-          data-share-url="{{ .DigitalLink }}"
-          data-share-label="DPP link"
-        >
-          {{ template "icon-share" . }}
-          Share DPP link
-        </button>
-      </div>
-      <div class="role-pill-row u-mb-4">
-        <span class="pill pill-accent">GTIN|{{ .GTIN }}</span>
-        <span class="pill pill-accent">Lot|{{ .Lot }}</span>
-        <span class="pill pill-accent">Serial|{{ .Serial }}</span>
-      </div>
-      {{ if .Termination }}
-        <hr class="u-divider" />
-        <div class="panel-block">
-          <h2 class="u-text-danger">Stream ended early</h2>
-          <p class="dpp-termination-meta">
-            {{ if .Termination.EndedAtHuman }}
-              Ended at
-              {{ .Termination.EndedAtHuman }}
-            {{ end }}
-            {{ if .Termination.EndedBy }}
-              by
-              {{ if and (ge (len .Termination.EndedBy) 9) (eq (slice .Termination.EndedBy 0 9) "appwrite:") }}
-                {{ slice .Termination.EndedBy 9 }}
-              {{ else }}
-                {{ .Termination.EndedBy }}
-              {{ end }}
-            {{ end }}
-            {{ if .Termination.SubstepID }}
-              while substep {{ .Termination.SubstepID }} was available
-            {{ end }}
-          </p>
-          {{ if .Termination.Reason }}
-            <dl class="substep-body-submitted-values">
-              <dt>Reason</dt>
-              <dd>{{ .Termination.Reason }}</dd>
-            </dl>
-          {{ else }}
-            <span class="muted">No reason provided</span>
-          {{ end }}
+        <div class="dpp-ids">
+          <span class="dpp-id">GTIN: {{ .GTIN }}</span>
+          <span class="dpp-id">Lot: {{ .Lot }}</span>
+          <span class="dpp-id">Serial: {{ .Serial }}</span>
         </div>
-      {{ end }}
-      <hr class="u-divider" />
-      <h2>History</h2>
-      <div class="dpp-history-list">
-        {{ range .Traceability }}
-          {{ template "dpp_history_step" (streamTimelineStep . true) }}
-        {{ end }}
       </div>
 
-      <hr class="u-divider" />
+      <hr class="u-divider-10" />
+      <div class="dpp-history">
+        <div class="panel-heading">
+          <h2>History</h2>
+        </div>
+        {{ template "stream_termination_details" .Termination }}
+        <div class="dpp-history-list">
+          {{ range .Traceability }}
+            {{ template "dpp_history_step" (streamTimelineStep . true) }}
+          {{ end }}
+        </div>
+      </div>
+
+      <hr class="u-divider-10" />
       <div class="dpp-integrity">
-        <h2>Integrity</h2>
+        <div class="panel-heading">
+          <h2>Integrity</h2>
+        </div>
         <div class="dpp-integrity-root">
           <strong>Merkle root:</strong>
           <code class="dpp-integrity-hash dpp-integrity-hash-full"

--- a/server/templates/pages/dpp.html
+++ b/server/templates/pages/dpp.html
@@ -53,7 +53,7 @@
               <dd>{{ .Termination.Reason }}</dd>
             </dl>
           {{ else }}
-            <span class="muted">No reason provided.</span>
+            <span class="muted">No reason provided</span>
           {{ end }}
         </div>
       {{ end }}

--- a/server/templates/pages/home.html
+++ b/server/templates/pages/home.html
@@ -17,7 +17,7 @@
         {{ end }}
       </div>
     {{ else }}
-      <p class="muted">No streams configured.</p>
+      <p class="muted">No streams configured</p>
     {{ end }}
   </section>
 {{ end }}

--- a/server/templates/pages/login.html
+++ b/server/templates/pages/login.html
@@ -5,7 +5,7 @@
     <section class="panel login">
       <div class="panel-heading">
         <h1>Login</h1>
-        <p>Use your account credentials to continue.</p>
+        <p>Use your account credentials to continue</p>
       </div>
       <form method="post" action="/login" class="input-form">
         <input type="hidden" name="next" value="{{ .Next }}" />

--- a/server/templates/pages/org_admin.html
+++ b/server/templates/pages/org_admin.html
@@ -14,18 +14,13 @@
           panel-sticky
         {{ end }}"
       >
-        <div class="panel-heading">
-          <h2>Organization profile</h2>
-          {{ if .NeedsOrganizationSetup }}
+        {{ if .NeedsOrganizationSetup }}
+          <div class="panel-heading">
             <p>
               Your org admin invite is not assigned to an organization yet.
               Create one now to continue.
             </p>
-          {{ else }}
-            <p>Switch between organization settings, roles, and members.</p>
-          {{ end }}
-        </div>
-        {{ if .NeedsOrganizationSetup }}
+          </div>
           <form
             method="post"
             action="/org-admin/users"
@@ -52,30 +47,6 @@
             <button class="btn btn-primary" type="submit">Create organization</button>
           </form>
         {{ else }}
-          <div class="org-profile-summary">
-            {{ if .OrganizationLogoURL }}
-              <img
-                src="{{ .OrganizationLogoURL }}"
-                alt="{{ .Organization.Name }} logo"
-                class="org-profile-logo"
-              />
-            {{ else }}
-              <span class="org-profile-logo-placeholder">
-                {{ template "icon-no-org" . }}
-              </span>
-            {{ end }}
-            <div class="org-profile-meta">
-              <p class="org-profile-name">
-                <strong>{{ .Organization.Name }}</strong>
-              </p>
-              <p class="muted org-profile-slug">
-                Slug:
-                {{ .Organization.Slug }}
-              </p>
-            </div>
-          </div>
-        {{ end }}
-        {{ if not .NeedsOrganizationSetup }}
           <nav
             class="sidebar-nav"
             aria-label="Organization admin sections"

--- a/server/templates/pages/org_admin.html
+++ b/server/templates/pages/org_admin.html
@@ -5,8 +5,8 @@
   <div class="stack u-max-w-7xl u-mx-auto">
     {{ template "page_header" .Header }}
     <div
-      class="org-admin-grid{{ if not .NeedsOrganizationSetup }}
-        org-admin-grid-ready
+      class="rail-layout{{ if not .NeedsOrganizationSetup }}
+        rail-layout-ready
       {{ end }}"
     >
       <section
@@ -95,7 +95,7 @@
 
       {{ if not .NeedsOrganizationSetup }}
         <section
-          class="panel org-admin-panel-main"
+          class="panel rail-layout-main org-admin-panel-main"
           data-org-admin-shell
           data-org-admin-default-panel="{{ .ActivePanel }}"
         >

--- a/server/templates/pages/org_admin.html
+++ b/server/templates/pages/org_admin.html
@@ -863,7 +863,7 @@
 <script>
   (function () {
     const orgAdminShell = document.querySelector("[data-org-admin-shell]");
-    const orgAdminMobilePanelMedia = window.matchMedia("(max-width: 1279px)");
+    const orgAdminMobilePanelMedia = window.matchMedia("(max-width: 767px)");
     const orgAdminStorageKey = "attesta_org_admin_panel";
     const orgAdminPanels = new Set(["profile", "roles", "members"]);
     let activeOrgAdminPanel = "profile";

--- a/server/templates/pages/org_admin.html
+++ b/server/templates/pages/org_admin.html
@@ -1,4 +1,4 @@
-{{/* Used on /org-admin/users to render organization administration page */}}
+{{/* Used on /org-admin/profile, /org-admin/roles, and /org-admin/members */}}
 
 {{ define "org_admin_body" }}
 
@@ -51,11 +51,12 @@
             class="sidebar-nav"
             aria-label="Organization admin sections"
           >
-            <button
-              type="button"
-              class="sidebar-nav-link"
+            <a
+              href="/org-admin/profile"
+              class="sidebar-nav-link{{ if eq .ActivePanel "profile" }} is-active{{ end }}"
               data-org-admin-nav="profile"
               aria-controls="org-admin-panel-profile"
+              {{ if eq .ActivePanel "profile" }}aria-current="page"{{ end }}
             >
               <span class="sidebar-nav-title"
                 >Organization profile</span
@@ -63,29 +64,31 @@
               <span class="sidebar-nav-copy"
                 >Update your organization name and logo</span
               >
-            </button>
-            <button
-              type="button"
-              class="sidebar-nav-link"
+            </a>
+            <a
+              href="/org-admin/roles"
+              class="sidebar-nav-link{{ if eq .ActivePanel "roles" }} is-active{{ end }}"
               data-org-admin-nav="roles"
               aria-controls="org-admin-panel-roles"
+              {{ if eq .ActivePanel "roles" }}aria-current="page"{{ end }}
             >
               <span class="sidebar-nav-title">Roles</span>
               <span class="sidebar-nav-copy"
                 >Manage the role catalog for your organization</span
               >
-            </button>
-            <button
-              type="button"
-              class="sidebar-nav-link"
+            </a>
+            <a
+              href="/org-admin/members"
+              class="sidebar-nav-link{{ if eq .ActivePanel "members" }} is-active{{ end }}"
               data-org-admin-nav="members"
               aria-controls="org-admin-panel-members"
+              {{ if eq .ActivePanel "members" }}aria-current="page"{{ end }}
             >
               <span class="sidebar-nav-title">Members</span>
               <span class="sidebar-nav-copy"
                 >Invite people and update member access</span
               >
-            </button>
+            </a>
           </nav>
         {{ end }}
       </section>
@@ -94,18 +97,13 @@
         <section
           class="panel org-admin-panel-main"
           data-org-admin-shell
-          data-org-admin-default-panel="{{ if .RoleError }}
-            roles
-          {{ else if or .UsersError .InviteError .InviteLink }}
-            members
-          {{ else }}
-            profile
-          {{ end }}"
+          data-org-admin-default-panel="{{ .ActivePanel }}"
         >
           <section
             class="org-admin-panel-section"
             id="org-admin-panel-profile"
             data-org-admin-panel="profile"
+            {{ if ne .ActivePanel "profile" }}hidden{{ end }}
           >
             <div class="panel-heading">
               <h2>Organization profile</h2>
@@ -173,6 +171,7 @@
             class="org-admin-panel-section"
             id="org-admin-panel-roles"
             data-org-admin-panel="roles"
+            {{ if ne .ActivePanel "roles" }}hidden{{ end }}
           >
             <div class="panel-head-actions">
               <div class="panel-heading">
@@ -444,6 +443,7 @@
             class="org-admin-panel-section"
             id="org-admin-panel-members"
             data-org-admin-panel="members"
+            {{ if ne .ActivePanel "members" }}hidden{{ end }}
           >
             <div class="panel-head-actions">
               <div class="panel-heading">
@@ -864,10 +864,26 @@
   (function () {
     const orgAdminShell = document.querySelector("[data-org-admin-shell]");
     const orgAdminMobilePanelMedia = window.matchMedia("(max-width: 767px)");
-    const orgAdminStorageKey = "attesta_org_admin_panel";
     const orgAdminPanels = new Set(["profile", "roles", "members"]);
+    const orgAdminPanelPaths = {
+      profile: "/org-admin/profile",
+      roles: "/org-admin/roles",
+      members: "/org-admin/members",
+    };
+    const orgAdminPanelFromPath = (path) => {
+      switch (path) {
+        case "/org-admin/profile":
+          return "profile";
+        case "/org-admin/roles":
+          return "roles";
+        case "/org-admin/members":
+          return "members";
+        default:
+          return null;
+      }
+    };
     let activeOrgAdminPanel = "profile";
-    const setOrgAdminPanel = (panelName, persist = true) => {
+    const setOrgAdminPanel = (panelName) => {
       if (!orgAdminShell || !orgAdminPanels.has(panelName)) {
         return;
       }
@@ -877,21 +893,18 @@
         const currentName = panel.getAttribute("data-org-admin-panel");
         panel.hidden = currentName !== panelName;
       });
-      const navButtons = Array.from(document.querySelectorAll("[data-org-admin-nav]"));
-      navButtons.forEach((button) => {
-        const currentName = button.getAttribute("data-org-admin-nav");
+      const navLinks = Array.from(document.querySelectorAll("[data-org-admin-nav]"));
+      navLinks.forEach((link) => {
+        const currentName = link.getAttribute("data-org-admin-nav");
         const isActive = currentName === panelName;
-        button.classList.toggle("is-active", isActive);
-        button.setAttribute("aria-current", isActive ? "page" : "false");
+        link.classList.toggle("is-active", isActive);
+        if (isActive) {
+          link.setAttribute("aria-current", "page");
+        } else {
+          link.removeAttribute("aria-current");
+        }
       });
       orgAdminShell.setAttribute("data-org-admin-ready", "true");
-      if (!persist) {
-        return;
-      }
-      try {
-        window.sessionStorage.setItem(orgAdminStorageKey, panelName);
-      } catch (error) {
-      }
     };
     const focusOrgAdminPanel = () => {
       if (!orgAdminShell || !orgAdminMobilePanelMedia.matches) {
@@ -908,15 +921,9 @@
 
     if (orgAdminShell) {
       const preferredPanel = (() => {
-        try {
-          const storedPanel = window.sessionStorage.getItem(orgAdminStorageKey);
-          if (storedPanel && orgAdminPanels.has(storedPanel)) {
-            return storedPanel;
-          }
-        } catch (error) {
-        }
-        if (window.location.pathname === "/org-admin/roles") {
-          return "roles";
+        const pathPanel = orgAdminPanelFromPath(window.location.pathname);
+        if (pathPanel && orgAdminPanels.has(pathPanel)) {
+          return pathPanel;
         }
         const defaultPanel = (orgAdminShell.getAttribute("data-org-admin-default-panel") || "").trim();
         if (orgAdminPanels.has(defaultPanel)) {
@@ -924,22 +931,37 @@
         }
         return "profile";
       })();
-      Array.from(document.querySelectorAll("[data-org-admin-nav]")).forEach((button) => {
-        button.addEventListener("click", () => {
-          const panelName = (button.getAttribute("data-org-admin-nav") || "").trim();
+      Array.from(document.querySelectorAll("[data-org-admin-nav]")).forEach((link) => {
+        link.addEventListener("click", (event) => {
+          event.preventDefault();
+          const panelName = (link.getAttribute("data-org-admin-nav") || "").trim();
+          if (!orgAdminPanels.has(panelName)) {
+            return;
+          }
           setOrgAdminPanel(panelName);
+          const path = orgAdminPanelPaths[panelName];
+          if (window.location.pathname === path) {
+            window.history.replaceState({ orgAdminPanel: panelName }, "", path);
+          } else {
+            window.history.pushState({ orgAdminPanel: panelName }, "", path);
+          }
           focusOrgAdminPanel();
         });
       });
-      Array.from(document.querySelectorAll("[data-org-admin-shell] form")).forEach((form) => {
-        form.addEventListener("submit", () => {
-          try {
-            window.sessionStorage.setItem(orgAdminStorageKey, activeOrgAdminPanel);
-          } catch (error) {
-          }
-        });
+      window.addEventListener("popstate", (event) => {
+        const statePanel = event.state && event.state.orgAdminPanel;
+        const panelName =
+          (statePanel && orgAdminPanels.has(statePanel) && statePanel) ||
+          orgAdminPanelFromPath(window.location.pathname) ||
+          preferredPanel;
+        setOrgAdminPanel(panelName);
+        focusOrgAdminPanel();
       });
-      setOrgAdminPanel(preferredPanel, false);
+      setOrgAdminPanel(preferredPanel);
+      const preferredPath = orgAdminPanelPaths[preferredPanel];
+      if (preferredPath) {
+        window.history.replaceState({ orgAdminPanel: preferredPanel }, "", preferredPath);
+      }
     }
 
     const rolePalettePickers = Array.from(document.querySelectorAll("[data-role-palette-picker]"));

--- a/server/templates/pages/org_admin.html
+++ b/server/templates/pages/org_admin.html
@@ -61,7 +61,7 @@
                 >Organization profile</span
               >
               <span class="sidebar-nav-copy"
-                >Update your organization name and logo.</span
+                >Update your organization name and logo</span
               >
             </button>
             <button
@@ -72,7 +72,7 @@
             >
               <span class="sidebar-nav-title">Roles</span>
               <span class="sidebar-nav-copy"
-                >Manage the role catalog for your organization.</span
+                >Manage the role catalog for your organization</span
               >
             </button>
             <button
@@ -83,7 +83,7 @@
             >
               <span class="sidebar-nav-title">Members</span>
               <span class="sidebar-nav-copy"
-                >Invite people and update member access.</span
+                >Invite people and update member access</span
               >
             </button>
           </nav>
@@ -109,7 +109,7 @@
           >
             <div class="panel-heading">
               <h2>Organization profile</h2>
-              <p>Review and update your organization details.</p>
+              <p>Review and update your organization details</p>
             </div>
             <div class="org-profile-summary">
               {{ if .OrganizationLogoURL }}
@@ -177,7 +177,7 @@
             <div class="panel-head-actions">
               <div class="panel-heading">
                 <h2>Roles</h2>
-                <p>Available roles for your organization.</p>
+                <p>Available roles for your organization</p>
               </div>
               <button
                 class="btn btn-primary"
@@ -437,7 +437,7 @@
                 {{ end }}
               </ul>
             {{ else }}
-              <p class="muted">No organization roles yet.</p>
+              <p class="muted">No organization roles yet</p>
             {{ end }}
           </section>
           <section
@@ -448,7 +448,7 @@
             <div class="panel-head-actions">
               <div class="panel-heading">
                 <h2>Users</h2>
-                <p>Members and invites for your organization.</p>
+                <p>Members and invites for your organization</p>
               </div>
               <button
                 class="btn btn-primary"
@@ -600,7 +600,7 @@
                                   data-role-picker-empty
                                   hidden
                                 >
-                                  No roles match your search.
+                                  No roles match your search
                                 </p>
                               </div>
                               <div data-role-picker-hidden-inputs></div>
@@ -672,7 +672,7 @@
                 {{ end }}
               </ul>
             {{ else }}
-              <p class="muted">No organization users yet.</p>
+              <p class="muted">No organization users yet</p>
             {{ end }}
           </section>
 
@@ -685,7 +685,7 @@
                 <div>
                   <h3 class="dialog-title">Add Role</h3>
                   <p class="dialog-subtitle">
-                    Create a new role for your organization.
+                    Create a new role for your organization
                   </p>
                 </div>
                 <button
@@ -775,7 +775,7 @@
                 <div>
                   <h3 class="dialog-title">Add User</h3>
                   <p class="dialog-subtitle">
-                    Invite a new user to your organization.
+                    Invite a new user to your organization
                   </p>
                 </div>
                 <button
@@ -840,7 +840,7 @@
                         data-role-picker-empty
                         hidden
                       >
-                        No roles match your search.
+                        No roles match your search
                       </p>
                     </div>
                     <div data-role-picker-hidden-inputs></div>

--- a/server/templates/pages/platform_admin.html
+++ b/server/templates/pages/platform_admin.html
@@ -346,7 +346,7 @@
                   {{ end }}
                   <div class="dialog-actions">
                     <button class="btn btn-primary" type="submit">
-                      Save organization
+                      Update organization data
                     </button>
                   </div>
                 </form>

--- a/server/templates/pages/platform_admin.html
+++ b/server/templates/pages/platform_admin.html
@@ -60,7 +60,7 @@
         <div>
           <h3 class="dialog-title">New organization</h3>
           <p class="dialog-subtitle">
-            Add a new organization to the platform.
+            Add a new organization to the platform
           </p>
         </div>
         <button
@@ -261,7 +261,7 @@
                       </ul>
                     {{ else }}
                       <p class="muted platform-admin-empty-note">
-                        No accepted org admins yet.
+                        No accepted org admins yet
                       </p>
                     {{ end }}
                   </div>
@@ -277,7 +277,7 @@
                       </ul>
                     {{ else }}
                       <p class="muted platform-admin-empty-note">
-                        No pending org admin invites.
+                        No pending org admin invites
                       </p>
                     {{ end }}
                   </div>
@@ -398,7 +398,7 @@
         {{ end }}
       </ul>
     {{ else }}
-      <p class="muted">No organizations match your search.</p>
+      <p class="muted">No organizations match your search</p>
     {{ end }}
 
     {{ if gt .TotalPages 1 }}

--- a/server/templates/pages/process.html
+++ b/server/templates/pages/process.html
@@ -21,7 +21,7 @@
     {{ if .Detail.ProcessDone }}
       <div class="process-resources-grid">
         {{ template "stream_timeline" .Detail.StreamTimeline }}
-        <div class="stack layout-stack-separator u-gap-4">
+        <div class="stack layout-stack-separator u-gap-12">
           {{ template "process_termination_details" .Detail }}
           {{ template "process_dpp" . }}
           {{ template "process_downloads" . }}

--- a/server/templates/pages/process.html
+++ b/server/templates/pages/process.html
@@ -143,7 +143,7 @@
 
 {{ define "process_dpp" }}
   {{ if .DPPURL }}
-    <section class="panel dpp-downloads-section">
+    <section class="panel" id="process-dpp">
       <div class="panel-head-actions">
         <div class="panel-heading">
           <h2>Digital Product Passport</h2>
@@ -159,19 +159,49 @@
         </button>
       </div>
       <div class="stack u-gap-2">
-        <div>
-          <strong>GS1 Digital Link:</strong>
-          <a href="{{ .DPPURL }}"><code>{{ .DPPURL }}</code></a>
+        <div class="process-gs1-code-block">
+          <span class="process-gs1-code-label">GS1 Digital Link</span>
+          <div class="process-gs1-code-row">
+            <a
+              href="{{ .DPPURL }}"
+              class="process-gs1-code"
+              target="_blank"
+              rel="noopener noreferrer"
+              >{{ .DPPURL }}</a
+            >
+            <button
+              type="button"
+              class="btn btn-ghost btn-icon btn-xs js-copy-text"
+              data-copy-text="{{ .DPPURL }}"
+              data-copy-label="GS1 Digital Link"
+              aria-label="Copy GS1 Digital Link"
+            >
+              {{ template "icon-copy" . }}
+              {{ template "icon-copy-done" . }}
+            </button>
+          </div>
         </div>
         {{ if .DPPGS1 }}
-          <div>
-            <strong>GS1 (01/10/21):</strong>
-            <code>{{ .DPPGS1 }}</code>
+          <div class="process-gs1-code-block">
+            <span class="process-gs1-code-label">GS1 (01/10/21)</span>
+            <div class="process-gs1-code-row">
+              <span class="process-gs1-code">{{ .DPPGS1 }}</span>
+              <button
+                type="button"
+                class="btn btn-ghost btn-icon btn-xs js-copy-text"
+                data-copy-text="{{ .DPPGS1 }}"
+                data-copy-label="GS1 code"
+                aria-label="Copy GS1 (01/10/21) code"
+              >
+                {{ template "icon-copy" . }}
+                {{ template "icon-copy-done" . }}
+              </button>
+            </div>
           </div>
         {{ end }}
-
       </div>
     </section>
+    <hr class="u-divider-flush" />
   {{ end }}
 {{ end }}
 

--- a/server/templates/pages/process.html
+++ b/server/templates/pages/process.html
@@ -1,261 +1,213 @@
-{{/* Used on /w/.WorkflowKey/process/.ProcessID to render process details page */}}
-
-{{ define "process_body" }}
-  <div
-    id="process-page"
-    class="process-page stack u-max-w-7xl u-mx-auto"
-    data-process-id="{{ .ProcessID }}"
-    data-workflow-key="{{ .WorkflowKey }}"
-    data-selected-substep="{{ .Detail.SelectedSubstepID }}"
-  >
-    <div id="process-page-content">
-      {{ template "process_content.html" . }}
-    </div>
-  </div>
-{{ end }}
-
-{{ define "process_content.html" }}
-  {{ template "error_banner.html" .Detail }}
-  <div class="stack">
-    {{ template "page_header" .Header }}
-    {{ if .Detail.ProcessDone }}
-      <div class="process-resources-grid">
-        {{ template "stream_timeline" .Detail.StreamTimeline }}
-        <div class="stack layout-stack-separator u-gap-12">
-          {{ template "process_termination_details" .Detail }}
-          {{ template "process_dpp" . }}
-          {{ template "process_downloads" . }}
+{{/* Used on /w/.WorkflowKey/process/.ProcessID to render process details page
+*/}} {{ define "process_body" }}
+<div
+  id="process-page"
+  class="process-page stack u-max-w-7xl u-mx-auto"
+  data-process-id="{{ .ProcessID }}"
+  data-workflow-key="{{ .WorkflowKey }}"
+  data-selected-substep="{{ .Detail.SelectedSubstepID }}"
+>
+  <div id="process-page-content">{{ template "process_content.html" . }}</div>
+</div>
+{{ end }} {{ define "process_content.html" }} {{ template "error_banner.html"
+.Detail }}
+<div class="stack">
+  {{ template "page_header" .Header }} {{ if .Detail.ProcessDone }}
+  <div class="process-resources-grid">
+    <div class="process-steps-column stack u-gap-4">
+      {{ if .Detail.Termination }}
+        <div class="process-termination-mobile">
+          {{ template "stream_termination_details" .Detail.Termination }}
         </div>
-      </div>
-    {{ else }}
+      {{ end }}
       {{ template "stream_timeline" .Detail.StreamTimeline }}
-      {{ if .Detail.CanTerminate }}
-        <div class="dialog-actions">
-          <button
-            type="button"
-            class="btn btn-danger"
-            onclick="document.getElementById('terminate-process-dialog').showModal()"
-          >
-            {{ template "icon-stop" . }} End stream
-          </button>
+    </div>
+    <div class="stack layout-stack-separator u-gap-12">
+      {{ if .Detail.Termination }}
+        <div class="process-termination-desktop">
+          {{ template "stream_termination_details" .Detail.Termination }}
         </div>
-        <dialog id="terminate-process-dialog" class="dialog">
-          <div class="dialog-card">
-            <header class="dialog-head">
-              <div>
-                <h3 class="dialog-title u-text-danger">
-                  Danger zone - End stream early
-                </h3>
-                <p class="dialog-subtitle">
-                  Available substep
-                  {{ .Detail.TerminateSubstep }}
-                </p>
-              </div>
-              <button
-                type="button"
-                class="btn btn-ghost btn-icon dialog-close"
-                onclick="document.getElementById('terminate-process-dialog').close()"
-              >
-                {{ template "icon-close" . }}
-              </button>
-            </header>
-            <form
-              method="post"
-              action="{{ .Detail.TerminateAction }}"
-              class="input-form"
-            >
-              {{ if .Detail.TerminateRoles }}
-                {{ if eq (len .Detail.TerminateRoles) 1 }}
-                  <input
-                    type="hidden"
-                    name="activeRole"
-                    value="{{ (index .Detail.TerminateRoles 0).Slug }}"
-                  />
-                {{ else }}
-                  <label>
-                    <span>End stream as</span>
-                    <select name="activeRole" required>
-                      <option value="">Select role</option>
-                      {{ range .Detail.TerminateRoles }}
-                        <option value="{{ .Slug }}">{{ .Label }}</option>
-                      {{ end }}
-                    </select>
-                  </label>
-                {{ end }}
-              {{ end }}
-              <label>
-                <span
-                  >This will permanently end this stream instance. Confirm only
-                  if you want to continue. Optionally you can enter a
-                  reason:</span
-                >
-                <textarea name="reason" rows="5" maxlength="1000"></textarea>
-              </label>
-              <div class="dialog-actions">
-                <button type="submit" class="btn btn-danger">
-                  {{ template "icon-stop" . }} End stream
-                </button>
-              </div>
-            </form>
-          </div>
-        </dialog>
       {{ end }}
-    {{ end }}
+      {{ template "process_dpp" . }}
+      {{ template "process_downloads" . }}
+    </div>
   </div>
-{{ end }}
-
-{{ define "process_downloads" }}
-  <section class="panel" id="process-downloads">
-    <div class="panel-head-actions">
-      <div class="panel-heading">
-        <h2>Downloads</h2>
-        <p>Export attachments and notarized data for this stream</p>
-      </div>
-      <button
-        type="button"
-        class="btn btn-secondary js-download-link"
-        data-download-url="{{ .WorkflowPath }}/process/{{ .ProcessID }}/files.zip"
-      >
-        {{ template "icon-download" . }}
-        Download all files
-      </button>
-    </div>
-    <div class="stack u-gap-2">
-      <div class="field-block">
-        <span class="field-label">Notarized stream data</span>
-        <div class="field-row">
-          <a
-            href="{{ .WorkflowPath }}/process/{{ .ProcessID }}/notarized.json"
-            target="_blank"
-            rel="noopener noreferrer"
-            >notarized.json</a
-          >
-          <button
-            type="button"
-            class="btn btn-ghost btn-icon btn-xs js-download-link"
-            data-download-url="{{ .WorkflowPath }}/process/{{ .ProcessID }}/notarized.json"
-            aria-label="Download notarized.json"
-          >
-            {{ template "icon-download" . }}
-          </button>
-        </div>
-      </div>
-      {{ if .Attachments }}
-        <div class="field-block">
-          <span class="field-label">Attachments</span>
-          <ul class="process-attachments-list">
-            {{ range .Attachments }}
-              <li>
-                <a href="{{ .URL }}">{{ .Filename }}</a>
-                <span class="muted">({{ .SubstepID }})</span>
-              </li>
-            {{ end }}
-          </ul>
-        </div>
-      {{ end }}
-    </div>
-  </section>
-{{ end }}
-
-{{ define "process_dpp" }}
-  {{ if .DPPURL }}
-    <section class="panel" id="process-dpp">
-      <div class="panel-head-actions">
-        <div class="panel-heading">
-          <h2>Digital Product Passport</h2>
-          <p>GS1 Digital Link and DPP data for this stream</p>
+  {{ else }} {{ template "stream_timeline" .Detail.StreamTimeline }} {{ if
+  .Detail.CanTerminate }}
+  <div class="dialog-actions">
+    <button
+      type="button"
+      class="btn btn-danger"
+      onclick="document.getElementById('terminate-process-dialog').showModal()"
+    >
+      {{ template "icon-stop" . }} End stream
+    </button>
+  </div>
+  <dialog id="terminate-process-dialog" class="dialog">
+    <div class="dialog-card">
+      <header class="dialog-head">
+        <div>
+          <h3 class="dialog-title u-text-danger">
+            Danger zone - End stream early
+          </h3>
+          <p class="dialog-subtitle">
+            Available substep {{ .Detail.TerminateSubstep }}
+          </p>
         </div>
         <button
           type="button"
-          class="btn btn-primary"
-          onclick="window.open('{{ .DPPURL }}', '_blank')"
+          class="btn btn-ghost btn-icon dialog-close"
+          onclick="document.getElementById('terminate-process-dialog').close()"
         >
-          {{ template "icon-external-link" . }}
-          View DPP data
+          {{ template "icon-close" . }}
+        </button>
+      </header>
+      <form
+        method="post"
+        action="{{ .Detail.TerminateAction }}"
+        class="input-form"
+      >
+        {{ if .Detail.TerminateRoles }} {{ if eq (len .Detail.TerminateRoles) 1
+        }}
+        <input
+          type="hidden"
+          name="activeRole"
+          value="{{ (index .Detail.TerminateRoles 0).Slug }}"
+        />
+        {{ else }}
+        <label>
+          <span>End stream as</span>
+          <select name="activeRole" required>
+            <option value="">Select role</option>
+            {{ range .Detail.TerminateRoles }}
+            <option value="{{ .Slug }}">{{ .Label }}</option>
+            {{ end }}
+          </select>
+        </label>
+        {{ end }} {{ end }}
+        <label>
+          <span
+            >This will permanently end this stream instance. Confirm only if you
+            want to continue. Optionally you can enter a reason:</span
+          >
+          <textarea name="reason" rows="5" maxlength="1000"></textarea>
+        </label>
+        <div class="dialog-actions">
+          <button type="submit" class="btn btn-danger">
+            {{ template "icon-stop" . }} End stream
+          </button>
+        </div>
+      </form>
+    </div>
+  </dialog>
+  {{ end }} {{ end }}
+</div>
+{{ end }} {{ define "process_downloads" }}
+<section class="panel" id="process-downloads">
+  <div class="panel-head-actions">
+    <div class="panel-heading">
+      <h2>Downloads</h2>
+      <p>Export attachments and notarized data for this stream</p>
+    </div>
+    <button
+      type="button"
+      class="btn btn-secondary js-download-link"
+      data-download-url="{{ .WorkflowPath }}/process/{{ .ProcessID }}/files.zip"
+    >
+      {{ template "icon-download" . }} Download all files
+    </button>
+  </div>
+  <div class="stack u-gap-2">
+    <div class="field-block">
+      <span class="field-label">Notarized stream data</span>
+      <div class="field-row">
+        <a
+          href="{{ .WorkflowPath }}/process/{{ .ProcessID }}/notarized.json"
+          target="_blank"
+          rel="noopener noreferrer"
+          >notarized.json</a
+        >
+        <button
+          type="button"
+          class="btn btn-ghost btn-icon btn-xs js-download-link"
+          data-download-url="{{ .WorkflowPath }}/process/{{ .ProcessID }}/notarized.json"
+          aria-label="Download notarized.json"
+        >
+          {{ template "icon-download" . }}
         </button>
       </div>
-      <div class="stack u-gap-2">
-        <div class="field-block">
-          <span class="field-label">GS1 Digital Link</span>
-          <div class="field-row">
-            <a
-              href="{{ .DPPURL }}"
-              class="process-gs1-code"
-              target="_blank"
-              rel="noopener noreferrer"
-              >{{ .DPPURL }}</a
-            >
-            <button
-              type="button"
-              class="btn btn-ghost btn-icon btn-xs js-copy-text"
-              data-copy-text="{{ .DPPURL }}"
-              data-copy-label="GS1 Digital Link"
-              aria-label="Copy GS1 Digital Link"
-            >
-              {{ template "icon-copy" . }}
-              {{ template "icon-copy-done" . }}
-            </button>
-          </div>
-        </div>
-        {{ if .DPPGS1 }}
-          <div class="field-block">
-            <span class="field-label">GS1 (01/10/21)</span>
-            <div class="field-row">
-              <span class="process-gs1-code">{{ .DPPGS1 }}</span>
-              <button
-                type="button"
-                class="btn btn-ghost btn-icon btn-xs js-copy-text"
-                data-copy-text="{{ .DPPGS1 }}"
-                data-copy-label="GS1 code"
-                aria-label="Copy GS1 (01/10/21) code"
-              >
-                {{ template "icon-copy" . }}
-                {{ template "icon-copy-done" . }}
-              </button>
-            </div>
-          </div>
+    </div>
+    {{ if .Attachments }}
+    <div class="field-block">
+      <span class="field-label">Attachments</span>
+      <ul class="process-attachments-list">
+        {{ range .Attachments }}
+        <li>
+          <a href="{{ .URL }}">{{ .Filename }}</a>
+          <span class="muted">({{ .SubstepID }})</span>
+        </li>
         {{ end }}
+      </ul>
+    </div>
+    {{ end }}
+  </div>
+</section>
+{{ end }} {{ define "process_dpp" }} {{ if .DPPURL }}
+<section class="panel" id="process-dpp">
+  <div class="panel-head-actions">
+    <div class="panel-heading">
+      <h2>Digital Product Passport</h2>
+      <p>GS1 Digital Link and DPP data for this stream</p>
+    </div>
+    <button
+      type="button"
+      class="btn btn-primary"
+      onclick="window.open('{{ .DPPURL }}', '_blank')"
+    >
+      {{ template "icon-external-link" . }} View DPP data
+    </button>
+  </div>
+  <div class="stack u-gap-2">
+    <div class="field-block">
+      <span class="field-label">GS1 Digital Link</span>
+      <div class="field-row">
+        <a
+          href="{{ .DPPURL }}"
+          class="process-gs1-code"
+          target="_blank"
+          rel="noopener noreferrer"
+          >{{ .DPPURL }}</a
+        >
+        <button
+          type="button"
+          class="btn btn-ghost btn-icon btn-xs js-copy-text"
+          data-copy-text="{{ .DPPURL }}"
+          data-copy-label="GS1 Digital Link"
+          aria-label="Copy GS1 Digital Link"
+        >
+          {{ template "icon-copy" . }} {{ template "icon-copy-done" . }}
+        </button>
       </div>
-    </section>
-    <hr class="u-divider-flush" />
-  {{ end }}
-{{ end }}
-
-{{ define "process_termination_details" }}
-  {{ if .Termination }}
-    <section class="panel">
-      <div class="panel-heading">
-        <h2>Stream ended early</h2>
-        <p>
-          {{ if .Termination.EndedAtHuman }}
-            Ended at
-            {{ .Termination.EndedAtHuman }}
-          {{ end }}
-          {{ if .Termination.EndedBy }}
-            by
-            {{ if and (ge (len .Termination.EndedBy) 9) (eq (slice .Termination.EndedBy 0 9) "appwrite:") }}
-              {{ slice .Termination.EndedBy 9 }}
-            {{ else }}
-              {{ .Termination.EndedBy }}
-            {{ end }}
-          {{ end }}
-          {{ if .Termination.SubstepID }}
-            while substep {{ .Termination.SubstepID }} was available
-          {{ end }}
-        </p>
+    </div>
+    {{ if .DPPGS1 }}
+    <div class="field-block">
+      <span class="field-label">GS1 (01/10/21)</span>
+      <div class="field-row">
+        <span class="process-gs1-code">{{ .DPPGS1 }}</span>
+        <button
+          type="button"
+          class="btn btn-ghost btn-icon btn-xs js-copy-text"
+          data-copy-text="{{ .DPPGS1 }}"
+          data-copy-label="GS1 code"
+          aria-label="Copy GS1 (01/10/21) code"
+        >
+          {{ template "icon-copy" . }} {{ template "icon-copy-done" . }}
+        </button>
       </div>
-      {{ if .Termination.Reason }}
-        <dl class="substep-body-submitted-values">
-          <dt>Reason</dt>
-          <dd>{{ .Termination.Reason }}</dd>
-        </dl>
-      {{ else }}
-        <span class="muted">No reason provided</span>
-      {{ end }}
-    </section>
-  {{ end }}
-{{ end }}
-
-{{ define "process.html" }}
-  {{ template "layout.html" . }}
+    </div>
+    {{ end }}
+  </div>
+</section>
+<hr class="u-divider-flush" />
+{{ end }} {{ end }} {{ define "process.html" }} {{ template "layout.html" . }}
 {{ end }}

--- a/server/templates/pages/process.html
+++ b/server/templates/pages/process.html
@@ -120,24 +120,40 @@
         Download all files
       </button>
     </div>
-    <div>
-      <a href="{{ .WorkflowPath }}/process/{{ .ProcessID }}/notarized.json"
-        >Notarized stream data</a
-      >
-    </div>
-    {{ if .Attachments }}
-      <div class="panel-block panel-block-spaced">
-        <p class="muted u-m-0 u-mb-2">Attachments</p>
-        <ul class="process-attachments-list">
-          {{ range .Attachments }}
-            <li>
-              <a href="{{ .URL }}">{{ .Filename }}</a>
-              <span class="muted">({{ .SubstepID }})</span>
-            </li>
-          {{ end }}
-        </ul>
+    <div class="stack u-gap-2">
+      <div class="field-block">
+        <span class="field-label">Notarized stream data</span>
+        <div class="field-row">
+          <a
+            href="{{ .WorkflowPath }}/process/{{ .ProcessID }}/notarized.json"
+            target="_blank"
+            rel="noopener noreferrer"
+            >notarized.json</a
+          >
+          <button
+            type="button"
+            class="btn btn-ghost btn-icon btn-xs js-download-link"
+            data-download-url="{{ .WorkflowPath }}/process/{{ .ProcessID }}/notarized.json"
+            aria-label="Download notarized.json"
+          >
+            {{ template "icon-download" . }}
+          </button>
+        </div>
       </div>
-    {{ end }}
+      {{ if .Attachments }}
+        <div class="field-block">
+          <span class="field-label">Attachments</span>
+          <ul class="process-attachments-list">
+            {{ range .Attachments }}
+              <li>
+                <a href="{{ .URL }}">{{ .Filename }}</a>
+                <span class="muted">({{ .SubstepID }})</span>
+              </li>
+            {{ end }}
+          </ul>
+        </div>
+      {{ end }}
+    </div>
   </section>
 {{ end }}
 
@@ -159,9 +175,9 @@
         </button>
       </div>
       <div class="stack u-gap-2">
-        <div class="process-gs1-code-block">
-          <span class="process-gs1-code-label">GS1 Digital Link</span>
-          <div class="process-gs1-code-row">
+        <div class="field-block">
+          <span class="field-label">GS1 Digital Link</span>
+          <div class="field-row">
             <a
               href="{{ .DPPURL }}"
               class="process-gs1-code"
@@ -182,9 +198,9 @@
           </div>
         </div>
         {{ if .DPPGS1 }}
-          <div class="process-gs1-code-block">
-            <span class="process-gs1-code-label">GS1 (01/10/21)</span>
-            <div class="process-gs1-code-row">
+          <div class="field-block">
+            <span class="field-label">GS1 (01/10/21)</span>
+            <div class="field-row">
               <span class="process-gs1-code">{{ .DPPGS1 }}</span>
               <button
                 type="button"

--- a/server/templates/pages/process.html
+++ b/server/templates/pages/process.html
@@ -109,7 +109,7 @@
     <div class="panel-head-actions">
       <div class="panel-heading">
         <h2>Downloads</h2>
-        <p>Export attachments and notarized data for this stream.</p>
+        <p>Export attachments and notarized data for this stream</p>
       </div>
       <button
         type="button"
@@ -147,7 +147,7 @@
       <div class="panel-head-actions">
         <div class="panel-heading">
           <h2>Digital Product Passport</h2>
-          <p>GS1 Digital Link and DPP data for this stream.</p>
+          <p>GS1 Digital Link and DPP data for this stream</p>
         </div>
         <button
           type="button"
@@ -204,7 +204,7 @@
           <dd>{{ .Termination.Reason }}</dd>
         </dl>
       {{ else }}
-        <span class="muted">No reason provided.</span>
+        <span class="muted">No reason provided</span>
       {{ end }}
     </section>
   {{ end }}

--- a/server/templates/pages/reset_request.html
+++ b/server/templates/pages/reset_request.html
@@ -5,7 +5,7 @@
     <section class="panel login">
       <div class="panel-heading">
         <h1>Reset Password</h1>
-        <p>Enter your email address to request a password reset.</p>
+        <p>Enter your email address to request a password reset</p>
       </div>
       <form method="post" action="/reset" class="input-form">
         <div class="form-field">

--- a/server/templates/pages/signup.html
+++ b/server/templates/pages/signup.html
@@ -3,7 +3,7 @@
     <section class="panel login">
       <div class="panel-heading">
         <h1>Sign Up</h1>
-        <p>Create an account to continue.</p>
+        <p>Create an account to continue</p>
       </div>
       {{ if .Error }}
         <p class="u-text-danger">{{ .Error }}</p>

--- a/server/templates/pages/stream.html
+++ b/server/templates/pages/stream.html
@@ -3,178 +3,171 @@
 {{ define "home_body" }}
   <div class="stack u-max-w-7xl u-mx-auto">
     {{ template "page_header" .Header }}
-    <div class="home-workflow-grid" data-home-root>
-      <section class="panel panel-sticky">
-        <div class="panel-heading">
-          <h2>Streams</h2>
-          <p>Jump to instances by status</p>
-        </div>
-        <nav class="sidebar-nav" aria-label="Stream status sections">
-          {{ range .ProcessGroups }}
-            {{ if eq .Status "available" }}
-              <button
-                type="button"
-                class="sidebar-nav-link is-active"
-                data-home-nav="{{ .Status }}"
-                aria-controls="{{ .PanelID }}"
-                aria-current="page"
-                aria-label="Available streams"
-                title="Streams waiting for your input"
-              >
-                <span class="sidebar-nav-title"> Available </span>
-              </button>
-            {{ else if eq .Status "active" }}
-              <button
-                type="button"
-                class="sidebar-nav-link"
-                data-home-nav="{{ .Status }}"
-                aria-controls="{{ .PanelID }}"
-                aria-current="false"
-                aria-label="Active streams"
-                title="Streams waiting for someone else input"
-              >
-                <span class="sidebar-nav-title"> Active </span>
-              </button>
-            {{ else if eq .Status "done" }}
-              <button
-                type="button"
-                class="sidebar-nav-link"
-                data-home-nav="{{ .Status }}"
-                aria-controls="{{ .PanelID }}"
-                aria-current="false"
-                aria-label="Completed streams"
-                title="Streams completed successfully"
-              >
-                <span class="sidebar-nav-title"> Done </span>
-              </button>
-            {{ else if eq .Status "terminated" }}
-              <button
-                type="button"
-                class="sidebar-nav-link"
-                data-home-nav="{{ .Status }}"
-                aria-controls="{{ .PanelID }}"
-                aria-current="false"
-                aria-label="Terminated streams"
-                title="Streams terminated before completion"
-              >
-                <span class="sidebar-nav-title"> Terminated </span>
-              </button>
-            {{ end }}
-          {{ end }}
-        </nav>
-      </section>
-
-      <div class="home-workflow-panel-main">
-        <div class="panel-head-actions">
+    {{ if .Error }}
+      <div class="error error--rich">
+        <h3>Stream configuration issue</h3>
+        <p>
+          This stream cannot start new processes until its organization and role
+          references are fixed.
+        </p>
+        <div class="error-detail">{{ .Error }}</div>
+      </div>
+    {{ else }}
+      <div class="home-workflow-grid" data-home-root>
+        <section class="panel panel-sticky">
           <div class="panel-heading">
-            <h2>Stream instances</h2>
-            <p>View and manage all instances of this stream</p>
+            <h2>Streams</h2>
+            <p>Jump to instances by status</p>
           </div>
-          <div class="panel-actions">
-            <button
-              class="btn btn-secondary"
-              type="button"
-              data-home-nav="preview"
-              onclick="document.getElementById('stream-preview-dialog').showModal()"
-            >
-              {{ template "icon-eye" . }}
-              View preview
-            </button>
-            <button
-              class="btn btn-primary"
-              type="button"
-              onclick="document.getElementById('new-instance-dialog').showModal()"
-              {{ if .Error }}disabled{{ end }}
-            >
-              {{ template "icon-play" . }}
-              New instance
-            </button>
-          </div>
-        </div>
-        <dialog id="new-instance-dialog" class="dialog">
-          <div class="dialog-card">
-            <header class="dialog-head">
-              <div>
-                <h3 class="dialog-title">New instance</h3>
-                <p class="dialog-subtitle">
-                  Give this stream instance a brief name
-                </p>
-              </div>
-              <button
-                type="button"
-                class="btn btn-ghost btn-icon dialog-close"
-                onclick="document.getElementById('new-instance-dialog').close()"
-              >
-                {{ template "icon-close" . }}
-              </button>
-            </header>
-            <form
-              method="post"
-              action="{{ .WorkflowPath }}/process/start"
-              class="input-form"
-            >
-              <div class="form-field">
-                <label for="instance-name">Instance name</label>
-                <input
-                  id="instance-name"
-                  name="name"
-                  type="text"
-                  maxlength="80"
-                  autocomplete="off"
-                />
-              </div>
-              <div class="dialog-actions">
-                <button class="btn btn-primary" type="submit">
-                  {{ template "icon-play" . }}
-                  Start instance
+          <nav class="sidebar-nav" aria-label="Stream status sections">
+            {{ range .ProcessGroups }}
+              {{ if eq .Status "available" }}
+                <button
+                  type="button"
+                  class="sidebar-nav-link is-active"
+                  data-home-nav="{{ .Status }}"
+                  aria-controls="{{ .PanelID }}"
+                  aria-current="page"
+                  aria-label="Available streams"
+                  title="Streams waiting for your input"
+                >
+                  <span class="sidebar-nav-title"> Available </span>
                 </button>
-              </div>
-            </form>
-          </div>
-        </dialog>
-        <dialog
-          id="stream-preview-dialog"
-          class="dialog"
-        >
-          <div class="dialog-card">
-            <header class="dialog-head">
-              <div>
-                <h3 class="dialog-title">Stream preview</h3>
-                <p class="dialog-subtitle">
-                  Inspect the stream timeline and form structure in read-only
-                  mode
-                </p>
-              </div>
+              {{ else if eq .Status "active" }}
+                <button
+                  type="button"
+                  class="sidebar-nav-link"
+                  data-home-nav="{{ .Status }}"
+                  aria-controls="{{ .PanelID }}"
+                  aria-current="false"
+                  aria-label="Active streams"
+                  title="Streams waiting for someone else input"
+                >
+                  <span class="sidebar-nav-title"> Active </span>
+                </button>
+              {{ else if eq .Status "done" }}
+                <button
+                  type="button"
+                  class="sidebar-nav-link"
+                  data-home-nav="{{ .Status }}"
+                  aria-controls="{{ .PanelID }}"
+                  aria-current="false"
+                  aria-label="Completed streams"
+                  title="Streams completed successfully"
+                >
+                  <span class="sidebar-nav-title"> Done </span>
+                </button>
+              {{ else if eq .Status "terminated" }}
+                <button
+                  type="button"
+                  class="sidebar-nav-link"
+                  data-home-nav="{{ .Status }}"
+                  aria-controls="{{ .PanelID }}"
+                  aria-current="false"
+                  aria-label="Terminated streams"
+                  title="Streams terminated before completion"
+                >
+                  <span class="sidebar-nav-title"> Terminated </span>
+                </button>
+              {{ end }}
+            {{ end }}
+          </nav>
+        </section>
+
+        <div class="home-workflow-panel-main">
+          <div class="panel-head-actions">
+            <div class="panel-heading">
+              <h2>Stream instances</h2>
+              <p>View and manage all instances of this stream</p>
+            </div>
+            <div class="panel-actions">
               <button
+                class="btn btn-secondary"
                 type="button"
-                class="btn btn-ghost btn-icon dialog-close"
-                onclick="document.getElementById('stream-preview-dialog').close()"
+                data-home-nav="preview"
+                onclick="document.getElementById('stream-preview-dialog').showModal()"
               >
-                {{ template "icon-close" . }}
+                {{ template "icon-eye" . }}
+                View preview
               </button>
-            </header>
-            <div class="stream-preview-body">
-              {{ template "stream_timeline" .Preview.StreamTimeline }}
+              <button
+                class="btn btn-primary"
+                type="button"
+                onclick="document.getElementById('new-instance-dialog').showModal()"
+              >
+                {{ template "icon-play" . }}
+                New instance
+              </button>
             </div>
           </div>
-        </dialog>
-        <div class="stream-status-sections">
-          {{ if .Error }}
-            <section
-              class="panel instances-panel"
-              id="home-panel-instances"
-              data-home-panel="instances"
-            >
-              <div class="panel-heading">
-                <h3>Stream configuration issue</h3>
-                <p>
-                  This stream cannot start new processes until its organization
-                  and role references are fixed.
-                </p>
+          <dialog id="new-instance-dialog" class="dialog">
+            <div class="dialog-card">
+              <header class="dialog-head">
+                <div>
+                  <h3 class="dialog-title">New instance</h3>
+                  <p class="dialog-subtitle">
+                    Give this stream instance a brief name
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-icon dialog-close"
+                  onclick="document.getElementById('new-instance-dialog').close()"
+                >
+                  {{ template "icon-close" . }}
+                </button>
+              </header>
+              <form
+                method="post"
+                action="{{ .WorkflowPath }}/process/start"
+                class="input-form"
+              >
+                <div class="form-field">
+                  <label for="instance-name">Instance name</label>
+                  <input
+                    id="instance-name"
+                    name="name"
+                    type="text"
+                    maxlength="80"
+                    autocomplete="off"
+                  />
+                </div>
+                <div class="dialog-actions">
+                  <button class="btn btn-primary" type="submit">
+                    {{ template "icon-play" . }}
+                    Start instance
+                  </button>
+                </div>
+              </form>
+            </div>
+          </dialog>
+          <dialog
+            id="stream-preview-dialog"
+            class="dialog"
+          >
+            <div class="dialog-card">
+              <header class="dialog-head">
+                <div>
+                  <h3 class="dialog-title">Stream preview</h3>
+                  <p class="dialog-subtitle">
+                    Inspect the stream timeline and form structure in read-only
+                    mode
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-icon dialog-close"
+                  onclick="document.getElementById('stream-preview-dialog').close()"
+                >
+                  {{ template "icon-close" . }}
+                </button>
+              </header>
+              <div class="stream-preview-body">
+                {{ template "stream_timeline" .Preview.StreamTimeline }}
               </div>
-              <div class="error">{{ .Error }}</div>
-            </section>
-          {{ else }}
+            </div>
+          </dialog>
+          <div class="stream-status-sections">
             {{ range .ProcessGroups }}
               <section
                 class="stream-status-section"
@@ -319,83 +312,83 @@
                 {{ end }}
               </section>
             {{ end }}
-          {{ end }}
+          </div>
         </div>
       </div>
-    </div>
 
-    <script>
-      (function () {
-        const homeRoot = document.querySelector("[data-home-root]");
-        if (!homeRoot) {
-          return;
-        }
-
-        const panels = Array.from(homeRoot.querySelectorAll("[data-home-panel]"));
-        const statusPanelNames = panels.map((panel) =>
-          (panel.getAttribute("data-home-panel") || "").trim(),
-        );
-
-        const defaultPanelName = statusPanelNames.includes("available")
-          ? "available"
-          : statusPanelNames[0] || "";
-
-        const initialPanelName = () => {
-          const hashPanelID = window.location.hash.replace(/^#/, "");
-          if (hashPanelID) {
-            const hashPanel = panels.find((panel) => panel.id === hashPanelID);
-            if (hashPanel) {
-              return (hashPanel.getAttribute("data-home-panel") || "").trim();
-            }
+      <script>
+        (function () {
+          const homeRoot = document.querySelector("[data-home-root]");
+          if (!homeRoot) {
+            return;
           }
 
-          const params = new URLSearchParams(window.location.search);
-          const queryPanel = statusPanelNames.find((panelName) => {
-            return (
-              params.has(panelName + "_page") || params.has(panelName + "_sort")
-            );
-          });
-          return queryPanel || defaultPanelName;
-        };
-
-        const showPanel = (panelName) => {
-          if (!statusPanelNames.includes(panelName)) {
-            panelName = defaultPanelName;
-          }
-
-          const buttons = Array.from(
-            homeRoot.querySelectorAll("[data-home-nav]"),
+          const panels = Array.from(homeRoot.querySelectorAll("[data-home-panel]"));
+          const statusPanelNames = panels.map((panel) =>
+            (panel.getAttribute("data-home-panel") || "").trim(),
           );
-          buttons.forEach((button) => {
-            const currentName = button.getAttribute("data-home-nav");
-            const isActive = currentName === panelName;
-            button.classList.toggle("is-active", isActive);
-            button.setAttribute("aria-current", isActive ? "page" : "false");
-          });
 
-          panels.forEach((panel) => {
-            const currentName = panel.getAttribute("data-home-panel");
-            panel.hidden = currentName !== panelName;
-          });
-        };
+          const defaultPanelName = statusPanelNames.includes("available")
+            ? "available"
+            : statusPanelNames[0] || "";
 
-        Array.from(homeRoot.querySelectorAll("[data-home-nav]")).forEach(
-          (button) => {
-            button.addEventListener("click", () => {
-              const panelName = (
-                button.getAttribute("data-home-nav") || ""
-              ).trim();
-              if (panelName === "preview") {
-                return;
+          const initialPanelName = () => {
+            const hashPanelID = window.location.hash.replace(/^#/, "");
+            if (hashPanelID) {
+              const hashPanel = panels.find((panel) => panel.id === hashPanelID);
+              if (hashPanel) {
+                return (hashPanel.getAttribute("data-home-panel") || "").trim();
               }
-              showPanel(panelName);
-            });
-          },
-        );
+            }
 
-        showPanel(initialPanelName());
-      })();
-    </script>
+            const params = new URLSearchParams(window.location.search);
+            const queryPanel = statusPanelNames.find((panelName) => {
+              return (
+                params.has(panelName + "_page") || params.has(panelName + "_sort")
+              );
+            });
+            return queryPanel || defaultPanelName;
+          };
+
+          const showPanel = (panelName) => {
+            if (!statusPanelNames.includes(panelName)) {
+              panelName = defaultPanelName;
+            }
+
+            const buttons = Array.from(
+              homeRoot.querySelectorAll("[data-home-nav]"),
+            );
+            buttons.forEach((button) => {
+              const currentName = button.getAttribute("data-home-nav");
+              const isActive = currentName === panelName;
+              button.classList.toggle("is-active", isActive);
+              button.setAttribute("aria-current", isActive ? "page" : "false");
+            });
+
+            panels.forEach((panel) => {
+              const currentName = panel.getAttribute("data-home-panel");
+              panel.hidden = currentName !== panelName;
+            });
+          };
+
+          Array.from(homeRoot.querySelectorAll("[data-home-nav]")).forEach(
+            (button) => {
+              button.addEventListener("click", () => {
+                const panelName = (
+                  button.getAttribute("data-home-nav") || ""
+                ).trim();
+                if (panelName === "preview") {
+                  return;
+                }
+                showPanel(panelName);
+              });
+            },
+          );
+
+          showPanel(initialPanelName());
+        })();
+      </script>
+    {{ end }}
   </div>
 {{ end }}
 

--- a/server/templates/pages/stream.html
+++ b/server/templates/pages/stream.html
@@ -7,7 +7,7 @@
       <section class="panel panel-sticky">
         <div class="panel-heading">
           <h2>Streams</h2>
-          <p>Jump to instances by status.</p>
+          <p>Jump to instances by status</p>
         </div>
         <nav class="sidebar-nav" aria-label="Stream status sections">
           {{ range .ProcessGroups }}
@@ -68,7 +68,7 @@
         <div class="panel-head-actions">
           <div class="panel-heading">
             <h2>Stream instances</h2>
-            <p>View and manage all instances of this stream.</p>
+            <p>View and manage all instances of this stream</p>
           </div>
           <div class="panel-actions">
             <button
@@ -97,7 +97,7 @@
               <div>
                 <h3 class="dialog-title">New instance</h3>
                 <p class="dialog-subtitle">
-                  Give this stream instance a brief name.
+                  Give this stream instance a brief name
                 </p>
               </div>
               <button
@@ -142,7 +142,7 @@
                 <h3 class="dialog-title">Stream preview</h3>
                 <p class="dialog-subtitle">
                   Inspect the stream timeline and form structure in read-only
-                  mode.
+                  mode
                 </p>
               </div>
               <button

--- a/server/templates/pages/stream.html
+++ b/server/templates/pages/stream.html
@@ -13,7 +13,7 @@
         <div class="error-detail">{{ .Error }}</div>
       </div>
     {{ else }}
-      <div class="home-workflow-grid" data-home-root>
+      <div class="rail-layout rail-layout-ready" data-home-root>
         <section class="panel panel-sticky">
           <div class="panel-heading">
             <h2>Streams</h2>
@@ -74,7 +74,7 @@
           </nav>
         </section>
 
-        <div class="home-workflow-panel-main">
+        <div class="rail-layout-main home-workflow-panel-main">
           <div class="panel-head-actions">
             <div class="panel-heading">
               <h2>Stream instances</h2>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -573,6 +573,37 @@ const copyLinkValue = async (button) => {
   window.prompt(`Copy ${label}:`, absoluteURL);
 };
 
+const copyFeedbackTimers = new WeakMap();
+
+const showCopyFeedback = (button) => {
+  const defaultIcon = button.querySelector("[data-copy-icon-default]");
+  const doneIcon = button.querySelector("[data-copy-icon-done]");
+  const previousTimer = copyFeedbackTimers.get(button);
+  if (previousTimer) {
+    window.clearTimeout(previousTimer);
+  }
+
+  if (defaultIcon && doneIcon) {
+    defaultIcon.classList.add("icon-hidden");
+    doneIcon.classList.remove("icon-hidden");
+    const timer = window.setTimeout(() => {
+      defaultIcon.classList.remove("icon-hidden");
+      doneIcon.classList.add("icon-hidden");
+      copyFeedbackTimers.delete(button);
+    }, 1200);
+    copyFeedbackTimers.set(button, timer);
+    return;
+  }
+
+  const originalText = button.textContent || "Copy";
+  button.textContent = "Copied";
+  const timer = window.setTimeout(() => {
+    button.textContent = originalText;
+    copyFeedbackTimers.delete(button);
+  }, 1200);
+  copyFeedbackTimers.set(button, timer);
+};
+
 const copyTextValue = async (button) => {
   if (!(button instanceof HTMLButtonElement)) {
     return;
@@ -585,11 +616,7 @@ const copyTextValue = async (button) => {
   if (navigator.clipboard?.writeText) {
     try {
       await navigator.clipboard.writeText(value);
-      const originalText = button.textContent || "Copy";
-      button.textContent = "Copied";
-      window.setTimeout(() => {
-        button.textContent = originalText;
-      }, 1200);
+      showCopyFeedback(button);
       return;
     } catch (_err) {}
   }

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -1,4 +1,5 @@
 @import url("./components/page-header.css");
+@import url("./components/stream-termination-details.css");
 @import url("./components/stream-card.css");
 @import url("./components/panel.css");
 @import url("./components/sidebar-nav.css");

--- a/web/src/styles/components/button.css
+++ b/web/src/styles/components/button.css
@@ -154,3 +154,7 @@ a.btn:hover {
 .btn-icon .icon-svg {
   display: block;
 }
+
+.btn-icon .icon-svg.icon-hidden {
+  display: none;
+}

--- a/web/src/styles/components/list-row.css
+++ b/web/src/styles/components/list-row.css
@@ -19,7 +19,7 @@
   padding: 0;
   margin: var(--space-3) 0 0;
   display: grid;
-  gap: var(--space-3);
+  gap: var(--space-1);
 }
 
 .list-row {
@@ -30,7 +30,7 @@
   padding: var(--space-3);
   border-radius: 4px;
   border: 1px solid var(--border);
-  background: var(--muted);
+  background: var(--secondary);
 }
 
 .list-row-main {
@@ -47,7 +47,7 @@
   align-items: center;
   flex: 0 0 auto;
   margin-inline-start: auto;
-  gap: var(--space-2);
+  gap: var(--space-1);
 }
 
 .list-row > .error {

--- a/web/src/styles/components/list-row.css
+++ b/web/src/styles/components/list-row.css
@@ -46,24 +46,13 @@
   display: inline-flex;
   align-items: center;
   flex: 0 0 auto;
+  flex-wrap: nowrap;
   margin-inline-start: auto;
   gap: var(--space-1);
+  white-space: nowrap;
 }
 
 .list-row > .error {
   flex: 1 1 100%;
   margin: 0;
-}
-
-@media (--sm-down) {
-  .list-row {
-    flex-direction: column;
-    align-items: stretch;
-    gap: var(--space-3);
-  }
-
-  .list-row-actions {
-    margin-inline-start: 0;
-    justify-content: flex-start;
-  }
 }

--- a/web/src/styles/components/panel.css
+++ b/web/src/styles/components/panel.css
@@ -1,5 +1,5 @@
 /*
- * Panel — card container and section headers (CSS-only component).
+ * Panel — layout container and section headers (CSS-only component).
  *
  * With actions (button, form, or action group):
  *   section.panel
@@ -26,11 +26,6 @@
  */
 
 .panel {
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: var(--space-5);
-  box-shadow: 0 10px 26px var(--shadow);
   min-width: 0;
 }
 
@@ -89,12 +84,6 @@
   .panel-sticky {
     position: sticky;
     top: 44px;
-  }
-}
-
-@media (--sm-down) {
-  .panel {
-    padding: var(--space-4);
   }
 }
 

--- a/web/src/styles/components/panel.css
+++ b/web/src/styles/components/panel.css
@@ -22,7 +22,7 @@
  *   div.panel-block[.panel-block-spaced]
  *
  * Modifiers:
- *   section.panel.panel-sticky   (sticky rail at --xl-up)
+ *   section.panel.panel-sticky   (sticky rail at --md-up)
  */
 
 .panel {
@@ -82,7 +82,7 @@
   margin-bottom: var(--space-3);
 }
 
-@media (--xl-up) {
+@media (--md-up) {
   .panel-sticky {
     position: sticky;
     top: 44px;

--- a/web/src/styles/components/panel.css
+++ b/web/src/styles/components/panel.css
@@ -41,6 +41,7 @@
   p {
     color: var(--muted-foreground);
     margin: 3px 0 0;
+    text-wrap: balance;
   }
 }
 

--- a/web/src/styles/components/panel.css
+++ b/web/src/styles/components/panel.css
@@ -50,6 +50,7 @@
   justify-content: space-between;
   gap: var(--space-4);
   margin-bottom: var(--space-5);
+  flex-wrap: nowrap;
 
   button {
     flex-shrink: 0;
@@ -62,6 +63,7 @@
 
 .panel-head-actions .panel-heading {
   margin-bottom: 0;
+  min-width: 0;
 }
 
 .panel-actions {
@@ -84,23 +86,5 @@
   .panel-sticky {
     position: sticky;
     top: 44px;
-  }
-}
-
-@media (--md-down) {
-  .panel-head-actions {
-    flex-direction: column;
-
-    button {
-      width: 100%;
-    }
-
-    form {
-      width: 100%;
-    }
-
-    .panel-actions {
-      width: 100%;
-    }
   }
 }

--- a/web/src/styles/components/shared.css
+++ b/web/src/styles/components/shared.css
@@ -50,6 +50,35 @@ svg.bi {
   color: var(--muted-foreground);
 }
 
+.field-label {
+  display: block;
+  margin: 0;
+  font-weight: var(--font-semibold);
+}
+
+.field-block {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.field-row {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+  max-width: 100%;
+  vertical-align: top;
+}
+
+.field-row > :not(button) {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.field-row > button {
+  flex: 0 0 auto;
+}
+
 .pill {
   font-family: var(--font-mono);
   font-size: var(--text-xs);

--- a/web/src/styles/components/shared.css
+++ b/web/src/styles/components/shared.css
@@ -195,6 +195,33 @@ svg.bi {
   white-space: pre-line;
 }
 
+.warning {
+  background: var(--warning-muted);
+  color: var(--warning-muted-foreground);
+  border: 1px solid
+    color-mix(in srgb, var(--warning-muted-foreground) 35%, transparent);
+  padding: var(--space-3) var(--space-3);
+  border-radius: 4px;
+  margin-block: 0;
+  white-space: pre-line;
+}
+
+.warning--rich {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  white-space: normal;
+}
+
+.warning--rich > :is(h1, h2, h3, h4, h5, h6, p) {
+  margin: 0;
+}
+
+.warning--rich > .warning-detail {
+  margin-top: var(--space-2);
+  white-space: pre-line;
+}
+
 .pagination-btn {
   padding: var(--space-3) var(--space-2);
 }

--- a/web/src/styles/components/shared.css
+++ b/web/src/styles/components/shared.css
@@ -139,6 +139,22 @@ svg.bi {
   white-space: pre-line;
 }
 
+.error--rich {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  white-space: normal;
+}
+
+.error--rich > :is(h1, h2, h3, h4, h5, h6, p) {
+  margin: 0;
+}
+
+.error--rich > .error-detail {
+  margin-top: var(--space-2);
+  white-space: pre-line;
+}
+
 .confirmation {
   background: var(--success-muted);
   color: var(--success-muted-foreground);

--- a/web/src/styles/components/sidebar-nav.css
+++ b/web/src/styles/components/sidebar-nav.css
@@ -8,13 +8,16 @@
  */
 
 .sidebar-nav {
-  display: grid;
+  display: flex;
+  flex-direction: column;
+  width: max-content;
+  max-width: 100%;
   gap: var(--space-1);
 }
 
 .sidebar-nav-link {
-  width: 100%;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   padding: var(--space-2) var(--space-3);
   text-align: left;
   border-radius: 4px;
@@ -31,7 +34,7 @@
 
 .sidebar-nav-title {
   font-weight: 500;
-  color: var(--primary);
+  color: var(--foreground);
 }
 
 .sidebar-nav-link:hover,

--- a/web/src/styles/components/sidebar-nav.css
+++ b/web/src/styles/components/sidebar-nav.css
@@ -2,7 +2,7 @@
  * Sidebar nav — section switcher tiles (CSS-only component).
  *
  * nav.sidebar-nav
- *   button.sidebar-nav-link[.is-active]
+ *   a.sidebar-nav-link[.is-active]   (or button, on pages that still use buttons)
  *     span.sidebar-nav-title
  *     span.sidebar-nav-copy?   (optional subtitle)
  */
@@ -20,6 +20,7 @@
   flex-direction: column;
   padding: var(--space-2) var(--space-3);
   text-align: left;
+  text-decoration: none;
   border-radius: 4px;
   border: 1px solid transparent;
   background: transparent;
@@ -38,7 +39,9 @@
 }
 
 .sidebar-nav-link:hover,
+.sidebar-nav-link:focus,
 .sidebar-nav-link.is-active {
+  text-decoration: none;
   background: color-mix(in srgb, var(--primary) 8%, var(--background));
 }
 

--- a/web/src/styles/components/sidebar-nav.css
+++ b/web/src/styles/components/sidebar-nav.css
@@ -9,40 +9,38 @@
 
 .sidebar-nav {
   display: grid;
-  gap: var(--space-2);
-  margin-top: var(--space-5);
+  gap: var(--space-1);
 }
 
 .sidebar-nav-link {
   width: 100%;
   display: grid;
-  padding: var(--space-3) var(--space-4);
+  padding: var(--space-2) var(--space-3);
   text-align: left;
   border-radius: 4px;
-  border: 1px solid var(--border);
-  background: var(--muted);
+  border: 1px solid transparent;
+  background: transparent;
   color: inherit;
   font: inherit;
   cursor: pointer;
   transition:
     border-color 0.18s ease,
     background-color 0.18s ease,
-    color 0.18s ease,
-    transform 0.18s ease;
-}
-
-.sidebar-nav-link:hover {
-  border-color: var(--primary);
-  transform: translateY(-1px);
-}
-
-.sidebar-nav-link.is-active {
-  border-color: var(--primary);
-  background: color-mix(in srgb, var(--primary) 14%, var(--muted));
+    color 0.18s ease;
 }
 
 .sidebar-nav-title {
   font-weight: 500;
+  color: var(--primary);
+}
+
+.sidebar-nav-link:hover,
+.sidebar-nav-link.is-active {
+  background: color-mix(in srgb, var(--primary) 8%, var(--background));
+}
+
+.sidebar-nav-link.is-active {
+  border-color: var(--primary);
 }
 
 .sidebar-nav-copy {

--- a/web/src/styles/components/stream-termination-details.css
+++ b/web/src/styles/components/stream-termination-details.css
@@ -1,0 +1,49 @@
+.stream-termination-details-title {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+}
+
+.stream-termination-details-fields {
+  margin: var(--space-2) 0 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-1) var(--space-4);
+}
+
+.stream-termination-details-field {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  column-gap: var(--space-2);
+  row-gap: 0;
+  min-width: 0;
+}
+
+.stream-termination-details-field .field-label {
+  display: inline;
+  flex-shrink: 0;
+  font-weight: var(--font-medium);
+}
+
+.stream-termination-details-field .field-label::after {
+  content: ":";
+}
+
+.stream-termination-details-field dt,
+.stream-termination-details-field dd {
+  font-size: var(--text-sm);
+  margin: 0;
+}
+
+.stream-termination-details-field dd {
+  min-width: 0;
+}
+
+@media (--sm-down) {
+  .stream-termination-details-fields {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/web/src/styles/layout/chrome.css
+++ b/web/src/styles/layout/chrome.css
@@ -211,6 +211,10 @@
   color: var(--muted-foreground);
 }
 
+.site-footer > * {
+  opacity: 0.5;
+}
+
 .site-footer p {
   margin: 0 0 var(--space-2);
   font-size: var(--text-xs);

--- a/web/src/styles/layout/chrome.css
+++ b/web/src/styles/layout/chrome.css
@@ -208,11 +208,11 @@
   padding: var(--space-5) 32px var(--space-6);
   border-top: 1px solid var(--border);
   background: var(--secondary);
+  color: var(--muted-foreground);
 }
 
 .site-footer p {
   margin: 0 0 var(--space-2);
-  color: var(--muted-foreground);
   font-size: var(--text-xs);
   line-height: var(--leading-normal);
 }

--- a/web/src/styles/layout/chrome.css
+++ b/web/src/styles/layout/chrome.css
@@ -234,6 +234,10 @@
   gap: var(--space-4);
 }
 
+.stack.u-gap-12 {
+  gap: var(--space-12);
+}
+
 .landing {
   max-width: 520px;
 }

--- a/web/src/styles/layout/grids.css
+++ b/web/src/styles/layout/grids.css
@@ -23,26 +23,15 @@
   }
 }
 
-.home-workflow-grid {
-  display: grid;
-  gap: var(--space-6);
-  align-items: start;
-  grid-template-columns: minmax(0, 1fr);
-}
-
-@media (--md-up) {
-  .home-workflow-grid {
-    grid-template-columns: minmax(260px, 300px) minmax(0, 1fr);
-  }
-}
-
-.dashboard-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: var(--space-4);
-}
-
-.org-admin-grid {
+/*
+ * Rail layout — sticky sidebar + main (stream dashboard, org admin).
+ * Side-by-side + sticky rail from --md-up (same breakpoint as .panel-sticky).
+ *
+ *   div.rail-layout[.rail-layout-ready]
+ *     section.panel.panel-sticky
+ *     .rail-layout-main
+ */
+.rail-layout {
   display: flex;
   flex-direction: column;
   gap: var(--space-12);
@@ -50,19 +39,27 @@
 }
 
 @media (--md-up) {
-  .org-admin-grid-ready {
+  .rail-layout-ready {
     flex-direction: row;
     align-items: start;
   }
 
-  .org-admin-grid-ready > .panel-sticky {
+  .rail-layout-ready > .panel-sticky {
     flex: 0 0 auto;
+    width: max-content;
+    max-width: 100%;
   }
 
-  .org-admin-grid-ready > .org-admin-panel-main {
+  .rail-layout-ready > .rail-layout-main {
     flex: 1 1 0;
     min-width: 0;
   }
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--space-4);
 }
 
 .process-resources-grid {

--- a/web/src/styles/layout/grids.css
+++ b/web/src/styles/layout/grids.css
@@ -43,18 +43,25 @@
 }
 
 .org-admin-grid {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: var(--space-12);
-  align-items: start;
+  align-items: stretch;
 }
 
-.org-admin-grid-ready {
-  grid-template-columns: minmax(0, 1fr);
-}
-
-@media (--xl-up) {
+@media (--md-up) {
   .org-admin-grid-ready {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    flex-direction: row;
+    align-items: start;
+  }
+
+  .org-admin-grid-ready > .panel-sticky {
+    flex: 0 0 auto;
+  }
+
+  .org-admin-grid-ready > .org-admin-panel-main {
+    flex: 1 1 0;
+    min-width: 0;
   }
 }
 

--- a/web/src/styles/layout/grids.css
+++ b/web/src/styles/layout/grids.css
@@ -30,7 +30,7 @@
   grid-template-columns: minmax(0, 1fr);
 }
 
-@media (--xl-up) {
+@media (--md-up) {
   .home-workflow-grid {
     grid-template-columns: minmax(260px, 300px) minmax(0, 1fr);
   }

--- a/web/src/styles/layout/grids.css
+++ b/web/src/styles/layout/grids.css
@@ -64,15 +64,14 @@
 
 .process-resources-grid {
   display: grid;
-  gap: var(--space-6);
+  gap: var(--space-12);
   grid-template-columns: minmax(0, 1fr);
   justify-content: start;
   align-items: start;
 }
 
-@media (--lg-up) {
+@media (--md-up) {
   .process-resources-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: var(--space-3);
   }
 }

--- a/web/src/styles/layout/grids.css
+++ b/web/src/styles/layout/grids.css
@@ -74,4 +74,8 @@
   .process-resources-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
+  .process-resources-grid .layout-stack-separator {
+    gap: var(--space-8);
+  }
 }

--- a/web/src/styles/layout/grids.css
+++ b/web/src/styles/layout/grids.css
@@ -44,7 +44,7 @@
 
 .org-admin-grid {
   display: grid;
-  gap: var(--space-6);
+  gap: var(--space-12);
   align-items: start;
 }
 

--- a/web/src/styles/layout/responsive.css
+++ b/web/src/styles/layout/responsive.css
@@ -10,11 +10,9 @@
   .site-footer {
     padding: var(--space-5) var(--space-4) var(--space-6);
   }
-}
 
-@media (--xl-down) {
   .layout-stack-separator {
     border-top: 1px solid var(--border);
-    padding-top: var(--space-6);
+    padding-top: var(--space-12);
   }
 }

--- a/web/src/styles/layout/responsive.css
+++ b/web/src/styles/layout/responsive.css
@@ -6,6 +6,10 @@
   .topbar {
     padding: var(--space-3) var(--space-4);
   }
+
+  .site-footer {
+    padding: var(--space-5) var(--space-4) var(--space-6);
+  }
 }
 
 @media (--xl-down) {

--- a/web/src/styles/pages/dpp.css
+++ b/web/src/styles/pages/dpp.css
@@ -1,8 +1,42 @@
+.dpp-page {
+  max-width: 80ch;
+}
+
+.dpp-ids {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2) var(--space-1);
+  margin-bottom: var(--space-4);
+}
+
+.dpp-id {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  padding: 5px var(--space-3);
+  color: var(--foreground);
+  background: var(--pill);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+
+.dpp-history .panel-heading:has(+ .stream-termination-details) {
+  margin-bottom: var(--space-3);
+}
+
+.dpp-history .stream-termination-details {
+  margin-bottom: var(--space-6);
+}
+
 .dpp-integrity-root {
   display: flex;
   align-items: center;
   gap: var(--space-2);
   margin-bottom: var(--space-3);
+}
+
+.dpp-integrity-root strong {
+  font-family: var(--font-mono);
 }
 
 .dpp-integrity-list {
@@ -23,6 +57,7 @@
   min-width: 0;
   overflow-wrap: anywhere;
   word-break: break-all;
+  font-family: var(--font-mono);
 }
 
 .dpp-integrity-hash-button {
@@ -102,9 +137,6 @@
   min-width: 0;
 }
 
-.dpp-termination-meta {
-  margin: 3px 0 var(--space-5);
-}
 
 @media (--sm-down) {
   .dpp-history-item::before {

--- a/web/src/styles/pages/dpp.css
+++ b/web/src/styles/pages/dpp.css
@@ -1,7 +1,3 @@
-.dpp-downloads-section code {
-  word-break: break-all;
-}
-
 .dpp-integrity-root {
   display: flex;
   align-items: center;

--- a/web/src/styles/pages/home.css
+++ b/web/src/styles/pages/home.css
@@ -10,7 +10,7 @@
   scroll-margin-top: 140px;
 }
 
-@media (--xl-down) {
+@media (--md-down) {
   .preview-panel,
   .instances-panel {
     scroll-margin-top: var(--space-3);

--- a/web/src/styles/pages/org-admin-page.css
+++ b/web/src/styles/pages/org-admin-page.css
@@ -50,7 +50,7 @@
   padding: var(--space-1);
   border: 1px solid var(--border);
   border-radius: 4px;
-  background: var(--pill);
+  background: var(--muted);
   color: var(--muted-foreground);
   font-size: var(--text-xs);
   font-weight: 600;

--- a/web/src/styles/pages/org-admin-page.css
+++ b/web/src/styles/pages/org-admin-page.css
@@ -14,7 +14,6 @@
 }
 
 .org-admin-panel-main {
-  grid-column: span 2;
   display: grid;
   gap: var(--space-7);
 }
@@ -85,9 +84,8 @@
   margin: 0;
 }
 
-@media (--xl-down) {
+@media (--md-down) {
   .org-admin-panel-main {
     scroll-margin-top: var(--space-3);
-    grid-column: auto;
   }
 }

--- a/web/src/styles/pages/process.css
+++ b/web/src/styles/pages/process.css
@@ -10,3 +10,46 @@
   gap: var(--space-2);
   font-size: var(--text-sm);
 }
+
+/* GS1 codes on the completed-process DPP panel */
+.process-gs1-code-block {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.process-gs1-code-label {
+  display: block;
+  font-weight: var(--font-semibold);
+}
+
+.process-gs1-code-row {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+  max-width: 100%;
+  vertical-align: top;
+}
+
+.process-gs1-code-row > .process-gs1-code {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.process-gs1-code {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+}
+
+.process-gs1-code-row .js-copy-text {
+  flex: 0 0 auto;
+}
+
+.process-gs1-code-row .js-copy-text [data-copy-icon-done] {
+  color: var(--primary);
+}

--- a/web/src/styles/pages/process.css
+++ b/web/src/styles/pages/process.css
@@ -2,6 +2,14 @@
   min-width: 0;
 }
 
+.process-termination-desktop {
+  display: none;
+}
+
+.process-steps-column {
+  min-width: 0;
+}
+
 #process-dpp .panel-head-actions,
 #process-downloads .panel-head-actions {
   margin-bottom: var(--space-4);
@@ -37,4 +45,14 @@
 
 .field-row .js-copy-text [data-copy-icon-done] {
   color: var(--primary);
+}
+
+@media (--md-up) {
+  .process-termination-mobile {
+    display: none;
+  }
+
+  .process-termination-desktop {
+    display: contents;
+  }
 }

--- a/web/src/styles/pages/process.css
+++ b/web/src/styles/pages/process.css
@@ -2,36 +2,25 @@
   min-width: 0;
 }
 
+#process-dpp .panel-head-actions,
+#process-downloads .panel-head-actions {
+  margin-bottom: var(--space-4);
+}
+
+#process-downloads .field-block:has(.process-attachments-list) > .field-label {
+  margin-bottom: var(--space-0.5);
+}
+
 .process-attachments-list {
   list-style: none;
   padding: 0;
   margin: 0;
   display: grid;
   gap: var(--space-2);
-  font-size: var(--text-sm);
 }
 
 /* GS1 codes on the completed-process DPP panel */
-.process-gs1-code-block {
-  min-width: 0;
-  max-width: 100%;
-}
-
-.process-gs1-code-label {
-  display: block;
-  font-weight: var(--font-semibold);
-}
-
-.process-gs1-code-row {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1);
-  min-width: 0;
-  max-width: 100%;
-  vertical-align: top;
-}
-
-.process-gs1-code-row > .process-gs1-code {
+.field-row > .process-gs1-code {
   min-width: 0;
   overflow: hidden;
 }
@@ -46,10 +35,6 @@
   font-size: var(--text-sm);
 }
 
-.process-gs1-code-row .js-copy-text {
-  flex: 0 0 auto;
-}
-
-.process-gs1-code-row .js-copy-text [data-copy-icon-done] {
+.field-row .js-copy-text [data-copy-icon-done] {
   color: var(--primary);
 }

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -27,7 +27,7 @@
   --font-semibold: 600;
   --font-bold: 700;
 
-  /* Spacing */
+  /* Spacing — 4px grid; --space-N ≈ N × 0.25rem */
   --space-1: 0.25rem;
   --space-2: 0.5rem;
   --space-3: 0.75rem;
@@ -35,6 +35,11 @@
   --space-5: 1.25rem;
   --space-6: 1.5rem;
   --space-7: 1.75rem;
+  --space-8: 2rem;
+  --space-9: 2.25rem;
+  --space-10: 2.5rem;
+  --space-11: 2.75rem;
+  --space-12: 3rem;
 
   /* Buttons */
   --btn-height-xs: 1.75rem; /* 28px — dense icon actions */
@@ -45,13 +50,13 @@
   --btn-padding-x-sm: var(--space-2);
 
   /* Surfaces */
-  --background: linear-gradient(135deg, #f3f4ef 0%, #e9efe2 100%);
+  --background: rgb(248, 253, 252);
   --foreground: #12210c;
   --card: #fff;
   --card-foreground: var(--foreground);
   --muted: #f8f9f4;
   --muted-foreground: #4f5d47;
-  --secondary: #fffaf2;
+  --secondary: #ffffff;
 
   /* Accent & semantic */
   --primary: #1e6f5c;
@@ -69,7 +74,7 @@
   --warning-muted: #fff7da;
 
   /* Borders & chips */
-  --border: #d9e0d0;
+  --border: #e4ebdc;
   --pill: #eff4e9;
   --tag: #eef2e6;
 

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -73,6 +73,7 @@
   --success-muted: #e6f4ea;
   --success-muted-foreground: var(--primary);
   --warning-muted: #fff7da;
+  --warning-muted-foreground: #a67f05;
 
   /* Borders & chips */
   --border: #c5d0b5;
@@ -206,6 +207,7 @@
   --destructive-muted-foreground: #ffd1cc;
   --success-muted: rgb(87 194 166 / 12%);
   --warning-muted: rgb(242 198 79 / 12%);
+  --warning-muted-foreground: var(--highlight-foreground);
 
   /* Borders & chips */
   --border: rgb(236 241 235 / 14%);

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -28,6 +28,7 @@
   --font-bold: 700;
 
   /* Spacing — 4px grid; --space-N ≈ N × 0.25rem */
+  --space-0.5: 1px;
   --space-1: 0.25rem;
   --space-2: 0.5rem;
   --space-3: 0.75rem;

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -74,7 +74,7 @@
   --warning-muted: #fff7da;
 
   /* Borders & chips */
-  --border: #e4ebdc;
+  --border: #c5d0b5;
   --pill: #eff4e9;
   --tag: #eef2e6;
 

--- a/web/src/styles/utilities.css
+++ b/web/src/styles/utilities.css
@@ -70,6 +70,10 @@
   gap: var(--space-4);
 }
 
+.u-gap-12 {
+  gap: var(--space-12);
+}
+
 .u-divider {
   margin: var(--space-6) 0;
   border: none;

--- a/web/src/styles/utilities.css
+++ b/web/src/styles/utilities.css
@@ -91,6 +91,12 @@
   border-top: 1px solid var(--border);
 }
 
+.u-divider-10 {
+  margin: var(--space-10) 0;
+  border: none;
+  border-top: 1px solid var(--border);
+}
+
 /* Replaces hardcoded signup error color with token-based danger text. */
 .u-text-danger {
   color: var(--destructive);


### PR DESCRIPTION
## Summary
- Restyle shared chrome and shells (footer, rail layouts for stream/org-admin, panel/list-row spacing, typography including JetBrains Mono regular).
- Improve process and DPP surfaces: field-block layout, GS1 truncate/copy with icon feedback, and a shared early-termination warning banner.
- Give org-admin settings sections distinct URLs and tighten related admin console copy/tests.

## Test plan
- [ ] Process page: completed stream shows termination banner (mobile above timeline / desktop in side stack); End stream dialog still works
- [ ] DPP page: overview IDs, History (with shared termination banner when ended early), Integrity, and Share link
- [ ] Process DPP/downloads panels: copy buttons swap to done icon; GS1 codes truncate and copy
- [ ] Org-admin: section URLs (`/org-admin/profile`, `/roles`, `/members`) and rail layout on md+
- [ ] Footer padding/opacity and fonts load with `display=swap`
- [ ] `task cover` / relevant Go template markup tests pass


Made with [Cursor](https://cursor.com)