### PR TITLE
Simplify stream dashboard URL state and compact mobile filter

### DIFF
--- a/docs/css.md
+++ b/docs/css.md
@@ -148,7 +148,7 @@ Other partials (`icons.html`, …) still live at `server/templates/` root until 
 | `data-stream-status` | `status_tag` micro-partial; `stream.html` section heads | `role-palette.css` (`--stream-color`) |
 | `data-progress` (via `style="--progress: …"`) | `components/stream_instance_card.html` | `.stream-instance-card-progress-fill` in `components/stream-instance-card.css` |
 | `data-org-admin-nav`, `data-org-admin-panel`, `data-org-admin-default-panel`, `data-org-admin-ready` | `org_admin.html` | `pages/org-admin-page.css`, inline script in `org_admin.html` |
-| `data-home-nav`, `data-home-panel` | `stream.html` | inline script in `stream.html` (panel switching + `?filter=` / `?sort=` / `?page=` sync) |
+| `data-home-nav`, `data-home-panel`, `data-home-filter-select` | `stream.html` | inline script in `stream.html` (panel switching + `?filter=` / `?sort=` / `?page=` sync; select is `--md-down` twin of filter nav) |
 | `data-process-id`, `data-workflow-key`, `data-selected-substep`, `data-substep-id` | `process.html` | `main.js` (SSE refresh, accordion) |
 | `data-formata-*`, `data-active-role-*` | `components/substep_body.html` | `main.js` (Formata embed, role picker) |
 | `data-override-url` | `components/substep_body.html` | `main.js` (substep override editor) |

--- a/docs/css.md
+++ b/docs/css.md
@@ -148,7 +148,7 @@ Other partials (`icons.html`, …) still live at `server/templates/` root until 
 | `data-stream-status` | `status_tag` micro-partial; `stream.html` section heads | `role-palette.css` (`--stream-color`) |
 | `data-progress` (via `style="--progress: …"`) | `components/stream_instance_card.html` | `.stream-instance-card-progress-fill` in `components/stream-instance-card.css` |
 | `data-org-admin-nav`, `data-org-admin-panel`, `data-org-admin-default-panel`, `data-org-admin-ready` | `org_admin.html` | `pages/org-admin-page.css`, inline script in `org_admin.html` |
-| `data-home-nav`, `data-home-panel` | `stream.html` | inline script in `stream.html` (panel switching + `?filter=` sync) |
+| `data-home-nav`, `data-home-panel` | `stream.html` | inline script in `stream.html` (panel switching + `?filter=` / `?sort=` / `?page=` sync) |
 | `data-process-id`, `data-workflow-key`, `data-selected-substep`, `data-substep-id` | `process.html` | `main.js` (SSE refresh, accordion) |
 | `data-formata-*`, `data-active-role-*` | `components/substep_body.html` | `main.js` (Formata embed, role picker) |
 | `data-override-url` | `components/substep_body.html` | `main.js` (substep override editor) |

--- a/server/cmd/server/home_handler_test.go
+++ b/server/cmd/server/home_handler_test.go
@@ -6,7 +6,6 @@ import (
 	"html/template"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1046,36 +1045,30 @@ func TestNormalizeHomeStatusFilter(t *testing.T) {
 	}
 }
 
-func TestHomePaginationURLIncludesFilterAndOmitsHash(t *testing.T) {
-	sortValues := map[string]string{
-		"active_sort": "status",
-		"all_sort":    "time_desc",
-	}
-	pageValues := map[string]int{
-		"active_page": 2,
-		"all_page":    1,
-	}
-
-	got := homePaginationURL("/w/workflow", sortValues, pageValues, "active_page", 3, "active")
-	want := "/w/workflow/?active_page=3&active_sort=status&filter=active"
+func TestHomePaginationURLUsesGlobalSortAndPage(t *testing.T) {
+	got := homePaginationURL("/w/workflow", "active", "status", 3)
+	want := "/w/workflow/?filter=active&page=3&sort=status"
 	if got != want {
 		t.Fatalf("pagination url = %q, want %q", got, want)
 	}
 	if strings.Contains(got, "#") {
 		t.Fatalf("did not expect hash in pagination url, got %q", got)
 	}
+	if strings.Contains(got, "_sort=") || strings.Contains(got, "_page=") {
+		t.Fatalf("did not expect per-status sort/page params, got %q", got)
+	}
 
-	allURL := homePaginationURL("/w/workflow", sortValues, pageValues, "all_page", 1, "all")
-	if strings.Contains(allURL, "filter=") {
-		t.Fatalf("default filter should omit filter param, got %q", allURL)
+	allURL := homePaginationURL("/w/workflow", "all", "time_desc", 1)
+	if allURL != "/w/workflow/" {
+		t.Fatalf("defaults should omit query params, got %q", allURL)
 	}
 }
 
-func TestBuildHomeProcessGroupsPreservesFilterInSortFields(t *testing.T) {
+func TestBuildHomeProcessGroupsUsesGlobalSortAndFilterFields(t *testing.T) {
 	groups := buildHomeProcessGroups("/w/workflow", []StreamInstanceCard{
 		{ID: "1", Status: "active"},
 		{ID: "2", Status: "done"},
-	}, "time_desc", url.Values{"done_sort": []string{"progress_desc"}})
+	}, "progress_desc", 1)
 
 	var done *ProcessStatusGroup
 	for i := range groups {
@@ -1087,10 +1080,16 @@ func TestBuildHomeProcessGroupsPreservesFilterInSortFields(t *testing.T) {
 	if done == nil {
 		t.Fatal("expected done process group")
 	}
+	if done.Sort != "progress_desc" {
+		t.Fatalf("expected shared sort progress_desc, got %q", done.Sort)
+	}
 	foundFilter := false
 	for _, field := range done.SortFields {
 		if field.Name == "filter" && field.Value == "done" {
 			foundFilter = true
+		}
+		if strings.HasSuffix(field.Name, "_sort") || strings.HasSuffix(field.Name, "_page") {
+			t.Fatalf("did not expect legacy sort/page field %#v", field)
 		}
 	}
 	if !foundFilter {
@@ -1098,6 +1097,9 @@ func TestBuildHomeProcessGroupsPreservesFilterInSortFields(t *testing.T) {
 	}
 	if !strings.Contains(done.NextURL, "filter=done") {
 		t.Fatalf("expected filter in pagination url, got %q", done.NextURL)
+	}
+	if !strings.Contains(done.NextURL, "sort=progress_desc") {
+		t.Fatalf("expected sort=progress_desc in pagination url, got %q", done.NextURL)
 	}
 }
 

--- a/server/cmd/server/home_template_preview_test.go
+++ b/server/cmd/server/home_template_preview_test.go
@@ -119,6 +119,8 @@ func TestHomeTemplateRendersSidebarAndReadOnlyPreview(t *testing.T) {
 		}
 	}
 	if !strings.Contains(compactBody, `aria-labelledby="stream-status-filter-label"`) ||
+		!strings.Contains(compactBody, `data-home-filter-select`) ||
+		!strings.Contains(compactBody, `class="stream-status-filter-select"`) ||
 		!strings.Contains(compactBody, `Filter by status`) {
 		t.Fatalf("expected stream status filter label, got: %s", body)
 	}

--- a/server/cmd/server/home_template_preview_test.go
+++ b/server/cmd/server/home_template_preview_test.go
@@ -33,7 +33,6 @@ func testHomeProcessGroups(items ...StreamInstanceCard) []ProcessStatusGroup {
 			PanelID:     "stream-section-" + status,
 			TotalCount:  len(processes),
 			Sort:        "time_desc",
-			SortParam:   homeProcessStatusSortParam(status),
 			SortFields:  sortFields,
 			CurrentPage: 1,
 			TotalPages:  totalPages,
@@ -203,14 +202,13 @@ func TestHomeTemplateRendersStatusPagination(t *testing.T) {
 				Label:       "All",
 				PanelID:     "stream-section-all",
 				TotalCount:  0,
-				Sort:        "time_desc",
-				SortParam:   "all_sort",
+				Sort:        "status",
 				CurrentPage: 1,
 				TotalPages:  1,
 				PageNumbers: []int{1},
-				PageLinks:   []PaginationLink{{Page: 1, URL: "/w/workflow/", IsCurrent: true}},
-				PreviousURL: "/w/workflow/",
-				NextURL:     "/w/workflow/",
+				PageLinks:   []PaginationLink{{Page: 1, URL: "/w/workflow/?sort=status", IsCurrent: true}},
+				PreviousURL: "/w/workflow/?sort=status",
+				NextURL:     "/w/workflow/?sort=status",
 				Processes:   nil,
 			},
 			{
@@ -218,15 +216,14 @@ func TestHomeTemplateRendersStatusPagination(t *testing.T) {
 				Label:       "Available",
 				PanelID:     "stream-section-available",
 				TotalCount:  0,
-				Sort:        "time_desc",
-				SortParam:   "available_sort",
+				Sort:        "status",
 				SortFields:  []QueryInput{{Name: "filter", Value: "available"}},
 				CurrentPage: 1,
 				TotalPages:  1,
 				PageNumbers: []int{1},
-				PageLinks:   []PaginationLink{{Page: 1, URL: "/w/workflow/?filter=available", IsCurrent: true}},
-				PreviousURL: "/w/workflow/?filter=available",
-				NextURL:     "/w/workflow/?filter=available",
+				PageLinks:   []PaginationLink{{Page: 1, URL: "/w/workflow/?filter=available&sort=status", IsCurrent: true}},
+				PreviousURL: "/w/workflow/?filter=available&sort=status",
+				NextURL:     "/w/workflow/?filter=available&sort=status",
 				Processes:   nil,
 			},
 			{
@@ -235,16 +232,15 @@ func TestHomeTemplateRendersStatusPagination(t *testing.T) {
 				PanelID:         "stream-section-active",
 				TotalCount:      11,
 				Sort:            "status",
-				SortParam:       "active_sort",
 				SortFields:      []QueryInput{{Name: "filter", Value: "active"}},
 				CurrentPage:     2,
 				TotalPages:      3,
 				PageNumbers:     []int{1, 2, 3},
-				PageLinks:       []PaginationLink{{Page: 1, URL: "/w/workflow/?active_sort=status&filter=active"}, {Page: 2, URL: "/w/workflow/?active_page=2&active_sort=status&filter=active", IsCurrent: true}, {Page: 3, URL: "/w/workflow/?active_page=3&active_sort=status&filter=active"}},
+				PageLinks:       []PaginationLink{{Page: 1, URL: "/w/workflow/?filter=active&sort=status"}, {Page: 2, URL: "/w/workflow/?filter=active&page=2&sort=status", IsCurrent: true}, {Page: 3, URL: "/w/workflow/?filter=active&page=3&sort=status"}},
 				HasPreviousPage: true,
 				HasNextPage:     true,
-				PreviousURL:     "/w/workflow/?active_sort=status&filter=active",
-				NextURL:         "/w/workflow/?active_page=3&active_sort=status&filter=active",
+				PreviousURL:     "/w/workflow/?filter=active&sort=status",
+				NextURL:         "/w/workflow/?filter=active&page=3&sort=status",
 				Processes:       []StreamInstanceCard{{ID: "process-13", Status: "active", DetailHref: "/w/workflow/process/process-13", Percent: 25, DoneSubsteps: 1, TotalSubsteps: 4, CreatedAt: "1 Mar 2026 at 10:00 UTC"}},
 			},
 		},
@@ -260,11 +256,11 @@ func TestHomeTemplateRendersStatusPagination(t *testing.T) {
 	if !strings.Contains(compactBody, `Active stream instances pagination`) {
 		t.Fatalf("expected active stream instances pagination nav, got: %s", body)
 	}
-	if !strings.Contains(compactBody, `/w/workflow/?active_page=3&amp;active_sort=status&amp;filter=active`) {
-		t.Fatalf("expected pagination to preserve filter, sort and active page, got: %s", body)
+	if !strings.Contains(compactBody, `/w/workflow/?filter=active&amp;page=3&amp;sort=status`) {
+		t.Fatalf("expected pagination to preserve filter, sort and page, got: %s", body)
 	}
-	if !strings.Contains(compactBody, `name="active_sort"`) {
-		t.Fatalf("expected active group sort select, got: %s", body)
+	if !strings.Contains(compactBody, `name="sort"`) {
+		t.Fatalf("expected global sort select, got: %s", body)
 	}
 	if !strings.Contains(compactBody, `name="filter" value="active"`) {
 		t.Fatalf("expected sort form to preserve filter, got: %s", body)
@@ -281,7 +277,7 @@ func TestHomeTemplateRendersStatusPagination(t *testing.T) {
 	}
 	stickyBlock := compactBody[stickyStart:stickyEnd]
 	navIdx := strings.Index(stickyBlock, `aria-labelledby="stream-status-filter-label"`)
-	sortIdx := strings.Index(stickyBlock, `name="active_sort"`)
+	sortIdx := strings.Index(stickyBlock, `name="sort"`)
 	if navIdx == -1 || sortIdx == -1 || !(navIdx < sortIdx) {
 		t.Fatalf("expected status sort control below stream-status-filter-nav inside sticky panel, got:\n%s", stickyBlock)
 	}
@@ -290,7 +286,7 @@ func TestHomeTemplateRendersStatusPagination(t *testing.T) {
 	if sectionStart == -1 || sectionEnd == -1 || sectionStart >= sectionEnd {
 		t.Fatal("expected active status section")
 	}
-	if strings.Contains(compactBody[sectionStart:sectionEnd], `select name="active_sort"`) {
+	if strings.Contains(compactBody[sectionStart:sectionEnd], `select name="sort"`) {
 		t.Fatalf("status sort must not remain in stream status section, got:\n%s", compactBody[sectionStart:sectionEnd])
 	}
 	if strings.Contains(compactBody, `#stream-section-`) {

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -327,9 +327,7 @@ type ProcessStatusGroup struct {
 	Status          string
 	Label           string
 	PanelID         string
-	PageParam       string
 	Sort            string
-	SortParam       string
 	SortFields      []QueryInput
 	TotalCount      int
 	CurrentPage     int
@@ -1769,33 +1767,18 @@ func homeProcessStatuses() []string {
 	return []string{"all", "available", processStatusActive, processStatusDone, processStatusTerminated}
 }
 
-func homeProcessStatusPageParam(status string) string {
-	return status + "_page"
-}
-
-func homeProcessStatusSortParam(status string) string {
-	return status + "_sort"
-}
-
-func homePaginationURL(workflowPath string, sortValues map[string]string, pageValues map[string]int, pageParam string, page int, filter string) string {
+func homePaginationURL(workflowPath, filter, sort string, page int) string {
 	values := url.Values{}
 	filter = normalizeHomeStatusFilter(filter)
 	if filter != "all" {
 		values.Set("filter", filter)
 	}
-	for _, status := range homeProcessStatuses() {
-		sortParam := homeProcessStatusSortParam(status)
-		if sortValue := normalizeHomeSortKey(sortValues[sortParam]); sortValue != "time_desc" {
-			values.Set(sortParam, sortValue)
-		}
-		param := homeProcessStatusPageParam(status)
-		value := pageValues[param]
-		if param == pageParam {
-			value = page
-		}
-		if value > 1 {
-			values.Set(param, strconv.Itoa(value))
-		}
+	sort = normalizeHomeSortKey(sort)
+	if sort != "time_desc" {
+		values.Set("sort", sort)
+	}
+	if page > 1 {
+		values.Set("page", strconv.Itoa(page))
 	}
 	target := strings.TrimRight(workflowPath, "/") + "/"
 	if encoded := values.Encode(); encoded != "" {
@@ -1804,15 +1787,9 @@ func homePaginationURL(workflowPath string, sortValues map[string]string, pageVa
 	return target
 }
 
-func buildHomeProcessGroups(workflowPath string, processes []StreamInstanceCard, sortKey string, query url.Values) []ProcessStatusGroup {
+func buildHomeProcessGroups(workflowPath string, processes []StreamInstanceCard, sortKey string, page int) []ProcessStatusGroup {
+	sortKey = normalizeHomeSortKey(sortKey)
 	byStatus := make(map[string][]StreamInstanceCard, len(homeProcessStatuses()))
-	pageValues := make(map[string]int, len(homeProcessStatuses()))
-	sortValues := make(map[string]string, len(homeProcessStatuses()))
-	for _, status := range homeProcessStatuses() {
-		pageValues[homeProcessStatusPageParam(status)] = parsePositiveInt(query.Get(homeProcessStatusPageParam(status)), 1)
-		sortParam := homeProcessStatusSortParam(status)
-		sortValues[sortParam] = normalizeHomeSortKey(firstNonEmpty(query.Get(sortParam), sortKey))
-	}
 	for _, process := range processes {
 		byStatus[process.Status] = append(byStatus[process.Status], process)
 	}
@@ -1825,12 +1802,8 @@ func buildHomeProcessGroups(workflowPath string, processes []StreamInstanceCard,
 		} else {
 			items = byStatus[status]
 		}
-		pageParam := homeProcessStatusPageParam(status)
-		sortParam := homeProcessStatusSortParam(status)
-		groupSort := normalizeHomeSortKey(sortValues[sortParam])
-		sortHomeProcessList(items, groupSort)
-		currentPage := normalizeHomePage(pageValues[pageParam], len(items))
-		pageValues[pageParam] = currentPage
+		sortHomeProcessList(items, sortKey)
+		currentPage := normalizeHomePage(page, len(items))
 		totalPages := 1
 		if len(items) > 0 {
 			totalPages = (len(items) + homeProcessesPerPage - 1) / homeProcessesPerPage
@@ -1846,41 +1819,25 @@ func buildHomeProcessGroups(workflowPath string, processes []StreamInstanceCard,
 		pageNumbers := make([]int, 0, totalPages)
 		pageLinks := make([]PaginationLink, 0, totalPages)
 		panelID := "stream-section-" + status
-		for page := 1; page <= totalPages; page++ {
-			pageNumbers = append(pageNumbers, page)
+		for pageNum := 1; pageNum <= totalPages; pageNum++ {
+			pageNumbers = append(pageNumbers, pageNum)
 			pageLinks = append(pageLinks, PaginationLink{
-				Page:      page,
-				URL:       homePaginationURL(workflowPath, sortValues, pageValues, pageParam, page, status),
-				IsCurrent: page == currentPage,
+				Page:      pageNum,
+				URL:       homePaginationURL(workflowPath, status, sortKey, pageNum),
+				IsCurrent: pageNum == currentPage,
 			})
 		}
 		previousPage := max(currentPage-1, 1)
 		nextPage := min(currentPage+1, totalPages)
-		sortFields := make([]QueryInput, 0, len(homeProcessStatuses())*2+1)
+		var sortFields []QueryInput
 		if status != "all" {
-			sortFields = append(sortFields, QueryInput{Name: "filter", Value: status})
-		}
-		for _, otherStatus := range homeProcessStatuses() {
-			otherSortParam := homeProcessStatusSortParam(otherStatus)
-			if otherSortParam != sortParam {
-				if otherSort := normalizeHomeSortKey(sortValues[otherSortParam]); otherSort != "time_desc" {
-					sortFields = append(sortFields, QueryInput{Name: otherSortParam, Value: otherSort})
-				}
-			}
-			otherPageParam := homeProcessStatusPageParam(otherStatus)
-			if otherPageParam != pageParam {
-				if otherPage := pageValues[otherPageParam]; otherPage > 1 {
-					sortFields = append(sortFields, QueryInput{Name: otherPageParam, Value: strconv.Itoa(otherPage)})
-				}
-			}
+			sortFields = []QueryInput{{Name: "filter", Value: status}}
 		}
 		groups = append(groups, ProcessStatusGroup{
 			Status:          status,
 			Label:           processStatusLabel(status),
 			PanelID:         panelID,
-			PageParam:       pageParam,
-			Sort:            groupSort,
-			SortParam:       sortParam,
+			Sort:            sortKey,
 			SortFields:      sortFields,
 			TotalCount:      len(items),
 			CurrentPage:     currentPage,
@@ -1891,8 +1848,8 @@ func buildHomeProcessGroups(workflowPath string, processes []StreamInstanceCard,
 			HasNextPage:     currentPage < totalPages,
 			PreviousPage:    previousPage,
 			NextPage:        nextPage,
-			PreviousURL:     homePaginationURL(workflowPath, sortValues, pageValues, pageParam, previousPage, status),
-			NextURL:         homePaginationURL(workflowPath, sortValues, pageValues, pageParam, nextPage, status),
+			PreviousURL:     homePaginationURL(workflowPath, status, sortKey, previousPage),
+			NextURL:         homePaginationURL(workflowPath, status, sortKey, nextPage),
 			Processes:       pagedItems,
 		})
 	}
@@ -4827,7 +4784,7 @@ func (s *Server) handleWorkflowHome(w http.ResponseWriter, r *http.Request) {
 
 	sortHomeProcessList(processes, sortKey)
 	sortHomeProcessList(filteredProcesses, sortKey)
-	processGroups := buildHomeProcessGroups(workflowPath(workflowKey), processes, sortKey, r.URL.Query())
+	processGroups := buildHomeProcessGroups(workflowPath(workflowKey), processes, sortKey, page)
 
 	currentPage := normalizeHomePage(page, len(filteredProcesses))
 	start := (currentPage - 1) * homeProcessesPerPage

--- a/server/cmd/server/panel_markup_test.go
+++ b/server/cmd/server/panel_markup_test.go
@@ -262,6 +262,8 @@ func TestStreamHomeBodyPanelMarkup(t *testing.T) {
 		`class="rail-layout rail-layout-ready"`,
 		`class="panel panel-sticky"`,
 		`class="stream-status-filter-nav"`,
+		`class="stream-status-filter-select"`,
+		`data-home-filter-select`,
 		`class="stream-status-filter-option is-active"`,
 		`class="status-tag status-tag-compact"`,
 		`data-stream-status="all"`,

--- a/server/cmd/server/panel_markup_test.go
+++ b/server/cmd/server/panel_markup_test.go
@@ -250,6 +250,7 @@ func TestStreamHomeBodyPanelMarkup(t *testing.T) {
 			WorkflowPath: "/w/workflow",
 			WorkflowName: "Demo workflow",
 		},
+		StatusFilter:  "all",
 		ProcessGroups: testHomeProcessGroups(),
 	}
 	if err := tmpl.ExecuteTemplate(&out, "home_body", view); err != nil {

--- a/server/templates/pages/stream.html
+++ b/server/templates/pages/stream.html
@@ -93,6 +93,24 @@
                 </button>
               {{ end }}
             </nav>
+            <select
+              id="stream-status-filter-select"
+              class="stream-status-filter-select"
+              aria-labelledby="stream-status-filter-label"
+              data-home-filter-select
+            >
+              <button type="button">
+                <selectedcontent></selectedcontent>
+              </button>
+              {{ range .ProcessGroups }}
+                <option
+                  value="{{ .Status }}"
+                  {{ if eq .Status $.StatusFilter }}selected{{ end }}
+                >
+                  {{ template "status_tag" .Status }}
+                </option>
+              {{ end }}
+            </select>
           </div>
           {{ range .ProcessGroups }}
             <form
@@ -378,6 +396,10 @@
             return defaultPanelName;
           };
 
+          const filterSelect = homeRoot.querySelector(
+            "[data-home-filter-select]",
+          );
+
           const showPanel = (panelName, options = {}) => {
             if (!statusPanelNames.includes(panelName)) {
               panelName = defaultPanelName;
@@ -398,6 +420,10 @@
               panel.hidden = currentName !== panelName;
             });
 
+            if (filterSelect && statusPanelNames.includes(panelName)) {
+              filterSelect.value = panelName;
+            }
+
             if (options.syncURL) {
               syncFilterURL(panelName);
             }
@@ -416,6 +442,15 @@
               });
             },
           );
+
+          if (filterSelect) {
+            filterSelect.addEventListener("change", () => {
+              showPanel(
+                (filterSelect.value || "").trim(),
+                { syncURL: true },
+              );
+            });
+          }
 
           showPanel(initialPanelName(), { syncURL: true });
         })();

--- a/server/templates/pages/stream.html
+++ b/server/templates/pages/stream.html
@@ -119,7 +119,7 @@
                 </span>
                 <select
                   id="stream-sort-{{ .Status }}"
-                  name="{{ .SortParam }}"
+                  name="sort"
                   onchange="this.form.submit()"
                 >
                   <option
@@ -354,6 +354,7 @@
               } else {
                 url.searchParams.delete("filter");
               }
+              url.searchParams.delete("page");
               url.hash = "";
               window.history.replaceState({}, "", url);
             } catch (_err) {}
@@ -374,12 +375,7 @@
               }
             }
 
-            const queryPanel = statusPanelNames.find((panelName) => {
-              return (
-                params.has(panelName + "_page") || params.has(panelName + "_sort")
-              );
-            });
-            return queryPanel || defaultPanelName;
+            return defaultPanelName;
           };
 
           const showPanel = (panelName, options = {}) => {

--- a/web/src/styles/pages/stream.css
+++ b/web/src/styles/pages/stream.css
@@ -224,6 +224,14 @@
 
 /* Single-column rail (< md): filter + sort side by side. */
 @media (--md-down) {
+  .stream-page.stack {
+    gap: var(--space-4);
+  }
+
+  .stream-page .rail-layout {
+    gap: var(--space-10);
+  }
+
   .stream-page .rail-layout-ready > .panel-sticky {
     display: flex;
     flex-direction: row;

--- a/web/src/styles/pages/stream.css
+++ b/web/src/styles/pages/stream.css
@@ -32,9 +32,24 @@
 }
 
 .stream-status-filter-nav {
-  display: flex;
+  display: none;
   flex-direction: column;
   width: 100%;
+}
+
+.stream-status-filter-select,
+.stream-status-sort-control select {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  font-family: inherit;
+  font-size: var(--text-sm);
+  line-height: 1.25;
+  padding: var(--space-2) var(--space-3);
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--foreground);
 }
 
 .stream-status-filter-option {
@@ -93,16 +108,86 @@
   font-size: var(--text-sm);
 }
 
-.stream-status-sort-control select {
-  width: 100%;
-  min-width: 0;
-  font-family: inherit;
-  font-size: var(--text-sm);
-  padding: var(--space-2) var(--space-3);
-  border-radius: 4px;
-  border: 1px solid var(--border);
-  background: var(--card);
-  color: var(--foreground);
+@supports (appearance: base-select) {
+  .stream-status-filter-select,
+  .stream-status-filter-select::picker(select) {
+    appearance: base-select;
+  }
+
+  .stream-status-filter-select {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    cursor: pointer;
+  }
+
+  .stream-status-filter-select:hover {
+    background: color-mix(in srgb, var(--primary) 8%, var(--card));
+  }
+
+  .stream-status-filter-select:open {
+    border-color: var(--primary);
+  }
+
+  .stream-status-filter-select::picker-icon {
+    color: var(--muted-foreground);
+  }
+
+  .stream-status-filter-select::picker(select) {
+    margin-top: var(--space-1);
+    padding: var(--space-1);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--card);
+    color: var(--foreground);
+  }
+
+  .stream-status-filter-select option {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    border-radius: 4px;
+    cursor: pointer;
+  }
+
+  .stream-status-filter-select option:hover,
+  .stream-status-filter-select option:focus-visible {
+    background: color-mix(in srgb, var(--primary) 8%, var(--card));
+  }
+
+  .stream-status-filter-select option:checked {
+    background: color-mix(in srgb, var(--primary) 12%, var(--card));
+  }
+
+  .stream-status-filter-select option::checkmark {
+    display: none;
+  }
+
+  .stream-status-filter-select selectedcontent {
+    display: inline-flex;
+    align-items: center;
+    min-width: 0;
+    line-height: 1.25;
+  }
+
+  .stream-status-filter-select selectedcontent .status-tag {
+    padding-block: 0;
+    line-height: inherit;
+    /* Inset ring stays inside the tag box so the select does not clip it. */
+    border: 0;
+    box-shadow: inset 0 0 0 1px var(--stream-color);
+  }
+}
+
+@media (--md-up) {
+  .stream-status-filter-nav {
+    display: flex;
+  }
+
+  .stream-status-filter-select {
+    display: none;
+  }
 }
 
 #stream-preview-dialog.dialog {
@@ -146,19 +231,21 @@
     gap: var(--space-8);
   }
 
-  .stream-page .stream-status-filter {
+  .stream-page .stream-status-filter,
+  .stream-page .stream-status-sort {
     width: auto;
     flex: 0 0 auto;
+    min-width: 0;
   }
 
   .stream-page .stream-status-sort {
     margin-top: 0;
-    width: auto;
-    flex: 0 0 auto;
   }
 
   .stream-page .stream-status-sort-control,
-  .stream-page .stream-status-sort-control select {
+  .stream-page .stream-status-sort-control select,
+  .stream-page .stream-status-filter-select {
     width: auto;
+    min-width: 10rem;
   }
 }


### PR DESCRIPTION
## Summary
- Collapse per-status `*_sort` / `*_page` into shared `?filter=&sort=&page=` on the stream dashboard
- Add a small-screen status `<select>` (customizable `base-select`) as a twin of the button filter nav, with client-side sync only
- Tighten mobile vertical gaps on the stream stack and rail

## Test plan
- [ ] Open `/w/:key/` and confirm sort/pagination URLs use `?sort=` / `?page=` (no `active_sort`, `done_page`, etc.)
- [ ] Change filter (buttons on desktop); URL keeps `sort`, clears `page`
- [ ] On a narrow viewport, status filter appears as a select; changing it updates the visible panel and `?filter=`
- [ ] Filter and sort selects match height/width on mobile; status tag ring is not clipped
- [ ] `go test ./cmd/server/ -run 'Home|Stream|PanelMarkup' -count=1`


Made with [Cursor](https://cursor.com)