### PR TITLE
feat(ui): HTMX filter, sort, and pagination on stream dashboard

### DIFF
--- a/server/cmd/server/dialog_markup_test.go
+++ b/server/cmd/server/dialog_markup_test.go
@@ -16,7 +16,10 @@ func TestStreamPageNewInstanceDialogMarkup(t *testing.T) {
 			WorkflowPath: "/w/workflow",
 			WorkflowName: "Demo workflow",
 		},
-		ProcessGroups: testHomeProcessGroups(),
+		StatusFilter:  "all",
+		Sort:          "time_desc",
+		FilterOptions: testHomeFilterOptions(),
+		ProcessGroups: testHomeActiveProcessGroups(nil, "all", "time_desc", 1),
 	}
 	if err := tmpl.ExecuteTemplate(&out, "home_body", view); err != nil {
 		t.Fatalf("render home_body: %v", err)
@@ -175,7 +178,10 @@ func TestStreamPreviewDialogPageScopedMarkup(t *testing.T) {
 			WorkflowPath: "/w/workflow",
 			WorkflowName: "Demo workflow",
 		},
-		ProcessGroups: testHomeProcessGroups(),
+		StatusFilter:  "all",
+		Sort:          "time_desc",
+		FilterOptions: testHomeFilterOptions(),
+		ProcessGroups: testHomeActiveProcessGroups(nil, "all", "time_desc", 1),
 	}
 	if err := tmpl.ExecuteTemplate(&out, "home_body", view); err != nil {
 		t.Fatalf("render home_body: %v", err)

--- a/server/cmd/server/home_handler_test.go
+++ b/server/cmd/server/home_handler_test.go
@@ -1275,6 +1275,239 @@ func TestHandleWorkflowHomeUsesHumanReadableProcessDates(t *testing.T) {
 	}
 }
 
+func TestHandleWorkflowHomeHTMXReturnsPartial(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 2, 3, 12, 0, 0, 0, time.UTC)
+
+	activeID := primitive.NewObjectID()
+	active := Process{
+		ID:          activeID,
+		WorkflowKey: "workflow",
+		Name:        "Pilot batch",
+		CreatedAt:   now.Add(-2 * time.Hour),
+		Status:      "",
+		Progress: map[string]ProcessStep{
+			"1_1": {State: "done", DoneAt: ptrTime(now.Add(-110 * time.Minute))},
+			"1_2": {State: "done", DoneAt: ptrTime(now.Add(-100 * time.Minute)), Data: map[string]interface{}{"note": "alpha"}},
+			"1_3": {State: "pending"},
+			"2_1": {State: "pending"},
+			"2_2": {State: "pending"},
+			"3_1": {State: "pending"},
+			"3_2": {State: "pending"},
+		},
+	}
+
+	doneID := primitive.NewObjectID()
+	done := Process{
+		ID:          doneID,
+		WorkflowKey: "workflow",
+		CreatedAt:   now.Add(-1 * time.Hour),
+		Status:      "active",
+		Progress: map[string]ProcessStep{
+			"1_1": {State: "done", DoneAt: ptrTime(now.Add(-70 * time.Minute))},
+			"1_2": {State: "done", DoneAt: ptrTime(now.Add(-60 * time.Minute))},
+			"1_3": {State: "done", DoneAt: ptrTime(now.Add(-50 * time.Minute))},
+			"2_1": {State: "done", DoneAt: ptrTime(now.Add(-40 * time.Minute))},
+			"2_2": {State: "done", DoneAt: ptrTime(now.Add(-30 * time.Minute))},
+			"3_1": {State: "done", DoneAt: ptrTime(now.Add(-20 * time.Minute))},
+			"3_2": {State: "done", DoneAt: ptrTime(now.Add(-10 * time.Minute))},
+		},
+	}
+
+	store.SeedProcess(active)
+	store.SeedProcess(done)
+
+	server := &Server{
+		authorizer: fakeAuthorizer{},
+		store:      store,
+		tmpl:       homeTestTemplates(),
+		configProvider: func() (RuntimeConfig, error) {
+			cfg := testRuntimeConfig()
+			cfg.Workflow.Description = "Demo workflow description"
+			return cfg, nil
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/w/workflow/", nil)
+	req.Header.Set("HX-Request", "true")
+	req = req.WithContext(context.WithValue(req.Context(), workflowContextKey{}, workflowContextValue{
+		Key: "workflow",
+		Cfg: testRuntimeConfig(),
+	}))
+	rec := httptest.NewRecorder()
+	server.handleWorkflowHome(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `id="stream-dashboard-results"`) {
+		t.Fatalf("expected HTMX results root, got %q", body)
+	}
+	if strings.Contains(body, "data-home-root") {
+		t.Fatalf("did not expect full page chrome in HTMX partial, got %q", body)
+	}
+	if !strings.Contains(body, "PROC 2 SORT time_desc FILTER all") {
+		t.Fatalf("expected active process list in partial, got %q", body)
+	}
+	if !strings.Contains(body, activeID.Hex()+":Pilot batch:available:28") {
+		t.Fatalf("expected process in HTMX partial, got %q", body)
+	}
+}
+
+func TestHandleWorkflowHomeHTMXFiltersAndPaginates(t *testing.T) {
+	store := NewMemoryStore()
+	base := time.Date(2026, 2, 3, 12, 0, 0, 0, time.UTC)
+
+	activeID := primitive.NewObjectID()
+	store.SeedProcess(Process{
+		ID:          activeID,
+		WorkflowKey: "workflow",
+		CreatedAt:   base.Add(-2 * time.Hour),
+		Status:      "active",
+		Progress: map[string]ProcessStep{
+			"1_1": {State: "done", DoneAt: ptrTime(base.Add(-110 * time.Minute))},
+		},
+	})
+
+	doneID := primitive.NewObjectID()
+	store.SeedProcess(Process{
+		ID:          doneID,
+		WorkflowKey: "workflow",
+		CreatedAt:   base.Add(-1 * time.Hour),
+		Status:      "done",
+		Progress: map[string]ProcessStep{
+			"1_1": {State: "done", DoneAt: ptrTime(base.Add(-70 * time.Minute))},
+			"1_2": {State: "done", DoneAt: ptrTime(base.Add(-60 * time.Minute))},
+			"1_3": {State: "done", DoneAt: ptrTime(base.Add(-50 * time.Minute))},
+			"2_1": {State: "done", DoneAt: ptrTime(base.Add(-40 * time.Minute))},
+			"2_2": {State: "done", DoneAt: ptrTime(base.Add(-30 * time.Minute))},
+			"3_1": {State: "done", DoneAt: ptrTime(base.Add(-20 * time.Minute))},
+			"3_2": {State: "done", DoneAt: ptrTime(base.Add(-10 * time.Minute))},
+		},
+	})
+
+	server := &Server{
+		authorizer: fakeAuthorizer{},
+		store:      store,
+		tmpl:       homeTestTemplates(),
+		configProvider: func() (RuntimeConfig, error) {
+			return testRuntimeConfig(), nil
+		},
+	}
+
+	t.Run("filter", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/w/workflow/?filter=done", nil)
+		req.Header.Set("HX-Request", "true")
+		req = req.WithContext(context.WithValue(req.Context(), workflowContextKey{}, workflowContextValue{
+			Key: "workflow",
+			Cfg: testRuntimeConfig(),
+		}))
+		rec := httptest.NewRecorder()
+		server.handleWorkflowHome(rec, req)
+
+		body := rec.Body.String()
+		if !strings.Contains(body, "PROC 1 SORT time_desc FILTER done") {
+			t.Fatalf("expected done filter in HTMX partial, got %q", body)
+		}
+		if !strings.Contains(body, doneID.Hex()+"::done:100") {
+			t.Fatalf("expected done process in HTMX partial, got %q", body)
+		}
+		if strings.Contains(body, activeID.Hex()+"::active") {
+			t.Fatalf("did not expect active process in done HTMX partial, got %q", body)
+		}
+	})
+
+	t.Run("page", func(t *testing.T) {
+		pageStore := NewMemoryStore()
+		pageBase := time.Date(2026, 2, 3, 12, 0, 0, 0, time.UTC)
+		expectedPageTwoID := ""
+		for i := 0; i < homeProcessesPerPage+1; i++ {
+			processID := primitive.NewObjectID()
+			if i == homeProcessesPerPage {
+				expectedPageTwoID = processID.Hex()
+			}
+			pageStore.SeedProcess(Process{
+				ID:          processID,
+				WorkflowKey: "workflow",
+				CreatedAt:   pageBase.Add(-time.Duration(i) * time.Minute),
+				Status:      "active",
+				Progress: map[string]ProcessStep{
+					"1_1": {State: "done", DoneAt: ptrTime(pageBase.Add(-time.Duration(i) * time.Minute))},
+				},
+			})
+		}
+		pageServer := &Server{
+			authorizer: fakeAuthorizer{},
+			store:      pageStore,
+			tmpl:       homeTestTemplates(),
+			configProvider: func() (RuntimeConfig, error) {
+				return testRuntimeConfig(), nil
+			},
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/w/workflow/?page=2", nil)
+		req.Header.Set("HX-Request", "true")
+		req = req.WithContext(context.WithValue(req.Context(), workflowContextKey{}, workflowContextValue{
+			Key: "workflow",
+			Cfg: testRuntimeConfig(),
+		}))
+		rec := httptest.NewRecorder()
+		pageServer.handleWorkflowHome(rec, req)
+
+		body := rec.Body.String()
+		if !strings.Contains(body, "PROC 1 SORT time_desc FILTER all PAGE 2/2") {
+			t.Fatalf("expected paginated all filter in HTMX partial, got %q", body)
+		}
+		if !strings.Contains(body, expectedPageTwoID+"::available") {
+			t.Fatalf("expected last process on page 2, got %q", body)
+		}
+	})
+}
+
+func TestBuildHomeFilterOptionsIncludesAllStatuses(t *testing.T) {
+	options := buildHomeFilterOptions([]StreamInstanceCard{
+		{ID: "1", Status: "active"},
+		{ID: "2", Status: "done"},
+		{ID: "3", Status: "available"},
+	})
+	if len(options) != len(homeProcessStatuses()) {
+		t.Fatalf("expected %d filter options, got %d", len(homeProcessStatuses()), len(options))
+	}
+	for _, option := range options {
+		if len(option.Processes) != 0 {
+			t.Fatalf("expected empty processes on filter option %q, got %d", option.Status, len(option.Processes))
+		}
+		if option.PanelID == "" || option.NavAriaLabel == "" || option.NavTitle == "" {
+			t.Fatalf("expected nav metadata on filter option %q, got %#v", option.Status, option)
+		}
+	}
+	var allOption *ProcessStatusGroup
+	for i := range options {
+		if options[i].Status == "all" {
+			allOption = &options[i]
+			break
+		}
+	}
+	if allOption == nil || allOption.TotalCount != 3 {
+		t.Fatalf("expected all filter count 3, got %#v", allOption)
+	}
+}
+
+func TestBuildHomeActiveProcessGroupBuildsSingleStatus(t *testing.T) {
+	group := buildHomeActiveProcessGroup("/w/workflow", []StreamInstanceCard{
+		{ID: "1", Status: "active"},
+		{ID: "2", Status: "done"},
+	}, "done", "time_desc", 1)
+	if group.Status != "done" {
+		t.Fatalf("expected done group, got %q", group.Status)
+	}
+	if len(group.Processes) != 1 || group.Processes[0].ID != "2" {
+		t.Fatalf("expected one done process, got %#v", group.Processes)
+	}
+}
+
 func homeTestTemplates() *template.Template {
 	return template.Must(template.New("test").Parse(`
 {{define "layout.html"}}{{template "home_body" .}}{{end}}
@@ -1283,6 +1516,12 @@ func homeTestTemplates() *template.Template {
 PROCESSES {{range .Processes}}{{.ID}}:{{.Name}}:{{.Status}}:{{.Percent}}|{{end}}{{ end }}{{ end }}
 {{end}}
 {{define "stream.html"}}{{template "layout.html" .}}{{end}}
+{{define "stream_dashboard_results"}}
+<div id="stream-dashboard-results">
+{{ $filter := .StatusFilter }}{{ range .ProcessGroups }}{{ if eq .Status $filter }}PROC {{len .Processes}} SORT {{.Sort}} FILTER {{$filter}} PAGE {{.CurrentPage}}/{{.TotalPages}}
+PROCESSES {{range .Processes}}{{.ID}}:{{.Name}}:{{.Status}}:{{.Percent}}|{{end}}{{ end }}{{ end }}
+</div>
+{{end}}
 `))
 }
 

--- a/server/cmd/server/home_template_preview_test.go
+++ b/server/cmd/server/home_template_preview_test.go
@@ -20,57 +20,14 @@ func testHomeActiveProcessGroups(items []StreamInstanceCard, statusFilter, sortK
 	return []ProcessStatusGroup{buildHomeActiveProcessGroup("/w/workflow", items, statusFilter, sortKey, page)}
 }
 
-func testHomeProcessGroups(items ...StreamInstanceCard) []ProcessStatusGroup {
-	byStatus := map[string][]StreamInstanceCard{}
-	for _, item := range items {
-		byStatus[item.Status] = append(byStatus[item.Status], item)
-	}
-	groups := make([]ProcessStatusGroup, 0, len(homeProcessStatuses()))
-	for _, status := range homeProcessStatuses() {
-		processes := byStatus[status]
-		if status == "all" {
-			processes = append([]StreamInstanceCard(nil), items...)
-		}
-		totalPages := 1
-		panelURL := "/w/workflow/"
-		if status != "all" {
-			panelURL = "/w/workflow/?filter=" + status
-		}
-		pageLinks := []PaginationLink{{Page: 1, URL: panelURL, IsCurrent: true}}
-		var sortFields []QueryInput
-		if status != "all" {
-			sortFields = []QueryInput{{Name: "filter", Value: status}}
-		}
-		navAriaLabel, navTitle, heading, emptyMessage, paginationAriaLabel := homeProcessStatusCopy(status)
-		groups = append(groups, ProcessStatusGroup{
-			Status:              status,
-			Label:               processStatusLabel(status),
-			NavAriaLabel:        navAriaLabel,
-			NavTitle:            navTitle,
-			Heading:             heading,
-			EmptyMessage:        emptyMessage,
-			PaginationAriaLabel: paginationAriaLabel,
-			PanelID:             "stream-section-" + status,
-			TotalCount:          len(processes),
-			Sort:                "time_desc",
-			SortFields:          sortFields,
-			CurrentPage:         1,
-			TotalPages:          totalPages,
-			PageNumbers:         []int{1},
-			PageLinks:           pageLinks,
-			PreviousURL:         panelURL,
-			NextURL:             panelURL,
-			Processes:           processes,
-		})
-	}
-	return groups
+func testHomeActiveGroup(statusFilter string, items ...StreamInstanceCard) []ProcessStatusGroup {
+	return testHomeActiveProcessGroups(items, statusFilter, "time_desc", 1)
 }
 
 func TestHomeTemplateRendersSidebarAndReadOnlyPreview(t *testing.T) {
 	tmpl := parseTestTemplates(t)
 
 	process := StreamInstanceCard{ID: "process-1", Name: "Pilot batch", Status: "active", DetailHref: "/w/workflow/process/process-1", Percent: 25, DoneSubsteps: 1, TotalSubsteps: 4, CreatedAt: "1 Mar 2026 at 10:00 UTC"}
-	items := []StreamInstanceCard{process}
 	view := HomeView{
 		PageBase: PageBase{
 			WorkflowKey:  "workflow",
@@ -78,10 +35,10 @@ func TestHomeTemplateRendersSidebarAndReadOnlyPreview(t *testing.T) {
 			WorkflowName: "Demo workflow",
 		},
 		WorkflowDescription: "Previewable workflow",
-		StatusFilter:        "all",
 		Sort:                "time_desc",
-		FilterOptions:       testHomeFilterOptions(items...),
-		ProcessGroups:       testHomeActiveProcessGroups(items, "all", "time_desc", 1),
+		StatusFilter:        "all",
+		FilterOptions:       testHomeFilterOptions(process),
+		ProcessGroups:       testHomeActiveGroup("all", process),
 		Preview: StreamInstanceDetailView{
 			HideStatus: true,
 			Timeline: []TimelineStep{
@@ -121,11 +78,8 @@ func TestHomeTemplateRendersSidebarAndReadOnlyPreview(t *testing.T) {
 
 	for _, marker := range []string{
 		`id="stream-dashboard-results"`,
-		`hx-get="/w/workflow/"`,
-		`filter=available`,
-		`filter=active`,
-		`filter=done`,
-		`filter=terminated`,
+		`hx-target="#stream-dashboard-results"`,
+		`hx-push-url="true"`,
 		`id="stream-preview-dialog"`,
 		`class="dialog-card"`,
 		`class="stream-preview-body"`,
@@ -144,13 +98,28 @@ func TestHomeTemplateRendersSidebarAndReadOnlyPreview(t *testing.T) {
 		!strings.Contains(compactBody, `Filter by status`) {
 		t.Fatalf("expected stream status filter label, got: %s", body)
 	}
+	for _, status := range []string{"all", "available", "active", "done", "terminated"} {
+		if !strings.Contains(compactBody, `aria-controls="stream-section-`+status+`"`) {
+			t.Fatalf("expected filter option for %q, got: %s", status, body)
+		}
+	}
+	if !strings.Contains(compactBody, `id="stream-section-all"`) {
+		t.Fatalf("expected active all section, got: %s", body)
+	}
+	for _, status := range []string{"available", "active", "done", "terminated"} {
+		if strings.Contains(compactBody, `id="stream-section-`+status+`"`) {
+			t.Fatalf("did not expect inactive section %q in HTMX results, got: %s", status, body)
+		}
+	}
 	for _, marker := range []string{
-		`id="stream-section-all"`,
-		`class="stream-status-filter-option is-active"`,
-		`hx-target="#stream-dashboard-results"`,
+		`data-home-root`,
+		`data-home-nav=`,
+		`panels.forEach((panel)`,
+		`panel.hidden = currentName !== panelName`,
+		`url.searchParams.set("filter", panelName)`,
 	} {
-		if !strings.Contains(compactBody, marker) {
-			t.Fatalf("expected stream dashboard HTMX marker %q, got: %s", marker, body)
+		if strings.Contains(body, marker) {
+			t.Fatalf("did not expect legacy client panel marker %q, got: %s", marker, body)
 		}
 	}
 	if strings.Contains(body, `scrollIntoView`) {
@@ -178,10 +147,10 @@ func TestHomeTemplateRendersEmptyStatusSections(t *testing.T) {
 			WorkflowName: "Demo workflow",
 		},
 		WorkflowDescription: "Previewable workflow",
-		StatusFilter:        "all",
 		Sort:                "time_desc",
+		StatusFilter:        "all",
 		FilterOptions:       testHomeFilterOptions(),
-		ProcessGroups:       testHomeActiveProcessGroups(nil, "all", "time_desc", 1),
+		ProcessGroups:       testHomeActiveGroup("all"),
 	}
 
 	var out bytes.Buffer
@@ -191,16 +160,18 @@ func TestHomeTemplateRendersEmptyStatusSections(t *testing.T) {
 	body := out.String()
 	compactBody := strings.Join(strings.Fields(body), " ")
 
-	for _, marker := range []string{
-		`No instances`,
-	} {
-		if !strings.Contains(compactBody, marker) {
-			t.Fatalf("expected empty status marker %q, got: %s", marker, body)
-		}
+	if !strings.Contains(compactBody, `No instances`) {
+		t.Fatalf("expected empty all-status marker, got: %s", body)
 	}
-	if !strings.Contains(compactBody, `filter=available`) ||
-		!strings.Contains(compactBody, `filter=done`) {
-		t.Fatalf("expected filter nav links for all statuses, got: %s", body)
+	for _, marker := range []string{
+		`No available instances`,
+		`No active instances`,
+		`No completed instances`,
+		`No terminated instances`,
+	} {
+		if strings.Contains(compactBody, marker) {
+			t.Fatalf("did not expect inactive empty marker %q, got: %s", marker, body)
+		}
 	}
 }
 
@@ -213,11 +184,9 @@ func TestHomeTemplateRendersStatusPagination(t *testing.T) {
 			WorkflowPath: "/w/workflow",
 			WorkflowName: "Demo workflow",
 		},
-		Sort:         "status",
-		StatusFilter: "active",
-		FilterOptions: buildHomeFilterOptions([]StreamInstanceCard{
-			{ID: "process-13", Status: "active"},
-		}),
+		Sort:          "status",
+		StatusFilter:  "active",
+		FilterOptions: testHomeFilterOptions(),
 		ProcessGroups: []ProcessStatusGroup{
 			{
 				Status:              "active",
@@ -257,6 +226,9 @@ func TestHomeTemplateRendersStatusPagination(t *testing.T) {
 	if !strings.Contains(compactBody, `/w/workflow/?filter=active&amp;page=3&amp;sort=status`) {
 		t.Fatalf("expected pagination to preserve filter, sort and page, got: %s", body)
 	}
+	if !strings.Contains(compactBody, `hx-get="/w/workflow/?filter=active&amp;page=3&amp;sort=status"`) {
+		t.Fatalf("expected pagination hx-get, got: %s", body)
+	}
 	if !strings.Contains(compactBody, `name="sort"`) {
 		t.Fatalf("expected global sort select, got: %s", body)
 	}
@@ -290,41 +262,30 @@ func TestHomeTemplateRendersStatusPagination(t *testing.T) {
 	if strings.Contains(compactBody, `#stream-section-`) {
 		t.Fatalf("did not expect hash anchors on pagination links, got: %s", body)
 	}
-	if !strings.Contains(compactBody, `hx-get="/w/workflow/?filter=active&amp;page=3&amp;sort=status"`) {
-		t.Fatalf("expected HTMX pagination link, got: %s", body)
-	}
 }
 
 func TestHomeTemplateHighlightsProcessWhenItIsUsersTurn(t *testing.T) {
 	tmpl := parseTestTemplates(t)
 
+	item := StreamInstanceCard{
+		ID:            "process-1",
+		Status:        "available",
+		DetailHref:    "/w/workflow/process/process-1",
+		Percent:       25,
+		DoneSubsteps:  1,
+		TotalSubsteps: 4,
+		CreatedAt:     "1 Mar 2026 at 10:00 UTC",
+	}
 	view := HomeView{
 		PageBase: PageBase{
 			WorkflowKey:  "workflow",
 			WorkflowPath: "/w/workflow",
 			WorkflowName: "Demo workflow",
 		},
-		StatusFilter: "all",
-		FilterOptions: testHomeFilterOptions(StreamInstanceCard{
-			ID:            "process-1",
-			Status:        "available",
-			DetailHref:    "/w/workflow/process/process-1",
-			Percent:       25,
-			DoneSubsteps:  1,
-			TotalSubsteps: 4,
-			CreatedAt:     "1 Mar 2026 at 10:00 UTC",
-		}),
-		ProcessGroups: testHomeActiveProcessGroups([]StreamInstanceCard{
-			{
-				ID:            "process-1",
-				Status:        "available",
-				DetailHref:    "/w/workflow/process/process-1",
-				Percent:       25,
-				DoneSubsteps:  1,
-				TotalSubsteps: 4,
-				CreatedAt:     "1 Mar 2026 at 10:00 UTC",
-			},
-		}, "all", "time_desc", 1),
+		Sort:          "time_desc",
+		StatusFilter:  "all",
+		FilterOptions: testHomeFilterOptions(item),
+		ProcessGroups: testHomeActiveGroup("all", item),
 	}
 
 	var out bytes.Buffer

--- a/server/cmd/server/home_template_preview_test.go
+++ b/server/cmd/server/home_template_preview_test.go
@@ -6,6 +6,20 @@ import (
 	"testing"
 )
 
+func testHomeFilterOptions(items ...StreamInstanceCard) []ProcessStatusGroup {
+	return buildHomeFilterOptions(items)
+}
+
+func testHomeActiveProcessGroups(items []StreamInstanceCard, statusFilter, sortKey string, page int) []ProcessStatusGroup {
+	if sortKey == "" {
+		sortKey = "time_desc"
+	}
+	if statusFilter == "" {
+		statusFilter = "all"
+	}
+	return []ProcessStatusGroup{buildHomeActiveProcessGroup("/w/workflow", items, statusFilter, sortKey, page)}
+}
+
 func testHomeProcessGroups(items ...StreamInstanceCard) []ProcessStatusGroup {
 	byStatus := map[string][]StreamInstanceCard{}
 	for _, item := range items {
@@ -56,6 +70,7 @@ func TestHomeTemplateRendersSidebarAndReadOnlyPreview(t *testing.T) {
 	tmpl := parseTestTemplates(t)
 
 	process := StreamInstanceCard{ID: "process-1", Name: "Pilot batch", Status: "active", DetailHref: "/w/workflow/process/process-1", Percent: 25, DoneSubsteps: 1, TotalSubsteps: 4, CreatedAt: "1 Mar 2026 at 10:00 UTC"}
+	items := []StreamInstanceCard{process}
 	view := HomeView{
 		PageBase: PageBase{
 			WorkflowKey:  "workflow",
@@ -64,7 +79,9 @@ func TestHomeTemplateRendersSidebarAndReadOnlyPreview(t *testing.T) {
 		},
 		WorkflowDescription: "Previewable workflow",
 		StatusFilter:        "all",
-		ProcessGroups:       testHomeProcessGroups(process),
+		Sort:                "time_desc",
+		FilterOptions:       testHomeFilterOptions(items...),
+		ProcessGroups:       testHomeActiveProcessGroups(items, "all", "time_desc", 1),
 		Preview: StreamInstanceDetailView{
 			HideStatus: true,
 			Timeline: []TimelineStep{
@@ -103,19 +120,18 @@ func TestHomeTemplateRendersSidebarAndReadOnlyPreview(t *testing.T) {
 	compactBody := strings.Join(strings.Fields(body), " ")
 
 	for _, marker := range []string{
-		`data-home-nav="all"`,
-		`data-home-nav="available"`,
-		`data-home-nav="active"`,
-		`data-home-nav="done"`,
-		`data-home-nav="terminated"`,
-		`data-home-nav="preview"`,
+		`id="stream-dashboard-results"`,
+		`hx-get="/w/workflow/"`,
+		`filter=available`,
+		`filter=active`,
+		`filter=done`,
+		`filter=terminated`,
 		`id="stream-preview-dialog"`,
 		`class="dialog-card"`,
 		`class="stream-preview-body"`,
 		`id="new-instance-dialog"`,
 		`name="name"`,
 		`Pilot batch`,
-		`data-home-root`,
 		`data-formata-disabled="true"`,
 		`Preview only. Start an instance to submit data.`,
 	} {
@@ -124,23 +140,17 @@ func TestHomeTemplateRendersSidebarAndReadOnlyPreview(t *testing.T) {
 		}
 	}
 	if !strings.Contains(compactBody, `aria-labelledby="stream-status-filter-label"`) ||
-		!strings.Contains(compactBody, `data-home-filter-select`) ||
 		!strings.Contains(compactBody, `class="stream-status-filter-select"`) ||
 		!strings.Contains(compactBody, `Filter by status`) {
 		t.Fatalf("expected stream status filter label, got: %s", body)
 	}
 	for _, marker := range []string{
-		`id="stream-section-all" data-home-panel="all"`,
-		`id="stream-section-available" data-home-panel="available" hidden`,
-		`id="stream-section-active" data-home-panel="active" hidden`,
-		`id="stream-section-done" data-home-panel="done" hidden`,
-		`id="stream-section-terminated" data-home-panel="terminated" hidden`,
-		`panels.forEach((panel)`,
-		`panel.hidden = currentName !== panelName`,
-		`url.searchParams.set("filter", panelName)`,
+		`id="stream-section-all"`,
+		`class="stream-status-filter-option is-active"`,
+		`hx-target="#stream-dashboard-results"`,
 	} {
 		if !strings.Contains(compactBody, marker) {
-			t.Fatalf("expected single visible stream status marker %q, got: %s", marker, body)
+			t.Fatalf("expected stream dashboard HTMX marker %q, got: %s", marker, body)
 		}
 	}
 	if strings.Contains(body, `scrollIntoView`) {
@@ -169,7 +179,9 @@ func TestHomeTemplateRendersEmptyStatusSections(t *testing.T) {
 		},
 		WorkflowDescription: "Previewable workflow",
 		StatusFilter:        "all",
-		ProcessGroups:       testHomeProcessGroups(),
+		Sort:                "time_desc",
+		FilterOptions:       testHomeFilterOptions(),
+		ProcessGroups:       testHomeActiveProcessGroups(nil, "all", "time_desc", 1),
 	}
 
 	var out bytes.Buffer
@@ -181,14 +193,14 @@ func TestHomeTemplateRendersEmptyStatusSections(t *testing.T) {
 
 	for _, marker := range []string{
 		`No instances`,
-		`No available instances`,
-		`No active instances`,
-		`No completed instances`,
-		`No terminated instances`,
 	} {
 		if !strings.Contains(compactBody, marker) {
 			t.Fatalf("expected empty status marker %q, got: %s", marker, body)
 		}
+	}
+	if !strings.Contains(compactBody, `filter=available`) ||
+		!strings.Contains(compactBody, `filter=done`) {
+		t.Fatalf("expected filter nav links for all statuses, got: %s", body)
 	}
 }
 
@@ -203,46 +215,10 @@ func TestHomeTemplateRendersStatusPagination(t *testing.T) {
 		},
 		Sort:         "status",
 		StatusFilter: "active",
+		FilterOptions: buildHomeFilterOptions([]StreamInstanceCard{
+			{ID: "process-13", Status: "active"},
+		}),
 		ProcessGroups: []ProcessStatusGroup{
-			{
-				Status:              "all",
-				Label:               "All",
-				NavAriaLabel:        "All streams",
-				NavTitle:            "All stream instances",
-				Heading:             "All stream instances",
-				EmptyMessage:        "No instances",
-				PaginationAriaLabel: "All stream instances pagination",
-				PanelID:             "stream-section-all",
-				TotalCount:          0,
-				Sort:                "status",
-				CurrentPage:         1,
-				TotalPages:          1,
-				PageNumbers:         []int{1},
-				PageLinks:           []PaginationLink{{Page: 1, URL: "/w/workflow/?sort=status", IsCurrent: true}},
-				PreviousURL:         "/w/workflow/?sort=status",
-				NextURL:             "/w/workflow/?sort=status",
-				Processes:           nil,
-			},
-			{
-				Status:              "available",
-				Label:               "Available",
-				NavAriaLabel:        "Available streams",
-				NavTitle:            "Streams waiting for your input",
-				Heading:             "Available stream instances",
-				EmptyMessage:        "No available instances",
-				PaginationAriaLabel: "Available stream instances pagination",
-				PanelID:             "stream-section-available",
-				TotalCount:          0,
-				Sort:                "status",
-				SortFields:          []QueryInput{{Name: "filter", Value: "available"}},
-				CurrentPage:         1,
-				TotalPages:          1,
-				PageNumbers:         []int{1},
-				PageLinks:           []PaginationLink{{Page: 1, URL: "/w/workflow/?filter=available&sort=status", IsCurrent: true}},
-				PreviousURL:         "/w/workflow/?filter=available&sort=status",
-				NextURL:             "/w/workflow/?filter=available&sort=status",
-				Processes:           nil,
-			},
 			{
 				Status:              "active",
 				Label:               "Active",
@@ -314,6 +290,9 @@ func TestHomeTemplateRendersStatusPagination(t *testing.T) {
 	if strings.Contains(compactBody, `#stream-section-`) {
 		t.Fatalf("did not expect hash anchors on pagination links, got: %s", body)
 	}
+	if !strings.Contains(compactBody, `hx-get="/w/workflow/?filter=active&amp;page=3&amp;sort=status"`) {
+		t.Fatalf("expected HTMX pagination link, got: %s", body)
+	}
 }
 
 func TestHomeTemplateHighlightsProcessWhenItIsUsersTurn(t *testing.T) {
@@ -326,7 +305,7 @@ func TestHomeTemplateHighlightsProcessWhenItIsUsersTurn(t *testing.T) {
 			WorkflowName: "Demo workflow",
 		},
 		StatusFilter: "all",
-		ProcessGroups: testHomeProcessGroups(StreamInstanceCard{
+		FilterOptions: testHomeFilterOptions(StreamInstanceCard{
 			ID:            "process-1",
 			Status:        "available",
 			DetailHref:    "/w/workflow/process/process-1",
@@ -335,6 +314,17 @@ func TestHomeTemplateHighlightsProcessWhenItIsUsersTurn(t *testing.T) {
 			TotalSubsteps: 4,
 			CreatedAt:     "1 Mar 2026 at 10:00 UTC",
 		}),
+		ProcessGroups: testHomeActiveProcessGroups([]StreamInstanceCard{
+			{
+				ID:            "process-1",
+				Status:        "available",
+				DetailHref:    "/w/workflow/process/process-1",
+				Percent:       25,
+				DoneSubsteps:  1,
+				TotalSubsteps: 4,
+				CreatedAt:     "1 Mar 2026 at 10:00 UTC",
+			},
+		}, "all", "time_desc", 1),
 	}
 
 	var out bytes.Buffer

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -355,6 +355,7 @@ type HomeView struct {
 	Error               string
 	Sort                string
 	StatusFilter        string
+	FilterOptions       []ProcessStatusGroup
 	ProcessGroups       []ProcessStatusGroup
 	Preview             StreamInstanceDetailView
 }
@@ -1805,77 +1806,113 @@ func homePaginationURL(workflowPath, filter, sort string, page int) string {
 	return target
 }
 
-func buildHomeProcessGroups(workflowPath string, processes []StreamInstanceCard, sortKey string, page int) []ProcessStatusGroup {
-	sortKey = normalizeHomeSortKey(sortKey)
+func homeProcessesByStatus(processes []StreamInstanceCard) map[string][]StreamInstanceCard {
 	byStatus := make(map[string][]StreamInstanceCard, len(homeProcessStatuses()))
 	for _, process := range processes {
 		byStatus[process.Status] = append(byStatus[process.Status], process)
 	}
+	return byStatus
+}
 
+func homeProcessItemsForStatus(processes []StreamInstanceCard, byStatus map[string][]StreamInstanceCard, status string) []StreamInstanceCard {
+	if status == "all" {
+		return append([]StreamInstanceCard(nil), processes...)
+	}
+	items := byStatus[status]
+	if len(items) == 0 {
+		return nil
+	}
+	return append([]StreamInstanceCard(nil), items...)
+}
+
+func buildHomeProcessGroupForStatus(workflowPath string, processes []StreamInstanceCard, byStatus map[string][]StreamInstanceCard, status, sortKey string, page int) ProcessStatusGroup {
+	sortKey = normalizeHomeSortKey(sortKey)
+	items := homeProcessItemsForStatus(processes, byStatus, status)
+	sortHomeProcessList(items, sortKey)
+	currentPage := normalizeHomePage(page, len(items))
+	totalPages := 1
+	if len(items) > 0 {
+		totalPages = (len(items) + homeProcessesPerPage - 1) / homeProcessesPerPage
+	}
+	start := (currentPage - 1) * homeProcessesPerPage
+	end := min(start+homeProcessesPerPage, len(items))
+	pagedItems := items
+	if start < len(items) {
+		pagedItems = items[start:end]
+	} else if len(items) > 0 {
+		pagedItems = items[:0]
+	}
+	pageNumbers := make([]int, 0, totalPages)
+	pageLinks := make([]PaginationLink, 0, totalPages)
+	panelID := "stream-section-" + status
+	for pageNum := 1; pageNum <= totalPages; pageNum++ {
+		pageNumbers = append(pageNumbers, pageNum)
+		pageLinks = append(pageLinks, PaginationLink{
+			Page:      pageNum,
+			URL:       homePaginationURL(workflowPath, status, sortKey, pageNum),
+			IsCurrent: pageNum == currentPage,
+		})
+	}
+	previousPage := max(currentPage-1, 1)
+	nextPage := min(currentPage+1, totalPages)
+	var sortFields []QueryInput
+	if status != "all" {
+		sortFields = []QueryInput{{Name: "filter", Value: status}}
+	}
+	navAriaLabel, navTitle, heading, emptyMessage, paginationAriaLabel := homeProcessStatusCopy(status)
+	return ProcessStatusGroup{
+		Status:              status,
+		Label:               processStatusLabel(status),
+		NavAriaLabel:        navAriaLabel,
+		NavTitle:            navTitle,
+		Heading:             heading,
+		EmptyMessage:        emptyMessage,
+		PaginationAriaLabel: paginationAriaLabel,
+		PanelID:             panelID,
+		Sort:                sortKey,
+		SortFields:          sortFields,
+		TotalCount:          len(items),
+		CurrentPage:         currentPage,
+		TotalPages:          totalPages,
+		PageNumbers:         pageNumbers,
+		PageLinks:           pageLinks,
+		HasPreviousPage:     currentPage > 1,
+		HasNextPage:         currentPage < totalPages,
+		PreviousPage:        previousPage,
+		NextPage:            nextPage,
+		PreviousURL:         homePaginationURL(workflowPath, status, sortKey, previousPage),
+		NextURL:             homePaginationURL(workflowPath, status, sortKey, nextPage),
+		Processes:           pagedItems,
+	}
+}
+
+func buildHomeFilterOptions(processes []StreamInstanceCard) []ProcessStatusGroup {
+	byStatus := homeProcessesByStatus(processes)
 	groups := make([]ProcessStatusGroup, 0, len(homeProcessStatuses()))
 	for _, status := range homeProcessStatuses() {
-		var items []StreamInstanceCard
-		if status == "all" {
-			items = append([]StreamInstanceCard(nil), processes...)
-		} else {
-			items = byStatus[status]
-		}
-		sortHomeProcessList(items, sortKey)
-		currentPage := normalizeHomePage(page, len(items))
-		totalPages := 1
-		if len(items) > 0 {
-			totalPages = (len(items) + homeProcessesPerPage - 1) / homeProcessesPerPage
-		}
-		start := (currentPage - 1) * homeProcessesPerPage
-		end := min(start+homeProcessesPerPage, len(items))
-		pagedItems := items
-		if start < len(items) {
-			pagedItems = items[start:end]
-		} else if len(items) > 0 {
-			pagedItems = items[:0]
-		}
-		pageNumbers := make([]int, 0, totalPages)
-		pageLinks := make([]PaginationLink, 0, totalPages)
-		panelID := "stream-section-" + status
-		for pageNum := 1; pageNum <= totalPages; pageNum++ {
-			pageNumbers = append(pageNumbers, pageNum)
-			pageLinks = append(pageLinks, PaginationLink{
-				Page:      pageNum,
-				URL:       homePaginationURL(workflowPath, status, sortKey, pageNum),
-				IsCurrent: pageNum == currentPage,
-			})
-		}
-		previousPage := max(currentPage-1, 1)
-		nextPage := min(currentPage+1, totalPages)
-		var sortFields []QueryInput
-		if status != "all" {
-			sortFields = []QueryInput{{Name: "filter", Value: status}}
-		}
-		navAriaLabel, navTitle, heading, emptyMessage, paginationAriaLabel := homeProcessStatusCopy(status)
+		navAriaLabel, navTitle, _, _, _ := homeProcessStatusCopy(status)
 		groups = append(groups, ProcessStatusGroup{
-			Status:              status,
-			Label:               processStatusLabel(status),
-			NavAriaLabel:        navAriaLabel,
-			NavTitle:            navTitle,
-			Heading:             heading,
-			EmptyMessage:        emptyMessage,
-			PaginationAriaLabel: paginationAriaLabel,
-			PanelID:             panelID,
-			Sort:                sortKey,
-			SortFields:          sortFields,
-			TotalCount:          len(items),
-			CurrentPage:         currentPage,
-			TotalPages:          totalPages,
-			PageNumbers:         pageNumbers,
-			PageLinks:           pageLinks,
-			HasPreviousPage:     currentPage > 1,
-			HasNextPage:         currentPage < totalPages,
-			PreviousPage:        previousPage,
-			NextPage:            nextPage,
-			PreviousURL:         homePaginationURL(workflowPath, status, sortKey, previousPage),
-			NextURL:             homePaginationURL(workflowPath, status, sortKey, nextPage),
-			Processes:           pagedItems,
+			Status:       status,
+			Label:        processStatusLabel(status),
+			NavAriaLabel: navAriaLabel,
+			NavTitle:     navTitle,
+			PanelID:      "stream-section-" + status,
+			TotalCount:   len(homeProcessItemsForStatus(processes, byStatus, status)),
 		})
+	}
+	return groups
+}
+
+func buildHomeActiveProcessGroup(workflowPath string, processes []StreamInstanceCard, statusFilter, sortKey string, page int) ProcessStatusGroup {
+	byStatus := homeProcessesByStatus(processes)
+	return buildHomeProcessGroupForStatus(workflowPath, processes, byStatus, normalizeHomeStatusFilter(statusFilter), sortKey, page)
+}
+
+func buildHomeProcessGroups(workflowPath string, processes []StreamInstanceCard, sortKey string, page int) []ProcessStatusGroup {
+	byStatus := homeProcessesByStatus(processes)
+	groups := make([]ProcessStatusGroup, 0, len(homeProcessStatuses()))
+	for _, status := range homeProcessStatuses() {
+		groups = append(groups, buildHomeProcessGroupForStatus(workflowPath, processes, byStatus, status, sortKey, page))
 	}
 	return groups
 }
@@ -4732,28 +4769,7 @@ func (s *Server) handleDeleteWorkflow(w http.ResponseWriter, r *http.Request) {
 	redirectHomeWithMessage(w, r, "confirmation", cfg.Workflow.Name+" was deleted.")
 }
 
-func (s *Server) handleWorkflowHome(w http.ResponseWriter, r *http.Request) {
-	user, _, ok := s.requireAuthenticatedPage(w, r)
-	if !ok {
-		return
-	}
-	workflowKey, cfg, err := s.selectedWorkflowUnvalidated(r)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	ctx := r.Context()
-	workflowError := homePickerMessage(r, "error")
-	if validationErr := s.validateWorkflowRefs(ctx, cfg); validationErr != nil {
-		var refErr *WorkflowRefValidationError
-		if !errors.As(validationErr, &refErr) {
-			http.Error(w, validationErr.Error(), http.StatusInternalServerError)
-			return
-		}
-		if workflowError == "" {
-			workflowError = refErr.Error()
-		}
-	}
+func (s *Server) buildWorkflowHomeView(ctx context.Context, r *http.Request, user *AccountUser, workflowKey string, cfg RuntimeConfig, workflowError string) HomeView {
 	sortKey := normalizeHomeSortKey(strings.TrimSpace(r.URL.Query().Get("sort")))
 	statusFilter := normalizeHomeStatusFilter(r.URL.Query().Get("filter"))
 	page := parsePositiveInt(r.URL.Query().Get("page"), 1)
@@ -4769,7 +4785,7 @@ func (s *Server) handleWorkflowHome(w http.ResponseWriter, r *http.Request) {
 			actor.Role = actor.RoleSlugs[0]
 		}
 	}
-	roleMeta := s.roleMetaIndex(r.Context())
+	roleMeta := s.roleMetaIndex(ctx)
 
 	totalSubsteps := countWorkflowSubsteps(cfg.Workflow)
 	var processes []StreamInstanceCard
@@ -4805,7 +4821,8 @@ func (s *Server) handleWorkflowHome(w http.ResponseWriter, r *http.Request) {
 		processes = append(processes, item)
 	}
 
-	processGroups := buildHomeProcessGroups(workflowPath(workflowKey), processes, sortKey, page)
+	filterOptions := buildHomeFilterOptions(processes)
+	activeGroup := buildHomeActiveProcessGroup(path, processes, statusFilter, sortKey, page)
 
 	preview := makeStreamInstanceDetailReadOnly(
 		s.buildStreamInstanceDetailView(ctx, cfg, workflowKey, buildWorkflowPreviewProcess(cfg.Workflow, workflowKey), actor, "", "", false),
@@ -4813,19 +4830,60 @@ func (s *Server) handleWorkflowHome(w http.ResponseWriter, r *http.Request) {
 	)
 	preview.HideStatus = true
 
-	view := HomeView{
+	return HomeView{
 		PageBase:            s.pageBaseForUser(user, "home_body", workflowKey, cfg.Workflow.Name),
 		Breadcrumbs:         buildStreamBreadcrumbs(workflowKey, cfg.Workflow.Name),
 		WorkflowDescription: strings.TrimSpace(cfg.Workflow.Description),
 		Error:               workflowError,
 		Sort:                sortKey,
 		StatusFilter:        statusFilter,
-		ProcessGroups:       processGroups,
+		FilterOptions:       filterOptions,
+		ProcessGroups:       []ProcessStatusGroup{activeGroup},
 		Preview:             preview,
 	}
+}
+
+func (s *Server) renderStreamDashboard(w http.ResponseWriter, view HomeView) {
 	if err := s.tmpl.ExecuteTemplate(w, "stream.html", view); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
+}
+
+func (s *Server) renderStreamDashboardResults(w http.ResponseWriter, view HomeView) {
+	if err := s.tmpl.ExecuteTemplate(w, "stream_dashboard_results", view); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (s *Server) handleWorkflowHome(w http.ResponseWriter, r *http.Request) {
+	user, _, ok := s.requireAuthenticatedPage(w, r)
+	if !ok {
+		return
+	}
+	workflowKey, cfg, err := s.selectedWorkflowUnvalidated(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	ctx := r.Context()
+	workflowError := homePickerMessage(r, "error")
+	if validationErr := s.validateWorkflowRefs(ctx, cfg); validationErr != nil {
+		var refErr *WorkflowRefValidationError
+		if !errors.As(validationErr, &refErr) {
+			http.Error(w, validationErr.Error(), http.StatusInternalServerError)
+			return
+		}
+		if workflowError == "" {
+			workflowError = refErr.Error()
+		}
+	}
+
+	view := s.buildWorkflowHomeView(ctx, r, user, workflowKey, cfg, workflowError)
+	if isHTMXRequest(r) {
+		s.renderStreamDashboardResults(w, view)
+		return
+	}
+	s.renderStreamDashboard(w, view)
 }
 
 func (s *Server) handleStartProcess(w http.ResponseWriter, r *http.Request) {

--- a/server/cmd/server/panel_markup_test.go
+++ b/server/cmd/server/panel_markup_test.go
@@ -251,7 +251,9 @@ func TestStreamHomeBodyPanelMarkup(t *testing.T) {
 			WorkflowName: "Demo workflow",
 		},
 		StatusFilter:  "all",
-		ProcessGroups: testHomeProcessGroups(),
+		Sort:          "time_desc",
+		FilterOptions: testHomeFilterOptions(),
+		ProcessGroups: testHomeActiveProcessGroups(nil, "all", "time_desc", 1),
 	}
 	if err := tmpl.ExecuteTemplate(&out, "home_body", view); err != nil {
 		t.Fatalf("render home_body: %v", err)
@@ -259,11 +261,11 @@ func TestStreamHomeBodyPanelMarkup(t *testing.T) {
 	body := out.String()
 
 	for _, want := range []string{
+		`id="stream-dashboard-results"`,
 		`class="rail-layout rail-layout-ready"`,
 		`class="panel panel-sticky"`,
 		`class="stream-status-filter-nav"`,
 		`class="stream-status-filter-select"`,
-		`data-home-filter-select`,
 		`class="stream-status-filter-option is-active"`,
 		`class="status-tag status-tag-compact"`,
 		`data-stream-status="all"`,
@@ -315,9 +317,9 @@ func TestStreamHomeBodyPanelMarkup(t *testing.T) {
 	}
 
 	mainStart := strings.Index(body, `class="rail-layout-main home-workflow-panel-main"`)
-	mainEnd := strings.Index(body, `class="stream-status-sections"`)
+	mainEnd := strings.Index(body, `class="stream-status-section"`)
 	if mainStart == -1 || mainEnd == -1 || mainStart >= mainEnd {
-		t.Fatal("expected rail-layout-main wrapping stream status sections")
+		t.Fatal("expected rail-layout-main wrapping stream status section")
 	}
 	mainBlock := body[mainStart:mainEnd]
 	if strings.Contains(mainBlock, `<section class="panel"`) || strings.Contains(mainBlock, `<section class="panel `) {

--- a/server/templates/pages/stream.html
+++ b/server/templates/pages/stream.html
@@ -23,7 +23,6 @@
             <button
               class="btn btn-secondary"
               type="button"
-              data-home-nav="preview"
               onclick="document.getElementById('stream-preview-dialog').showModal()"
             >
               {{ template "icon-eye" . }}
@@ -51,353 +50,277 @@
         <div class="error-detail">{{ .Error }}</div>
       </div>
     {{ else }}
-      <div class="rail-layout rail-layout-ready" data-home-root>
-        <section class="panel panel-sticky">
-          <div class="stream-status-filter">
-            <span
-              class="stream-status-rail-label"
-              id="stream-status-filter-label"
-            >
-              {{ template "icon-filter" . }}
-              Filter by status
-            </span>
-            <nav
-              class="stream-status-filter-nav"
-              aria-labelledby="stream-status-filter-label"
-            >
-              {{ range .ProcessGroups }}
-                <button
-                  type="button"
-                  class="stream-status-filter-option{{ if eq .Status $.StatusFilter }} is-active{{ end }}"
-                  data-home-nav="{{ .Status }}"
-                  aria-controls="{{ .PanelID }}"
-                  aria-current="{{ if eq .Status $.StatusFilter }}page{{ else }}false{{ end }}"
-                  aria-label="{{ .NavAriaLabel }}"
-                  title="{{ .NavTitle }}"
-                >
-                  {{ template "status_tag" .Status }}
-                </button>
-              {{ end }}
-            </nav>
-            <select
-              id="stream-status-filter-select"
-              class="stream-status-filter-select"
-              aria-labelledby="stream-status-filter-label"
-              data-home-filter-select
-            >
-              <button type="button">
-                <selectedcontent></selectedcontent>
-              </button>
-              {{ range .ProcessGroups }}
-                <option
-                  value="{{ .Status }}"
-                  {{ if eq .Status $.StatusFilter }}selected{{ end }}
-                >
-                  {{ template "status_tag" .Status }}
-                </option>
-              {{ end }}
-            </select>
-          </div>
-          {{ range .ProcessGroups }}
-            <form
-              method="get"
-              action="{{ $.WorkflowPath }}/"
-              class="stream-status-sort"
-              data-home-panel="{{ .Status }}"
-              {{ if ne .Status $.StatusFilter }}hidden{{ end }}
-            >
-              {{ range .SortFields }}
-                <input
-                  type="hidden"
-                  name="{{ .Name }}"
-                  value="{{ .Value }}"
-                />
-              {{ end }}
-              <label
-                class="stream-status-sort-control"
-                for="stream-sort-{{ .Status }}"
-              >
-                <span class="stream-status-rail-label">
-                  {{ template "icon-sort" . }}
-                  Sort by
-                </span>
-                <select
-                  id="stream-sort-{{ .Status }}"
-                  name="sort"
-                  onchange="this.form.submit()"
-                >
-                  <option
-                    value="time_desc"
-                    {{ if eq .Sort "time_desc" }}selected{{ end }}
-                  >
-                    Newest
-                  </option>
-                  <option
-                    value="time_asc"
-                    {{ if eq .Sort "time_asc" }}selected{{ end }}
-                  >
-                    Oldest
-                  </option>
-                  <option
-                    value="progress_desc"
-                    {{ if eq .Sort "progress_desc" }}selected{{ end }}
-                  >
-                    Most advanced
-                  </option>
-                  <option
-                    value="progress_asc"
-                    {{ if eq .Sort "progress_asc" }}selected{{ end }}
-                  >
-                    Least advanced
-                  </option>
-                  <option
-                    value="status"
-                    {{ if eq .Sort "status" }}selected{{ end }}
-                  >
-                    Status
-                  </option>
-                </select>
-              </label>
-            </form>
-          {{ end }}
-        </section>
-
-        <div class="rail-layout-main home-workflow-panel-main">
-          <dialog id="new-instance-dialog" class="dialog">
-            <div class="dialog-card">
-              <header class="dialog-head">
-                <div>
-                  <h3 class="dialog-title">New instance</h3>
-                  <p class="dialog-subtitle">
-                    Give this stream instance a brief name
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  class="btn btn-ghost btn-icon dialog-close"
-                  onclick="document.getElementById('new-instance-dialog').close()"
-                >
-                  {{ template "icon-close" . }}
-                </button>
-              </header>
-              <form
-                method="post"
-                action="{{ .WorkflowPath }}/process/start"
-                class="input-form"
-              >
-                <div class="form-field">
-                  <label for="instance-name">Instance name</label>
-                  <input
-                    id="instance-name"
-                    name="name"
-                    type="text"
-                    maxlength="80"
-                    autocomplete="off"
-                  />
-                </div>
-                <div class="dialog-actions">
-                  <button class="btn btn-primary" type="submit">
-                    {{ template "icon-play" . }}
-                    Start instance
-                  </button>
-                </div>
-              </form>
+      <dialog id="new-instance-dialog" class="dialog">
+        <div class="dialog-card">
+          <header class="dialog-head">
+            <div>
+              <h3 class="dialog-title">New instance</h3>
+              <p class="dialog-subtitle">
+                Give this stream instance a brief name
+              </p>
             </div>
-          </dialog>
-          <dialog
-            id="stream-preview-dialog"
-            class="dialog"
+            <button
+              type="button"
+              class="btn btn-ghost btn-icon dialog-close"
+              onclick="document.getElementById('new-instance-dialog').close()"
+            >
+              {{ template "icon-close" . }}
+            </button>
+          </header>
+          <form
+            method="post"
+            action="{{ .WorkflowPath }}/process/start"
+            class="input-form"
           >
-            <div class="dialog-card">
-              <header class="dialog-head">
-                <div>
-                  <h3 class="dialog-title">Stream preview</h3>
-                  <p class="dialog-subtitle">
-                    Inspect the stream timeline and form structure in read-only
-                    mode
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  class="btn btn-ghost btn-icon dialog-close"
-                  onclick="document.getElementById('stream-preview-dialog').close()"
-                >
-                  {{ template "icon-close" . }}
-                </button>
-              </header>
-              <div class="stream-preview-body">
-                {{ template "stream_timeline" .Preview.StreamTimeline }}
-              </div>
+            <div class="form-field">
+              <label for="instance-name">Instance name</label>
+              <input
+                id="instance-name"
+                name="name"
+                type="text"
+                maxlength="80"
+                autocomplete="off"
+              />
             </div>
-          </dialog>
-          <div class="stream-status-sections">
-            {{ range .ProcessGroups }}
-              <section
-                class="stream-status-section"
-                id="{{ .PanelID }}"
-                data-home-panel="{{ .Status }}"
-                {{ if ne .Status $.StatusFilter }}hidden{{ end }}
-              >
-                <div class="stream-status-section-head">
-                  <h3>{{ .Heading }}</h3>
-                </div>
-                {{ if .Processes }}
-                  <ul class="stream-instance-card-list">
-                    {{ range .Processes }}
-                      {{ template "stream_instance_card" . }}
-                    {{ end }}
-                  </ul>
-                {{ else }}
-                  <div class="stream-instance-card-empty">
-                    <p class="muted">{{ .EmptyMessage }}</p>
-                  </div>
-                {{ end }}
-                {{ if gt .TotalPages 1 }}
-                  <nav
-                    class="platform-admin-pagination platform-admin-pagination--inline"
-                    aria-label="{{ .PaginationAriaLabel }}"
-                  >
-                    <div class="platform-admin-pagination-pages">
-                      <a
-                        class="btn btn-secondary pagination-btn{{ if not .HasPreviousPage }} is-disabled{{ end }}"
-                        href="{{ .PreviousURL }}"
-                      >
-                        {{ template "icon-chevron-left" . }}
-                      </a>
-                      {{ range .PageLinks }}
-                        <a
-                          class="{{ if .IsCurrent }}
-                            btn btn-primary
-                          {{ else }}
-                            btn btn-secondary
-                          {{ end }}"
-                          href="{{ .URL }}"
-                          >{{ .Page }}</a
-                        >
-                      {{ end }}
-                      <a
-                        class="btn btn-secondary pagination-btn{{ if not .HasNextPage }} is-disabled{{ end }}"
-                        href="{{ .NextURL }}"
-                      >
-                        {{ template "icon-chevron-right" . }}
-                      </a>
-                    </div>
-                  </nav>
-                {{ end }}
-              </section>
-            {{ end }}
+            <div class="dialog-actions">
+              <button class="btn btn-primary" type="submit">
+                {{ template "icon-play" . }}
+                Start instance
+              </button>
+            </div>
+          </form>
+        </div>
+      </dialog>
+      <dialog id="stream-preview-dialog" class="dialog">
+        <div class="dialog-card">
+          <header class="dialog-head">
+            <div>
+              <h3 class="dialog-title">Stream preview</h3>
+              <p class="dialog-subtitle">
+                Inspect the stream timeline and form structure in read-only mode
+              </p>
+            </div>
+            <button
+              type="button"
+              class="btn btn-ghost btn-icon dialog-close"
+              onclick="document.getElementById('stream-preview-dialog').close()"
+            >
+              {{ template "icon-close" . }}
+            </button>
+          </header>
+          <div class="stream-preview-body">
+            {{ template "stream_timeline" .Preview.StreamTimeline }}
           </div>
         </div>
-      </div>
+      </dialog>
 
-      <script>
-        (function () {
-          const homeRoot = document.querySelector("[data-home-root]");
-          if (!homeRoot) {
-            return;
-          }
-
-          const panels = Array.from(homeRoot.querySelectorAll("[data-home-panel]"));
-          const statusPanelNames = panels.map((panel) =>
-            (panel.getAttribute("data-home-panel") || "").trim(),
-          );
-
-          const defaultPanelName = statusPanelNames.includes("all")
-            ? "all"
-            : statusPanelNames[0] || "";
-
-          const syncFilterURL = (panelName) => {
-            try {
-              const url = new URL(window.location.href);
-              if (panelName && panelName !== "all") {
-                url.searchParams.set("filter", panelName);
-              } else {
-                url.searchParams.delete("filter");
-              }
-              url.searchParams.delete("page");
-              url.hash = "";
-              window.history.replaceState({}, "", url);
-            } catch (_err) {}
-          };
-
-          const initialPanelName = () => {
-            const params = new URLSearchParams(window.location.search);
-            const filterParam = (params.get("filter") || "").trim().toLowerCase();
-            if (statusPanelNames.includes(filterParam)) {
-              return filterParam;
-            }
-
-            const hashPanelID = window.location.hash.replace(/^#/, "");
-            if (hashPanelID) {
-              const hashPanel = panels.find((panel) => panel.id === hashPanelID);
-              if (hashPanel) {
-                return (hashPanel.getAttribute("data-home-panel") || "").trim();
-              }
-            }
-
-            return defaultPanelName;
-          };
-
-          const filterSelect = homeRoot.querySelector(
-            "[data-home-filter-select]",
-          );
-
-          const showPanel = (panelName, options = {}) => {
-            if (!statusPanelNames.includes(panelName)) {
-              panelName = defaultPanelName;
-            }
-
-            const buttons = Array.from(
-              homeRoot.querySelectorAll("[data-home-nav]"),
-            );
-            buttons.forEach((button) => {
-              const currentName = button.getAttribute("data-home-nav");
-              const isActive = currentName === panelName;
-              button.classList.toggle("is-active", isActive);
-              button.setAttribute("aria-current", isActive ? "page" : "false");
-            });
-
-            panels.forEach((panel) => {
-              const currentName = panel.getAttribute("data-home-panel");
-              panel.hidden = currentName !== panelName;
-            });
-
-            if (filterSelect && statusPanelNames.includes(panelName)) {
-              filterSelect.value = panelName;
-            }
-
-            if (options.syncURL) {
-              syncFilterURL(panelName);
-            }
-          };
-
-          Array.from(homeRoot.querySelectorAll("[data-home-nav]")).forEach(
-            (button) => {
-              button.addEventListener("click", () => {
-                const panelName = (
-                  button.getAttribute("data-home-nav") || ""
-                ).trim();
-                if (panelName === "preview") {
-                  return;
-                }
-                showPanel(panelName, { syncURL: true });
-              });
-            },
-          );
-
-          if (filterSelect) {
-            filterSelect.addEventListener("change", () => {
-              showPanel(
-                (filterSelect.value || "").trim(),
-                { syncURL: true },
-              );
-            });
-          }
-
-          showPanel(initialPanelName(), { syncURL: true });
-        })();
-      </script>
+      {{ template "stream_dashboard_results" . }}
     {{ end }}
+  </div>
+{{ end }}
+
+{{ define "stream_dashboard_results" }}
+  <div id="stream-dashboard-results" class="rail-layout rail-layout-ready">
+    <section class="panel panel-sticky">
+      <div class="stream-status-filter">
+        <span class="stream-status-rail-label" id="stream-status-filter-label">
+          {{ template "icon-filter" . }}
+          Filter by status
+        </span>
+        <nav
+          class="stream-status-filter-nav"
+          aria-labelledby="stream-status-filter-label"
+        >
+          {{ range .FilterOptions }}
+            <a
+              class="stream-status-filter-option{{ if eq .Status $.StatusFilter }} is-active{{ end }}"
+              href="{{ $.WorkflowPath }}/{{- if or (ne .Status "all") (ne $.Sort "time_desc") -}}
+                ?{{- if ne .Status "all" -}}
+                  filter={{ .Status }}{{- if ne $.Sort "time_desc" -}}&{{ end -}}
+                {{- end -}}{{- if ne $.Sort "time_desc" -}}
+                  sort={{ $.Sort }}
+                {{- end -}}
+              {{- end -}}"
+              hx-get="{{ $.WorkflowPath }}/{{- if or (ne .Status "all") (ne $.Sort "time_desc") -}}
+                ?{{- if ne .Status "all" -}}
+                  filter={{ .Status }}{{- if ne $.Sort "time_desc" -}}&{{ end -}}
+                {{- end -}}{{- if ne $.Sort "time_desc" -}}
+                  sort={{ $.Sort }}
+                {{- end -}}
+              {{- end -}}"
+              hx-target="#stream-dashboard-results"
+              hx-select="#stream-dashboard-results"
+              hx-swap="outerHTML"
+              hx-push-url="true"
+              aria-controls="{{ .PanelID }}"
+              aria-current="{{ if eq .Status $.StatusFilter }}page{{ else }}false{{ end }}"
+              aria-label="{{ .NavAriaLabel }}"
+              title="{{ .NavTitle }}"
+            >
+              {{ template "status_tag" .Status }}
+            </a>
+          {{ end }}
+        </nav>
+        <form
+          method="get"
+          action="{{ .WorkflowPath }}/"
+          hx-get="{{ .WorkflowPath }}/"
+          hx-target="#stream-dashboard-results"
+          hx-select="#stream-dashboard-results"
+          hx-swap="outerHTML"
+          hx-push-url="true"
+          hx-trigger="change from:#stream-status-filter-select"
+        >
+          {{ if ne .Sort "time_desc" }}
+            <input type="hidden" name="sort" value="{{ .Sort }}" />
+          {{ end }}
+          <select
+            id="stream-status-filter-select"
+            class="stream-status-filter-select"
+            name="filter"
+            aria-labelledby="stream-status-filter-label"
+          >
+            <button type="button">
+              <selectedcontent></selectedcontent>
+            </button>
+            {{ range .FilterOptions }}
+              <option
+                value="{{ .Status }}"
+                {{ if eq .Status $.StatusFilter }}selected{{ end }}
+              >
+                {{ template "status_tag" .Status }}
+              </option>
+            {{ end }}
+          </select>
+        </form>
+      </div>
+      {{ range .ProcessGroups }}
+          <form
+            method="get"
+            action="{{ $.WorkflowPath }}/"
+            class="stream-status-sort"
+            hx-get="{{ $.WorkflowPath }}/"
+            hx-target="#stream-dashboard-results"
+            hx-select="#stream-dashboard-results"
+            hx-swap="outerHTML"
+            hx-push-url="true"
+            hx-trigger="change from:select"
+          >
+            {{ range .SortFields }}
+              <input type="hidden" name="{{ .Name }}" value="{{ .Value }}" />
+            {{ end }}
+            <label
+              class="stream-status-sort-control"
+              for="stream-sort-{{ .Status }}"
+            >
+              <span class="stream-status-rail-label">
+                {{ template "icon-sort" . }}
+                Sort by
+              </span>
+              <select id="stream-sort-{{ .Status }}" name="sort">
+                <option
+                  value="time_desc"
+                  {{ if eq .Sort "time_desc" }}selected{{ end }}
+                >
+                  Newest
+                </option>
+                <option
+                  value="time_asc"
+                  {{ if eq .Sort "time_asc" }}selected{{ end }}
+                >
+                  Oldest
+                </option>
+                <option
+                  value="progress_desc"
+                  {{ if eq .Sort "progress_desc" }}selected{{ end }}
+                >
+                  Most advanced
+                </option>
+                <option
+                  value="progress_asc"
+                  {{ if eq .Sort "progress_asc" }}selected{{ end }}
+                >
+                  Least advanced
+                </option>
+                <option
+                  value="status"
+                  {{ if eq .Sort "status" }}selected{{ end }}
+                >
+                  Status
+                </option>
+              </select>
+            </label>
+          </form>
+      {{ end }}
+    </section>
+
+    <div class="rail-layout-main home-workflow-panel-main">
+      {{ range .ProcessGroups }}
+          <section class="stream-status-section" id="{{ .PanelID }}">
+            <div class="stream-status-section-head">
+              <h3>{{ .Heading }}</h3>
+            </div>
+            {{ if .Processes }}
+              <ul class="stream-instance-card-list">
+                {{ range .Processes }}
+                  {{ template "stream_instance_card" . }}
+                {{ end }}
+              </ul>
+            {{ else }}
+              <div class="stream-instance-card-empty">
+                <p class="muted">{{ .EmptyMessage }}</p>
+              </div>
+            {{ end }}
+            {{ if gt .TotalPages 1 }}
+              <nav
+                class="platform-admin-pagination platform-admin-pagination--inline"
+                aria-label="{{ .PaginationAriaLabel }}"
+              >
+                <div class="platform-admin-pagination-pages">
+                  <a
+                    class="btn btn-secondary pagination-btn{{ if not .HasPreviousPage }} is-disabled{{ end }}"
+                    href="{{ .PreviousURL }}"
+                    hx-get="{{ .PreviousURL }}"
+                    hx-target="#stream-dashboard-results"
+                    hx-select="#stream-dashboard-results"
+                    hx-swap="outerHTML"
+                    hx-push-url="true"
+                  >
+                    {{ template "icon-chevron-left" . }}
+                  </a>
+                  {{ range .PageLinks }}
+                    <a
+                      class="{{ if .IsCurrent }}
+                        btn btn-primary
+                      {{ else }}
+                        btn btn-secondary
+                      {{ end }}"
+                      href="{{ .URL }}"
+                      hx-get="{{ .URL }}"
+                      hx-target="#stream-dashboard-results"
+                      hx-select="#stream-dashboard-results"
+                      hx-swap="outerHTML"
+                      hx-push-url="true"
+                      >{{ .Page }}</a
+                    >
+                  {{ end }}
+                  <a
+                    class="btn btn-secondary pagination-btn{{ if not .HasNextPage }} is-disabled{{ end }}"
+                    href="{{ .NextURL }}"
+                    hx-get="{{ .NextURL }}"
+                    hx-target="#stream-dashboard-results"
+                    hx-select="#stream-dashboard-results"
+                    hx-swap="outerHTML"
+                    hx-push-url="true"
+                  >
+                    {{ template "icon-chevron-right" . }}
+                  </a>
+                </div>
+              </nav>
+            {{ end }}
+          </section>
+      {{ end }}
+    </div>
   </div>
 {{ end }}
 

--- a/web/src/styles/pages/stream.css
+++ b/web/src/styles/pages/stream.css
@@ -60,6 +60,7 @@
   min-width: 0;
   padding: var(--space-2);
   text-align: left;
+  text-decoration: none;
   border: 0;
   border-radius: 4px;
   background: transparent;
@@ -79,6 +80,7 @@
 
 .stream-status-filter-option:hover {
   background: color-mix(in srgb, var(--primary) 8%, var(--background));
+  text-decoration: none;
 }
 
 .stream-status-rail-label {


### PR DESCRIPTION
## Summary
- Move stream dashboard filter, sort, and pagination to HTMX so each interaction hits the network and swaps `#stream-dashboard-results` (no full reload, no client-only panel toggling).
- Serve `stream_dashboard_results` when `HX-Request` is set; build `FilterOptions` for nav and a single active `ProcessGroups` entry for the paged list.
- Align home template/markup tests with the new partial and HTMX attributes.

## Test plan
- [ ] Open a stream dashboard (`/w/:key/`) and confirm filter clicks update the list without a full page refresh; URL updates via `hx-push-url`
- [ ] Change sort and confirm list order updates and URL reflects `sort` (page resets)
- [ ] With >10 instances, paginate and confirm soft navigation preserves filter/sort
- [ ] Hard-refresh mid-filter/sort/page and confirm server-rendered state matches the URL
- [ ] `cd server && go test ./cmd/server/ -run 'Home|handleWorkflowHome|HandleHome|BuildHome|DialogMarkup|PanelMarkup' -count=1`


Made with [Cursor](https://cursor.com)