### PR TITLE
feat(ui): Lucide icons, topbar chrome, and HTMX stream dashboard

### DIFF
--- a/server/cmd/server/dialog_markup_test.go
+++ b/server/cmd/server/dialog_markup_test.go
@@ -16,7 +16,10 @@ func TestStreamPageNewInstanceDialogMarkup(t *testing.T) {
 			WorkflowPath: "/w/workflow",
 			WorkflowName: "Demo workflow",
 		},
-		ProcessGroups: testHomeProcessGroups(),
+		StatusFilter:  "all",
+		Sort:          "time_desc",
+		FilterOptions: testHomeFilterOptions(),
+		ProcessGroups: testHomeActiveProcessGroups(nil, "all", "time_desc", 1),
 	}
 	if err := tmpl.ExecuteTemplate(&out, "home_body", view); err != nil {
 		t.Fatalf("render home_body: %v", err)
@@ -175,7 +178,10 @@ func TestStreamPreviewDialogPageScopedMarkup(t *testing.T) {
 			WorkflowPath: "/w/workflow",
 			WorkflowName: "Demo workflow",
 		},
-		ProcessGroups: testHomeProcessGroups(),
+		StatusFilter:  "all",
+		Sort:          "time_desc",
+		FilterOptions: testHomeFilterOptions(),
+		ProcessGroups: testHomeActiveProcessGroups(nil, "all", "time_desc", 1),
 	}
 	if err := tmpl.ExecuteTemplate(&out, "home_body", view); err != nil {
 		t.Fatalf("render home_body: %v", err)

--- a/server/cmd/server/home_handler_test.go
+++ b/server/cmd/server/home_handler_test.go
@@ -1275,6 +1275,239 @@ func TestHandleWorkflowHomeUsesHumanReadableProcessDates(t *testing.T) {
 	}
 }
 
+func TestHandleWorkflowHomeHTMXReturnsPartial(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 2, 3, 12, 0, 0, 0, time.UTC)
+
+	activeID := primitive.NewObjectID()
+	active := Process{
+		ID:          activeID,
+		WorkflowKey: "workflow",
+		Name:        "Pilot batch",
+		CreatedAt:   now.Add(-2 * time.Hour),
+		Status:      "",
+		Progress: map[string]ProcessStep{
+			"1_1": {State: "done", DoneAt: ptrTime(now.Add(-110 * time.Minute))},
+			"1_2": {State: "done", DoneAt: ptrTime(now.Add(-100 * time.Minute)), Data: map[string]interface{}{"note": "alpha"}},
+			"1_3": {State: "pending"},
+			"2_1": {State: "pending"},
+			"2_2": {State: "pending"},
+			"3_1": {State: "pending"},
+			"3_2": {State: "pending"},
+		},
+	}
+
+	doneID := primitive.NewObjectID()
+	done := Process{
+		ID:          doneID,
+		WorkflowKey: "workflow",
+		CreatedAt:   now.Add(-1 * time.Hour),
+		Status:      "active",
+		Progress: map[string]ProcessStep{
+			"1_1": {State: "done", DoneAt: ptrTime(now.Add(-70 * time.Minute))},
+			"1_2": {State: "done", DoneAt: ptrTime(now.Add(-60 * time.Minute))},
+			"1_3": {State: "done", DoneAt: ptrTime(now.Add(-50 * time.Minute))},
+			"2_1": {State: "done", DoneAt: ptrTime(now.Add(-40 * time.Minute))},
+			"2_2": {State: "done", DoneAt: ptrTime(now.Add(-30 * time.Minute))},
+			"3_1": {State: "done", DoneAt: ptrTime(now.Add(-20 * time.Minute))},
+			"3_2": {State: "done", DoneAt: ptrTime(now.Add(-10 * time.Minute))},
+		},
+	}
+
+	store.SeedProcess(active)
+	store.SeedProcess(done)
+
+	server := &Server{
+		authorizer: fakeAuthorizer{},
+		store:      store,
+		tmpl:       homeTestTemplates(),
+		configProvider: func() (RuntimeConfig, error) {
+			cfg := testRuntimeConfig()
+			cfg.Workflow.Description = "Demo workflow description"
+			return cfg, nil
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/w/workflow/", nil)
+	req.Header.Set("HX-Request", "true")
+	req = req.WithContext(context.WithValue(req.Context(), workflowContextKey{}, workflowContextValue{
+		Key: "workflow",
+		Cfg: testRuntimeConfig(),
+	}))
+	rec := httptest.NewRecorder()
+	server.handleWorkflowHome(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `id="stream-dashboard-results"`) {
+		t.Fatalf("expected HTMX results root, got %q", body)
+	}
+	if strings.Contains(body, "data-home-root") {
+		t.Fatalf("did not expect full page chrome in HTMX partial, got %q", body)
+	}
+	if !strings.Contains(body, "PROC 2 SORT time_desc FILTER all") {
+		t.Fatalf("expected active process list in partial, got %q", body)
+	}
+	if !strings.Contains(body, activeID.Hex()+":Pilot batch:available:28") {
+		t.Fatalf("expected process in HTMX partial, got %q", body)
+	}
+}
+
+func TestHandleWorkflowHomeHTMXFiltersAndPaginates(t *testing.T) {
+	store := NewMemoryStore()
+	base := time.Date(2026, 2, 3, 12, 0, 0, 0, time.UTC)
+
+	activeID := primitive.NewObjectID()
+	store.SeedProcess(Process{
+		ID:          activeID,
+		WorkflowKey: "workflow",
+		CreatedAt:   base.Add(-2 * time.Hour),
+		Status:      "active",
+		Progress: map[string]ProcessStep{
+			"1_1": {State: "done", DoneAt: ptrTime(base.Add(-110 * time.Minute))},
+		},
+	})
+
+	doneID := primitive.NewObjectID()
+	store.SeedProcess(Process{
+		ID:          doneID,
+		WorkflowKey: "workflow",
+		CreatedAt:   base.Add(-1 * time.Hour),
+		Status:      "done",
+		Progress: map[string]ProcessStep{
+			"1_1": {State: "done", DoneAt: ptrTime(base.Add(-70 * time.Minute))},
+			"1_2": {State: "done", DoneAt: ptrTime(base.Add(-60 * time.Minute))},
+			"1_3": {State: "done", DoneAt: ptrTime(base.Add(-50 * time.Minute))},
+			"2_1": {State: "done", DoneAt: ptrTime(base.Add(-40 * time.Minute))},
+			"2_2": {State: "done", DoneAt: ptrTime(base.Add(-30 * time.Minute))},
+			"3_1": {State: "done", DoneAt: ptrTime(base.Add(-20 * time.Minute))},
+			"3_2": {State: "done", DoneAt: ptrTime(base.Add(-10 * time.Minute))},
+		},
+	})
+
+	server := &Server{
+		authorizer: fakeAuthorizer{},
+		store:      store,
+		tmpl:       homeTestTemplates(),
+		configProvider: func() (RuntimeConfig, error) {
+			return testRuntimeConfig(), nil
+		},
+	}
+
+	t.Run("filter", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/w/workflow/?filter=done", nil)
+		req.Header.Set("HX-Request", "true")
+		req = req.WithContext(context.WithValue(req.Context(), workflowContextKey{}, workflowContextValue{
+			Key: "workflow",
+			Cfg: testRuntimeConfig(),
+		}))
+		rec := httptest.NewRecorder()
+		server.handleWorkflowHome(rec, req)
+
+		body := rec.Body.String()
+		if !strings.Contains(body, "PROC 1 SORT time_desc FILTER done") {
+			t.Fatalf("expected done filter in HTMX partial, got %q", body)
+		}
+		if !strings.Contains(body, doneID.Hex()+"::done:100") {
+			t.Fatalf("expected done process in HTMX partial, got %q", body)
+		}
+		if strings.Contains(body, activeID.Hex()+"::active") {
+			t.Fatalf("did not expect active process in done HTMX partial, got %q", body)
+		}
+	})
+
+	t.Run("page", func(t *testing.T) {
+		pageStore := NewMemoryStore()
+		pageBase := time.Date(2026, 2, 3, 12, 0, 0, 0, time.UTC)
+		expectedPageTwoID := ""
+		for i := 0; i < homeProcessesPerPage+1; i++ {
+			processID := primitive.NewObjectID()
+			if i == homeProcessesPerPage {
+				expectedPageTwoID = processID.Hex()
+			}
+			pageStore.SeedProcess(Process{
+				ID:          processID,
+				WorkflowKey: "workflow",
+				CreatedAt:   pageBase.Add(-time.Duration(i) * time.Minute),
+				Status:      "active",
+				Progress: map[string]ProcessStep{
+					"1_1": {State: "done", DoneAt: ptrTime(pageBase.Add(-time.Duration(i) * time.Minute))},
+				},
+			})
+		}
+		pageServer := &Server{
+			authorizer: fakeAuthorizer{},
+			store:      pageStore,
+			tmpl:       homeTestTemplates(),
+			configProvider: func() (RuntimeConfig, error) {
+				return testRuntimeConfig(), nil
+			},
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/w/workflow/?page=2", nil)
+		req.Header.Set("HX-Request", "true")
+		req = req.WithContext(context.WithValue(req.Context(), workflowContextKey{}, workflowContextValue{
+			Key: "workflow",
+			Cfg: testRuntimeConfig(),
+		}))
+		rec := httptest.NewRecorder()
+		pageServer.handleWorkflowHome(rec, req)
+
+		body := rec.Body.String()
+		if !strings.Contains(body, "PROC 1 SORT time_desc FILTER all PAGE 2/2") {
+			t.Fatalf("expected paginated all filter in HTMX partial, got %q", body)
+		}
+		if !strings.Contains(body, expectedPageTwoID+"::available") {
+			t.Fatalf("expected last process on page 2, got %q", body)
+		}
+	})
+}
+
+func TestBuildHomeFilterOptionsIncludesAllStatuses(t *testing.T) {
+	options := buildHomeFilterOptions([]StreamInstanceCard{
+		{ID: "1", Status: "active"},
+		{ID: "2", Status: "done"},
+		{ID: "3", Status: "available"},
+	})
+	if len(options) != len(homeProcessStatuses()) {
+		t.Fatalf("expected %d filter options, got %d", len(homeProcessStatuses()), len(options))
+	}
+	for _, option := range options {
+		if len(option.Processes) != 0 {
+			t.Fatalf("expected empty processes on filter option %q, got %d", option.Status, len(option.Processes))
+		}
+		if option.PanelID == "" || option.NavAriaLabel == "" || option.NavTitle == "" {
+			t.Fatalf("expected nav metadata on filter option %q, got %#v", option.Status, option)
+		}
+	}
+	var allOption *ProcessStatusGroup
+	for i := range options {
+		if options[i].Status == "all" {
+			allOption = &options[i]
+			break
+		}
+	}
+	if allOption == nil || allOption.TotalCount != 3 {
+		t.Fatalf("expected all filter count 3, got %#v", allOption)
+	}
+}
+
+func TestBuildHomeActiveProcessGroupBuildsSingleStatus(t *testing.T) {
+	group := buildHomeActiveProcessGroup("/w/workflow", []StreamInstanceCard{
+		{ID: "1", Status: "active"},
+		{ID: "2", Status: "done"},
+	}, "done", "time_desc", 1)
+	if group.Status != "done" {
+		t.Fatalf("expected done group, got %q", group.Status)
+	}
+	if len(group.Processes) != 1 || group.Processes[0].ID != "2" {
+		t.Fatalf("expected one done process, got %#v", group.Processes)
+	}
+}
+
 func homeTestTemplates() *template.Template {
 	return template.Must(template.New("test").Parse(`
 {{define "layout.html"}}{{template "home_body" .}}{{end}}
@@ -1283,6 +1516,12 @@ func homeTestTemplates() *template.Template {
 PROCESSES {{range .Processes}}{{.ID}}:{{.Name}}:{{.Status}}:{{.Percent}}|{{end}}{{ end }}{{ end }}
 {{end}}
 {{define "stream.html"}}{{template "layout.html" .}}{{end}}
+{{define "stream_dashboard_results"}}
+<div id="stream-dashboard-results">
+{{ $filter := .StatusFilter }}{{ range .ProcessGroups }}{{ if eq .Status $filter }}PROC {{len .Processes}} SORT {{.Sort}} FILTER {{$filter}} PAGE {{.CurrentPage}}/{{.TotalPages}}
+PROCESSES {{range .Processes}}{{.ID}}:{{.Name}}:{{.Status}}:{{.Percent}}|{{end}}{{ end }}{{ end }}
+</div>
+{{end}}
 `))
 }
 

--- a/server/cmd/server/home_template_preview_test.go
+++ b/server/cmd/server/home_template_preview_test.go
@@ -6,50 +6,22 @@ import (
 	"testing"
 )
 
-func testHomeProcessGroups(items ...StreamInstanceCard) []ProcessStatusGroup {
-	byStatus := map[string][]StreamInstanceCard{}
-	for _, item := range items {
-		byStatus[item.Status] = append(byStatus[item.Status], item)
+func testHomeFilterOptions(items ...StreamInstanceCard) []ProcessStatusGroup {
+	return buildHomeFilterOptions(items)
+}
+
+func testHomeActiveProcessGroups(items []StreamInstanceCard, statusFilter, sortKey string, page int) []ProcessStatusGroup {
+	if sortKey == "" {
+		sortKey = "time_desc"
 	}
-	groups := make([]ProcessStatusGroup, 0, len(homeProcessStatuses()))
-	for _, status := range homeProcessStatuses() {
-		processes := byStatus[status]
-		if status == "all" {
-			processes = append([]StreamInstanceCard(nil), items...)
-		}
-		totalPages := 1
-		panelURL := "/w/workflow/"
-		if status != "all" {
-			panelURL = "/w/workflow/?filter=" + status
-		}
-		pageLinks := []PaginationLink{{Page: 1, URL: panelURL, IsCurrent: true}}
-		var sortFields []QueryInput
-		if status != "all" {
-			sortFields = []QueryInput{{Name: "filter", Value: status}}
-		}
-		navAriaLabel, navTitle, heading, emptyMessage, paginationAriaLabel := homeProcessStatusCopy(status)
-		groups = append(groups, ProcessStatusGroup{
-			Status:              status,
-			Label:               processStatusLabel(status),
-			NavAriaLabel:        navAriaLabel,
-			NavTitle:            navTitle,
-			Heading:             heading,
-			EmptyMessage:        emptyMessage,
-			PaginationAriaLabel: paginationAriaLabel,
-			PanelID:             "stream-section-" + status,
-			TotalCount:          len(processes),
-			Sort:                "time_desc",
-			SortFields:          sortFields,
-			CurrentPage:         1,
-			TotalPages:          totalPages,
-			PageNumbers:         []int{1},
-			PageLinks:           pageLinks,
-			PreviousURL:         panelURL,
-			NextURL:             panelURL,
-			Processes:           processes,
-		})
+	if statusFilter == "" {
+		statusFilter = "all"
 	}
-	return groups
+	return []ProcessStatusGroup{buildHomeActiveProcessGroup("/w/workflow", items, statusFilter, sortKey, page)}
+}
+
+func testHomeActiveGroup(statusFilter string, items ...StreamInstanceCard) []ProcessStatusGroup {
+	return testHomeActiveProcessGroups(items, statusFilter, "time_desc", 1)
 }
 
 func TestHomeTemplateRendersSidebarAndReadOnlyPreview(t *testing.T) {
@@ -63,8 +35,10 @@ func TestHomeTemplateRendersSidebarAndReadOnlyPreview(t *testing.T) {
 			WorkflowName: "Demo workflow",
 		},
 		WorkflowDescription: "Previewable workflow",
+		Sort:                "time_desc",
 		StatusFilter:        "all",
-		ProcessGroups:       testHomeProcessGroups(process),
+		FilterOptions:       testHomeFilterOptions(process),
+		ProcessGroups:       testHomeActiveGroup("all", process),
 		Preview: StreamInstanceDetailView{
 			HideStatus: true,
 			Timeline: []TimelineStep{
@@ -103,19 +77,15 @@ func TestHomeTemplateRendersSidebarAndReadOnlyPreview(t *testing.T) {
 	compactBody := strings.Join(strings.Fields(body), " ")
 
 	for _, marker := range []string{
-		`data-home-nav="all"`,
-		`data-home-nav="available"`,
-		`data-home-nav="active"`,
-		`data-home-nav="done"`,
-		`data-home-nav="terminated"`,
-		`data-home-nav="preview"`,
+		`id="stream-dashboard-results"`,
+		`hx-target="#stream-dashboard-results"`,
+		`hx-push-url="true"`,
 		`id="stream-preview-dialog"`,
 		`class="dialog-card"`,
 		`class="stream-preview-body"`,
 		`id="new-instance-dialog"`,
 		`name="name"`,
 		`Pilot batch`,
-		`data-home-root`,
 		`data-formata-disabled="true"`,
 		`Preview only. Start an instance to submit data.`,
 	} {
@@ -124,23 +94,32 @@ func TestHomeTemplateRendersSidebarAndReadOnlyPreview(t *testing.T) {
 		}
 	}
 	if !strings.Contains(compactBody, `aria-labelledby="stream-status-filter-label"`) ||
-		!strings.Contains(compactBody, `data-home-filter-select`) ||
 		!strings.Contains(compactBody, `class="stream-status-filter-select"`) ||
 		!strings.Contains(compactBody, `Filter by status`) {
 		t.Fatalf("expected stream status filter label, got: %s", body)
 	}
+	for _, status := range []string{"all", "available", "active", "done", "terminated"} {
+		if !strings.Contains(compactBody, `aria-controls="stream-section-`+status+`"`) {
+			t.Fatalf("expected filter option for %q, got: %s", status, body)
+		}
+	}
+	if !strings.Contains(compactBody, `id="stream-section-all"`) {
+		t.Fatalf("expected active all section, got: %s", body)
+	}
+	for _, status := range []string{"available", "active", "done", "terminated"} {
+		if strings.Contains(compactBody, `id="stream-section-`+status+`"`) {
+			t.Fatalf("did not expect inactive section %q in HTMX results, got: %s", status, body)
+		}
+	}
 	for _, marker := range []string{
-		`id="stream-section-all" data-home-panel="all"`,
-		`id="stream-section-available" data-home-panel="available" hidden`,
-		`id="stream-section-active" data-home-panel="active" hidden`,
-		`id="stream-section-done" data-home-panel="done" hidden`,
-		`id="stream-section-terminated" data-home-panel="terminated" hidden`,
+		`data-home-root`,
+		`data-home-nav=`,
 		`panels.forEach((panel)`,
 		`panel.hidden = currentName !== panelName`,
 		`url.searchParams.set("filter", panelName)`,
 	} {
-		if !strings.Contains(compactBody, marker) {
-			t.Fatalf("expected single visible stream status marker %q, got: %s", marker, body)
+		if strings.Contains(body, marker) {
+			t.Fatalf("did not expect legacy client panel marker %q, got: %s", marker, body)
 		}
 	}
 	if strings.Contains(body, `scrollIntoView`) {
@@ -168,8 +147,10 @@ func TestHomeTemplateRendersEmptyStatusSections(t *testing.T) {
 			WorkflowName: "Demo workflow",
 		},
 		WorkflowDescription: "Previewable workflow",
+		Sort:                "time_desc",
 		StatusFilter:        "all",
-		ProcessGroups:       testHomeProcessGroups(),
+		FilterOptions:       testHomeFilterOptions(),
+		ProcessGroups:       testHomeActiveGroup("all"),
 	}
 
 	var out bytes.Buffer
@@ -179,15 +160,17 @@ func TestHomeTemplateRendersEmptyStatusSections(t *testing.T) {
 	body := out.String()
 	compactBody := strings.Join(strings.Fields(body), " ")
 
+	if !strings.Contains(compactBody, `No instances`) {
+		t.Fatalf("expected empty all-status marker, got: %s", body)
+	}
 	for _, marker := range []string{
-		`No instances`,
 		`No available instances`,
 		`No active instances`,
 		`No completed instances`,
 		`No terminated instances`,
 	} {
-		if !strings.Contains(compactBody, marker) {
-			t.Fatalf("expected empty status marker %q, got: %s", marker, body)
+		if strings.Contains(compactBody, marker) {
+			t.Fatalf("did not expect inactive empty marker %q, got: %s", marker, body)
 		}
 	}
 }
@@ -201,48 +184,10 @@ func TestHomeTemplateRendersStatusPagination(t *testing.T) {
 			WorkflowPath: "/w/workflow",
 			WorkflowName: "Demo workflow",
 		},
-		Sort:         "status",
-		StatusFilter: "active",
+		Sort:          "status",
+		StatusFilter:  "active",
+		FilterOptions: testHomeFilterOptions(),
 		ProcessGroups: []ProcessStatusGroup{
-			{
-				Status:              "all",
-				Label:               "All",
-				NavAriaLabel:        "All streams",
-				NavTitle:            "All stream instances",
-				Heading:             "All stream instances",
-				EmptyMessage:        "No instances",
-				PaginationAriaLabel: "All stream instances pagination",
-				PanelID:             "stream-section-all",
-				TotalCount:          0,
-				Sort:                "status",
-				CurrentPage:         1,
-				TotalPages:          1,
-				PageNumbers:         []int{1},
-				PageLinks:           []PaginationLink{{Page: 1, URL: "/w/workflow/?sort=status", IsCurrent: true}},
-				PreviousURL:         "/w/workflow/?sort=status",
-				NextURL:             "/w/workflow/?sort=status",
-				Processes:           nil,
-			},
-			{
-				Status:              "available",
-				Label:               "Available",
-				NavAriaLabel:        "Available streams",
-				NavTitle:            "Streams waiting for your input",
-				Heading:             "Available stream instances",
-				EmptyMessage:        "No available instances",
-				PaginationAriaLabel: "Available stream instances pagination",
-				PanelID:             "stream-section-available",
-				TotalCount:          0,
-				Sort:                "status",
-				SortFields:          []QueryInput{{Name: "filter", Value: "available"}},
-				CurrentPage:         1,
-				TotalPages:          1,
-				PageNumbers:         []int{1},
-				PageLinks:           []PaginationLink{{Page: 1, URL: "/w/workflow/?filter=available&sort=status", IsCurrent: true}},
-				PreviousURL:         "/w/workflow/?filter=available&sort=status",
-				NextURL:             "/w/workflow/?filter=available&sort=status",
-				Processes:           nil,
-			},
 			{
 				Status:              "active",
 				Label:               "Active",
@@ -280,6 +225,9 @@ func TestHomeTemplateRendersStatusPagination(t *testing.T) {
 	}
 	if !strings.Contains(compactBody, `/w/workflow/?filter=active&amp;page=3&amp;sort=status`) {
 		t.Fatalf("expected pagination to preserve filter, sort and page, got: %s", body)
+	}
+	if !strings.Contains(compactBody, `hx-get="/w/workflow/?filter=active&amp;page=3&amp;sort=status"`) {
+		t.Fatalf("expected pagination hx-get, got: %s", body)
 	}
 	if !strings.Contains(compactBody, `name="sort"`) {
 		t.Fatalf("expected global sort select, got: %s", body)
@@ -319,22 +267,25 @@ func TestHomeTemplateRendersStatusPagination(t *testing.T) {
 func TestHomeTemplateHighlightsProcessWhenItIsUsersTurn(t *testing.T) {
 	tmpl := parseTestTemplates(t)
 
+	item := StreamInstanceCard{
+		ID:            "process-1",
+		Status:        "available",
+		DetailHref:    "/w/workflow/process/process-1",
+		Percent:       25,
+		DoneSubsteps:  1,
+		TotalSubsteps: 4,
+		CreatedAt:     "1 Mar 2026 at 10:00 UTC",
+	}
 	view := HomeView{
 		PageBase: PageBase{
 			WorkflowKey:  "workflow",
 			WorkflowPath: "/w/workflow",
 			WorkflowName: "Demo workflow",
 		},
-		StatusFilter: "all",
-		ProcessGroups: testHomeProcessGroups(StreamInstanceCard{
-			ID:            "process-1",
-			Status:        "available",
-			DetailHref:    "/w/workflow/process/process-1",
-			Percent:       25,
-			DoneSubsteps:  1,
-			TotalSubsteps: 4,
-			CreatedAt:     "1 Mar 2026 at 10:00 UTC",
-		}),
+		Sort:          "time_desc",
+		StatusFilter:  "all",
+		FilterOptions: testHomeFilterOptions(item),
+		ProcessGroups: testHomeActiveGroup("all", item),
 	}
 
 	var out bytes.Buffer

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -355,6 +355,7 @@ type HomeView struct {
 	Error               string
 	Sort                string
 	StatusFilter        string
+	FilterOptions       []ProcessStatusGroup
 	ProcessGroups       []ProcessStatusGroup
 	Preview             StreamInstanceDetailView
 }
@@ -1805,77 +1806,113 @@ func homePaginationURL(workflowPath, filter, sort string, page int) string {
 	return target
 }
 
-func buildHomeProcessGroups(workflowPath string, processes []StreamInstanceCard, sortKey string, page int) []ProcessStatusGroup {
-	sortKey = normalizeHomeSortKey(sortKey)
+func homeProcessesByStatus(processes []StreamInstanceCard) map[string][]StreamInstanceCard {
 	byStatus := make(map[string][]StreamInstanceCard, len(homeProcessStatuses()))
 	for _, process := range processes {
 		byStatus[process.Status] = append(byStatus[process.Status], process)
 	}
+	return byStatus
+}
 
+func homeProcessItemsForStatus(processes []StreamInstanceCard, byStatus map[string][]StreamInstanceCard, status string) []StreamInstanceCard {
+	if status == "all" {
+		return append([]StreamInstanceCard(nil), processes...)
+	}
+	items := byStatus[status]
+	if len(items) == 0 {
+		return nil
+	}
+	return append([]StreamInstanceCard(nil), items...)
+}
+
+func buildHomeProcessGroupForStatus(workflowPath string, processes []StreamInstanceCard, byStatus map[string][]StreamInstanceCard, status, sortKey string, page int) ProcessStatusGroup {
+	sortKey = normalizeHomeSortKey(sortKey)
+	items := homeProcessItemsForStatus(processes, byStatus, status)
+	sortHomeProcessList(items, sortKey)
+	currentPage := normalizeHomePage(page, len(items))
+	totalPages := 1
+	if len(items) > 0 {
+		totalPages = (len(items) + homeProcessesPerPage - 1) / homeProcessesPerPage
+	}
+	start := (currentPage - 1) * homeProcessesPerPage
+	end := min(start+homeProcessesPerPage, len(items))
+	pagedItems := items
+	if start < len(items) {
+		pagedItems = items[start:end]
+	} else if len(items) > 0 {
+		pagedItems = items[:0]
+	}
+	pageNumbers := make([]int, 0, totalPages)
+	pageLinks := make([]PaginationLink, 0, totalPages)
+	panelID := "stream-section-" + status
+	for pageNum := 1; pageNum <= totalPages; pageNum++ {
+		pageNumbers = append(pageNumbers, pageNum)
+		pageLinks = append(pageLinks, PaginationLink{
+			Page:      pageNum,
+			URL:       homePaginationURL(workflowPath, status, sortKey, pageNum),
+			IsCurrent: pageNum == currentPage,
+		})
+	}
+	previousPage := max(currentPage-1, 1)
+	nextPage := min(currentPage+1, totalPages)
+	var sortFields []QueryInput
+	if status != "all" {
+		sortFields = []QueryInput{{Name: "filter", Value: status}}
+	}
+	navAriaLabel, navTitle, heading, emptyMessage, paginationAriaLabel := homeProcessStatusCopy(status)
+	return ProcessStatusGroup{
+		Status:              status,
+		Label:               processStatusLabel(status),
+		NavAriaLabel:        navAriaLabel,
+		NavTitle:            navTitle,
+		Heading:             heading,
+		EmptyMessage:        emptyMessage,
+		PaginationAriaLabel: paginationAriaLabel,
+		PanelID:             panelID,
+		Sort:                sortKey,
+		SortFields:          sortFields,
+		TotalCount:          len(items),
+		CurrentPage:         currentPage,
+		TotalPages:          totalPages,
+		PageNumbers:         pageNumbers,
+		PageLinks:           pageLinks,
+		HasPreviousPage:     currentPage > 1,
+		HasNextPage:         currentPage < totalPages,
+		PreviousPage:        previousPage,
+		NextPage:            nextPage,
+		PreviousURL:         homePaginationURL(workflowPath, status, sortKey, previousPage),
+		NextURL:             homePaginationURL(workflowPath, status, sortKey, nextPage),
+		Processes:           pagedItems,
+	}
+}
+
+func buildHomeFilterOptions(processes []StreamInstanceCard) []ProcessStatusGroup {
+	byStatus := homeProcessesByStatus(processes)
 	groups := make([]ProcessStatusGroup, 0, len(homeProcessStatuses()))
 	for _, status := range homeProcessStatuses() {
-		var items []StreamInstanceCard
-		if status == "all" {
-			items = append([]StreamInstanceCard(nil), processes...)
-		} else {
-			items = byStatus[status]
-		}
-		sortHomeProcessList(items, sortKey)
-		currentPage := normalizeHomePage(page, len(items))
-		totalPages := 1
-		if len(items) > 0 {
-			totalPages = (len(items) + homeProcessesPerPage - 1) / homeProcessesPerPage
-		}
-		start := (currentPage - 1) * homeProcessesPerPage
-		end := min(start+homeProcessesPerPage, len(items))
-		pagedItems := items
-		if start < len(items) {
-			pagedItems = items[start:end]
-		} else if len(items) > 0 {
-			pagedItems = items[:0]
-		}
-		pageNumbers := make([]int, 0, totalPages)
-		pageLinks := make([]PaginationLink, 0, totalPages)
-		panelID := "stream-section-" + status
-		for pageNum := 1; pageNum <= totalPages; pageNum++ {
-			pageNumbers = append(pageNumbers, pageNum)
-			pageLinks = append(pageLinks, PaginationLink{
-				Page:      pageNum,
-				URL:       homePaginationURL(workflowPath, status, sortKey, pageNum),
-				IsCurrent: pageNum == currentPage,
-			})
-		}
-		previousPage := max(currentPage-1, 1)
-		nextPage := min(currentPage+1, totalPages)
-		var sortFields []QueryInput
-		if status != "all" {
-			sortFields = []QueryInput{{Name: "filter", Value: status}}
-		}
-		navAriaLabel, navTitle, heading, emptyMessage, paginationAriaLabel := homeProcessStatusCopy(status)
+		navAriaLabel, navTitle, _, _, _ := homeProcessStatusCopy(status)
 		groups = append(groups, ProcessStatusGroup{
-			Status:              status,
-			Label:               processStatusLabel(status),
-			NavAriaLabel:        navAriaLabel,
-			NavTitle:            navTitle,
-			Heading:             heading,
-			EmptyMessage:        emptyMessage,
-			PaginationAriaLabel: paginationAriaLabel,
-			PanelID:             panelID,
-			Sort:                sortKey,
-			SortFields:          sortFields,
-			TotalCount:          len(items),
-			CurrentPage:         currentPage,
-			TotalPages:          totalPages,
-			PageNumbers:         pageNumbers,
-			PageLinks:           pageLinks,
-			HasPreviousPage:     currentPage > 1,
-			HasNextPage:         currentPage < totalPages,
-			PreviousPage:        previousPage,
-			NextPage:            nextPage,
-			PreviousURL:         homePaginationURL(workflowPath, status, sortKey, previousPage),
-			NextURL:             homePaginationURL(workflowPath, status, sortKey, nextPage),
-			Processes:           pagedItems,
+			Status:       status,
+			Label:        processStatusLabel(status),
+			NavAriaLabel: navAriaLabel,
+			NavTitle:     navTitle,
+			PanelID:      "stream-section-" + status,
+			TotalCount:   len(homeProcessItemsForStatus(processes, byStatus, status)),
 		})
+	}
+	return groups
+}
+
+func buildHomeActiveProcessGroup(workflowPath string, processes []StreamInstanceCard, statusFilter, sortKey string, page int) ProcessStatusGroup {
+	byStatus := homeProcessesByStatus(processes)
+	return buildHomeProcessGroupForStatus(workflowPath, processes, byStatus, normalizeHomeStatusFilter(statusFilter), sortKey, page)
+}
+
+func buildHomeProcessGroups(workflowPath string, processes []StreamInstanceCard, sortKey string, page int) []ProcessStatusGroup {
+	byStatus := homeProcessesByStatus(processes)
+	groups := make([]ProcessStatusGroup, 0, len(homeProcessStatuses()))
+	for _, status := range homeProcessStatuses() {
+		groups = append(groups, buildHomeProcessGroupForStatus(workflowPath, processes, byStatus, status, sortKey, page))
 	}
 	return groups
 }
@@ -4732,28 +4769,7 @@ func (s *Server) handleDeleteWorkflow(w http.ResponseWriter, r *http.Request) {
 	redirectHomeWithMessage(w, r, "confirmation", cfg.Workflow.Name+" was deleted.")
 }
 
-func (s *Server) handleWorkflowHome(w http.ResponseWriter, r *http.Request) {
-	user, _, ok := s.requireAuthenticatedPage(w, r)
-	if !ok {
-		return
-	}
-	workflowKey, cfg, err := s.selectedWorkflowUnvalidated(r)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	ctx := r.Context()
-	workflowError := homePickerMessage(r, "error")
-	if validationErr := s.validateWorkflowRefs(ctx, cfg); validationErr != nil {
-		var refErr *WorkflowRefValidationError
-		if !errors.As(validationErr, &refErr) {
-			http.Error(w, validationErr.Error(), http.StatusInternalServerError)
-			return
-		}
-		if workflowError == "" {
-			workflowError = refErr.Error()
-		}
-	}
+func (s *Server) buildWorkflowHomeView(ctx context.Context, r *http.Request, user *AccountUser, workflowKey string, cfg RuntimeConfig, workflowError string) HomeView {
 	sortKey := normalizeHomeSortKey(strings.TrimSpace(r.URL.Query().Get("sort")))
 	statusFilter := normalizeHomeStatusFilter(r.URL.Query().Get("filter"))
 	page := parsePositiveInt(r.URL.Query().Get("page"), 1)
@@ -4769,7 +4785,7 @@ func (s *Server) handleWorkflowHome(w http.ResponseWriter, r *http.Request) {
 			actor.Role = actor.RoleSlugs[0]
 		}
 	}
-	roleMeta := s.roleMetaIndex(r.Context())
+	roleMeta := s.roleMetaIndex(ctx)
 
 	totalSubsteps := countWorkflowSubsteps(cfg.Workflow)
 	var processes []StreamInstanceCard
@@ -4805,7 +4821,8 @@ func (s *Server) handleWorkflowHome(w http.ResponseWriter, r *http.Request) {
 		processes = append(processes, item)
 	}
 
-	processGroups := buildHomeProcessGroups(workflowPath(workflowKey), processes, sortKey, page)
+	filterOptions := buildHomeFilterOptions(processes)
+	activeGroup := buildHomeActiveProcessGroup(path, processes, statusFilter, sortKey, page)
 
 	preview := makeStreamInstanceDetailReadOnly(
 		s.buildStreamInstanceDetailView(ctx, cfg, workflowKey, buildWorkflowPreviewProcess(cfg.Workflow, workflowKey), actor, "", "", false),
@@ -4813,19 +4830,60 @@ func (s *Server) handleWorkflowHome(w http.ResponseWriter, r *http.Request) {
 	)
 	preview.HideStatus = true
 
-	view := HomeView{
+	return HomeView{
 		PageBase:            s.pageBaseForUser(user, "home_body", workflowKey, cfg.Workflow.Name),
 		Breadcrumbs:         buildStreamBreadcrumbs(workflowKey, cfg.Workflow.Name),
 		WorkflowDescription: strings.TrimSpace(cfg.Workflow.Description),
 		Error:               workflowError,
 		Sort:                sortKey,
 		StatusFilter:        statusFilter,
-		ProcessGroups:       processGroups,
+		FilterOptions:       filterOptions,
+		ProcessGroups:       []ProcessStatusGroup{activeGroup},
 		Preview:             preview,
 	}
+}
+
+func (s *Server) renderStreamDashboard(w http.ResponseWriter, view HomeView) {
 	if err := s.tmpl.ExecuteTemplate(w, "stream.html", view); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
+}
+
+func (s *Server) renderStreamDashboardResults(w http.ResponseWriter, view HomeView) {
+	if err := s.tmpl.ExecuteTemplate(w, "stream_dashboard_results", view); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (s *Server) handleWorkflowHome(w http.ResponseWriter, r *http.Request) {
+	user, _, ok := s.requireAuthenticatedPage(w, r)
+	if !ok {
+		return
+	}
+	workflowKey, cfg, err := s.selectedWorkflowUnvalidated(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	ctx := r.Context()
+	workflowError := homePickerMessage(r, "error")
+	if validationErr := s.validateWorkflowRefs(ctx, cfg); validationErr != nil {
+		var refErr *WorkflowRefValidationError
+		if !errors.As(validationErr, &refErr) {
+			http.Error(w, validationErr.Error(), http.StatusInternalServerError)
+			return
+		}
+		if workflowError == "" {
+			workflowError = refErr.Error()
+		}
+	}
+
+	view := s.buildWorkflowHomeView(ctx, r, user, workflowKey, cfg, workflowError)
+	if isHTMXRequest(r) {
+		s.renderStreamDashboardResults(w, view)
+		return
+	}
+	s.renderStreamDashboard(w, view)
 }
 
 func (s *Server) handleStartProcess(w http.ResponseWriter, r *http.Request) {

--- a/server/cmd/server/panel_markup_test.go
+++ b/server/cmd/server/panel_markup_test.go
@@ -251,7 +251,9 @@ func TestStreamHomeBodyPanelMarkup(t *testing.T) {
 			WorkflowName: "Demo workflow",
 		},
 		StatusFilter:  "all",
-		ProcessGroups: testHomeProcessGroups(),
+		Sort:          "time_desc",
+		FilterOptions: testHomeFilterOptions(),
+		ProcessGroups: testHomeActiveProcessGroups(nil, "all", "time_desc", 1),
 	}
 	if err := tmpl.ExecuteTemplate(&out, "home_body", view); err != nil {
 		t.Fatalf("render home_body: %v", err)
@@ -259,11 +261,11 @@ func TestStreamHomeBodyPanelMarkup(t *testing.T) {
 	body := out.String()
 
 	for _, want := range []string{
+		`id="stream-dashboard-results"`,
 		`class="rail-layout rail-layout-ready"`,
 		`class="panel panel-sticky"`,
 		`class="stream-status-filter-nav"`,
 		`class="stream-status-filter-select"`,
-		`data-home-filter-select`,
 		`class="stream-status-filter-option is-active"`,
 		`class="status-tag status-tag-compact"`,
 		`data-stream-status="all"`,
@@ -315,9 +317,9 @@ func TestStreamHomeBodyPanelMarkup(t *testing.T) {
 	}
 
 	mainStart := strings.Index(body, `class="rail-layout-main home-workflow-panel-main"`)
-	mainEnd := strings.Index(body, `class="stream-status-sections"`)
+	mainEnd := strings.Index(body, `class="stream-status-section"`)
 	if mainStart == -1 || mainEnd == -1 || mainStart >= mainEnd {
-		t.Fatal("expected rail-layout-main wrapping stream status sections")
+		t.Fatal("expected rail-layout-main wrapping stream status section")
 	}
 	mainBlock := body[mainStart:mainEnd]
 	if strings.Contains(mainBlock, `<section class="panel"`) || strings.Contains(mainBlock, `<section class="panel `) {

--- a/server/templates/icons.html
+++ b/server/templates/icons.html
@@ -49,7 +49,7 @@
     stroke-width="2"
     stroke-linecap="round"
     stroke-linejoin="round"
-    class="icon-svg icon-svg-lg account-icon"
+    class="icon-svg icon-svg-md account-icon"
     aria-hidden="true"
   >
     <circle cx="12" cy="12" r="10" />

--- a/server/templates/icons.html
+++ b/server/templates/icons.html
@@ -1,16 +1,17 @@
 {{ define "icon-theme-moon" }}
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    stroke="currentColor"
-    fill="none"
-    class="icon-svg icon-svg-md theme-icon-moon"
     viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="icon-svg icon-svg-md theme-icon-moon"
     aria-hidden="true"
   >
     <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"
+      d="M20.985 12.486a9 9 0 1 1-9.473-9.472c.405-.022.617.46.402.803a6 6 0 0 0 8.268 8.268c.344-.215.825-.004.803.401"
     />
   </svg>
 {{ end }}
@@ -18,114 +19,139 @@
 {{ define "icon-theme-sun" }}
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    stroke="currentColor"
-    fill="none"
-    class="icon-svg icon-svg-md theme-icon-sun"
     viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="icon-svg icon-svg-md theme-icon-sun"
     aria-hidden="true"
   >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"
-    />
+    <circle cx="12" cy="12" r="4" />
+    <path d="M12 2v2" />
+    <path d="M12 20v2" />
+    <path d="m4.93 4.93 1.41 1.41" />
+    <path d="m17.66 17.66 1.41 1.41" />
+    <path d="M2 12h2" />
+    <path d="M20 12h2" />
+    <path d="m6.34 17.66-1.41 1.41" />
+    <path d="m19.07 4.93-1.41 1.41" />
   </svg>
 {{ end }}
 
 {{ define "icon-account" }}
   <svg
-    class="icon-svg icon-svg-lg account-icon"
     xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 16 16"
-    fill="currentColor"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="icon-svg icon-svg-lg account-icon"
     aria-hidden="true"
   >
-    <path d="M11 6a3 3 0 1 1-6 0 3 3 0 0 1 6 0" />
-    <path
-      fill-rule="evenodd"
-      d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8m8-7a7 7 0 0 0-5.468 11.37C3.242 11.226 4.805 10 8 10s4.757 1.225 5.468 2.37A7 7 0 0 0 8 1"
-    />
+    <circle cx="12" cy="12" r="10" />
+    <circle cx="12" cy="10" r="3" />
+    <path d="M7 20.662V19a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v1.662" />
   </svg>
 {{ end }}
 
 {{ define "icon-building-grid" }}
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    fill="currentColor"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
     class="icon-svg icon-svg-md"
-    viewBox="0 0 16 16"
+    aria-hidden="true"
   >
-    <path
-      d="M4 2.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5zm3 0a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5zm3.5-.5a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h1a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5zM4 5.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5zM7.5 5a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h1a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5zm2.5.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5zM4.5 8a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h1a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5zm2.5.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5zm3.5-.5a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h1a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5z"
-    />
-    <path
-      d="M2 1a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1zm11 0H3v14h3v-2.5a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 .5.5V15h3z"
-    />
+    <path d="M10 12h4" />
+    <path d="M10 8h4" />
+    <path d="M14 21v-3a2 2 0 0 0-4 0v3" />
+    <path d="M6 10H4a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-2" />
+    <path d="M6 21V5a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v16" />
   </svg>
 {{ end }}
 
 {{ define "icon-users-group" }}
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    fill="currentColor"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
     class="icon-svg icon-svg-md"
-    viewBox="0 0 16 16"
+    aria-hidden="true"
   >
-    <path
-      d="M7 14s-1 0-1-1 1-4 5-4 5 3 5 4-1 1-1 1zm4-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6m-5.784 6A2.24 2.24 0 0 1 5 13c0-1.355.68-2.75 1.936-3.72A6.3 6.3 0 0 0 5 9c-4 0-5 3-5 4s1 1 1 1zM4.5 8a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5"
-    />
+    <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+    <path d="M16 3.128a4 4 0 0 1 0 7.744" />
+    <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+    <circle cx="9" cy="7" r="4" />
   </svg>
 {{ end }}
 
 {{ define "icon-sign-out" }}
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    fill="currentColor"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
     class="icon-svg icon-svg-md"
-    viewBox="0 0 16 16"
+    aria-hidden="true"
   >
-    <path
-      fill-rule="evenodd"
-      d="M10 12.5a.5.5 0 0 1-.5.5h-8a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5h8a.5.5 0 0 1 .5.5v2a.5.5 0 0 0 1 0v-2A1.5 1.5 0 0 0 9.5 2h-8A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h8a1.5 1.5 0 0 0 1.5-1.5v-2a.5.5 0 0 0-1 0z"
-    />
-    <path
-      fill-rule="evenodd"
-      d="M15.854 8.354a.5.5 0 0 0 0-.708l-3-3a.5.5 0 0 0-.708.708L14.293 7.5H5.5a.5.5 0 0 0 0 1h8.793l-2.147 2.146a.5.5 0 0 0 .708.708z"
-    />
+    <path d="m16 17 5-5-5-5" />
+    <path d="M21 12H9" />
+    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
   </svg>
 {{ end }}
 
 {{ define "icon-trash" }}
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 16 16"
-    fill="currentColor"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
     class="icon-svg icon-svg-md"
     aria-hidden="true"
   >
-    <path
-      d="M5.5 5.5A.5.5 0 0 1 6 6v5a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0A.5.5 0 0 1 8.5 6v5a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v5a.5.5 0 0 0 1 0z"
-    />
-    <path
-      d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 1 1 0-2H5V1.5A1.5 1.5 0 0 1 6.5 0h3A1.5 1.5 0 0 1 11 1.5V2h2.5a1 1 0 0 1 1 1M6 2h4v-.5a.5.5 0 0 0-.5-.5h-3a.5.5 0 0 0-.5.5zM4 4v9a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4z"
-    />
+    <path d="M10 11v6" />
+    <path d="M14 11v6" />
+    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+    <path d="M3 6h18" />
+    <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
   </svg>
 {{ end }}
 
 {{ define "icon-trash-muted" }}
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 16 16"
-    fill="var(--muted-foreground)"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="var(--muted-foreground)"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
     class="icon-svg icon-svg-md"
     aria-hidden="true"
   >
-    <path
-      d="M5.5 5.5A.5.5 0 0 1 6 6v5a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0A.5.5 0 0 1 8.5 6v5a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v5a.5.5 0 0 0 1 0z"
-    />
-    <path
-      d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 1 1 0-2H5V1.5A1.5 1.5 0 0 1 6.5 0h3A1.5 1.5 0 0 1 11 1.5V2h2.5a1 1 0 0 1 1 1M6 2h4v-.5a.5.5 0 0 0-.5-.5h-3a.5.5 0 0 0-.5.5zM4 4v9a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4z"
-    />
+    <path d="M10 11v6" />
+    <path d="M14 11v6" />
+    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+    <path d="M3 6h18" />
+    <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
   </svg>
 {{ end }}
 
@@ -184,12 +210,17 @@
 {{ define "icon-play" }}
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    fill="currentColor"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
     class="icon-svg icon-svg-md"
-    viewBox="0 0 16 16"
+    aria-hidden="true"
   >
     <path
-      d="m11.596 8.697-6.363 3.692c-.54.313-1.233-.066-1.233-.697V4.308c0-.63.692-1.01 1.233-.696l6.363 3.692a.802.802 0 0 1 0 1.393"
+      d="M5 5a2 2 0 0 1 3.008-1.728l11.997 6.998a2 2 0 0 1 .003 3.458l-12 7A2 2 0 0 1 5 19z"
     />
   </svg>
 {{ end }}
@@ -234,35 +265,42 @@
 {{ define "icon-eye" }}
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    fill="currentColor"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
     class="icon-svg icon-svg-md icon-eye"
-    viewBox="0 0 16 16"
+    aria-hidden="true"
   >
     <path
-      d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8M1.173 8a13 13 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5s3.879 1.168 5.168 2.457A13 13 0 0 1 14.828 8q-.086.13-.195.288c-.335.48-.83 1.12-1.465 1.755C11.879 11.332 10.119 12.5 8 12.5s-3.879-1.168-5.168-2.457A13 13 0 0 1 1.172 8z"
+      d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"
     />
-    <path
-      d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5M4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0"
-    />
+    <circle cx="12" cy="12" r="3" />
   </svg>
 {{ end }}
 
 {{ define "icon-eye-off" }}
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    fill="currentColor"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
     class="icon-svg icon-svg-md icon-eye-off"
-    viewBox="0 0 16 16"
+    aria-hidden="true"
   >
     <path
-      d="M13.359 11.238C15.06 9.72 16 8 16 8s-3-5.5-8-5.5a7 7 0 0 0-2.79.588l.77.771A6 6 0 0 1 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13 13 0 0 1 14.828 8q-.086.13-.195.288c-.335.48-.83 1.12-1.465 1.755q-.247.248-.517.486z"
+      d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49"
     />
+    <path d="M14.084 14.158a3 3 0 0 1-4.242-4.242" />
     <path
-      d="M11.297 9.176a3.5 3.5 0 0 0-4.474-4.474l.823.823a2.5 2.5 0 0 1 2.829 2.829zm-2.943 1.299.822.822a3.5 3.5 0 0 1-4.474-4.474l.823.823a2.5 2.5 0 0 0 2.829 2.829"
+      d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143"
     />
-    <path
-      d="M3.35 5.47q-.27.24-.518.487A13 13 0 0 0 1.172 8l.195.288c.335.48.83 1.12 1.465 1.755C4.121 11.332 5.881 12.5 8 12.5c.716 0 1.39-.133 2.02-.36l.77.772A7 7 0 0 1 8 13.5C3 13.5 0 8 0 8s.939-1.721 2.641-3.238l.708.709zm10.296 8.884-12-12 .708-.708 12 12z"
-    />
+    <path d="m2 2 20 20" />
   </svg>
 {{ end }}
 
@@ -571,12 +609,13 @@
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24"
-    fill="currentColor"
+    fill="none"
     stroke="currentColor"
     stroke-width="2"
     stroke-linecap="round"
     stroke-linejoin="round"
     class="icon-svg icon-svg-md"
+    aria-hidden="true"
   >
     <circle cx="18" cy="5" r="3" />
     <circle cx="6" cy="12" r="3" />

--- a/server/templates/layout.html
+++ b/server/templates/layout.html
@@ -181,7 +181,7 @@
                     {{ if .ShowMyOrgLink }}
                       <a href="/org-admin/profile" class="account-menu-item">
                         {{ template "icon-users-group" . }}
-                        My Org
+                        My organization
                       </a>
                     {{ end }}
                     <form method="post" action="/logout">

--- a/server/templates/pages/stream.html
+++ b/server/templates/pages/stream.html
@@ -23,7 +23,6 @@
             <button
               class="btn btn-secondary"
               type="button"
-              data-home-nav="preview"
               onclick="document.getElementById('stream-preview-dialog').showModal()"
             >
               {{ template "icon-eye" . }}
@@ -51,353 +50,277 @@
         <div class="error-detail">{{ .Error }}</div>
       </div>
     {{ else }}
-      <div class="rail-layout rail-layout-ready" data-home-root>
-        <section class="panel panel-sticky">
-          <div class="stream-status-filter">
-            <span
-              class="stream-status-rail-label"
-              id="stream-status-filter-label"
-            >
-              {{ template "icon-filter" . }}
-              Filter by status
-            </span>
-            <nav
-              class="stream-status-filter-nav"
-              aria-labelledby="stream-status-filter-label"
-            >
-              {{ range .ProcessGroups }}
-                <button
-                  type="button"
-                  class="stream-status-filter-option{{ if eq .Status $.StatusFilter }} is-active{{ end }}"
-                  data-home-nav="{{ .Status }}"
-                  aria-controls="{{ .PanelID }}"
-                  aria-current="{{ if eq .Status $.StatusFilter }}page{{ else }}false{{ end }}"
-                  aria-label="{{ .NavAriaLabel }}"
-                  title="{{ .NavTitle }}"
-                >
-                  {{ template "status_tag" .Status }}
-                </button>
-              {{ end }}
-            </nav>
-            <select
-              id="stream-status-filter-select"
-              class="stream-status-filter-select"
-              aria-labelledby="stream-status-filter-label"
-              data-home-filter-select
-            >
-              <button type="button">
-                <selectedcontent></selectedcontent>
-              </button>
-              {{ range .ProcessGroups }}
-                <option
-                  value="{{ .Status }}"
-                  {{ if eq .Status $.StatusFilter }}selected{{ end }}
-                >
-                  {{ template "status_tag" .Status }}
-                </option>
-              {{ end }}
-            </select>
-          </div>
-          {{ range .ProcessGroups }}
-            <form
-              method="get"
-              action="{{ $.WorkflowPath }}/"
-              class="stream-status-sort"
-              data-home-panel="{{ .Status }}"
-              {{ if ne .Status $.StatusFilter }}hidden{{ end }}
-            >
-              {{ range .SortFields }}
-                <input
-                  type="hidden"
-                  name="{{ .Name }}"
-                  value="{{ .Value }}"
-                />
-              {{ end }}
-              <label
-                class="stream-status-sort-control"
-                for="stream-sort-{{ .Status }}"
-              >
-                <span class="stream-status-rail-label">
-                  {{ template "icon-sort" . }}
-                  Sort by
-                </span>
-                <select
-                  id="stream-sort-{{ .Status }}"
-                  name="sort"
-                  onchange="this.form.submit()"
-                >
-                  <option
-                    value="time_desc"
-                    {{ if eq .Sort "time_desc" }}selected{{ end }}
-                  >
-                    Newest
-                  </option>
-                  <option
-                    value="time_asc"
-                    {{ if eq .Sort "time_asc" }}selected{{ end }}
-                  >
-                    Oldest
-                  </option>
-                  <option
-                    value="progress_desc"
-                    {{ if eq .Sort "progress_desc" }}selected{{ end }}
-                  >
-                    Most advanced
-                  </option>
-                  <option
-                    value="progress_asc"
-                    {{ if eq .Sort "progress_asc" }}selected{{ end }}
-                  >
-                    Least advanced
-                  </option>
-                  <option
-                    value="status"
-                    {{ if eq .Sort "status" }}selected{{ end }}
-                  >
-                    Status
-                  </option>
-                </select>
-              </label>
-            </form>
-          {{ end }}
-        </section>
-
-        <div class="rail-layout-main home-workflow-panel-main">
-          <dialog id="new-instance-dialog" class="dialog">
-            <div class="dialog-card">
-              <header class="dialog-head">
-                <div>
-                  <h3 class="dialog-title">New instance</h3>
-                  <p class="dialog-subtitle">
-                    Give this stream instance a brief name
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  class="btn btn-ghost btn-icon dialog-close"
-                  onclick="document.getElementById('new-instance-dialog').close()"
-                >
-                  {{ template "icon-close" . }}
-                </button>
-              </header>
-              <form
-                method="post"
-                action="{{ .WorkflowPath }}/process/start"
-                class="input-form"
-              >
-                <div class="form-field">
-                  <label for="instance-name">Instance name</label>
-                  <input
-                    id="instance-name"
-                    name="name"
-                    type="text"
-                    maxlength="80"
-                    autocomplete="off"
-                  />
-                </div>
-                <div class="dialog-actions">
-                  <button class="btn btn-primary" type="submit">
-                    {{ template "icon-play" . }}
-                    Start instance
-                  </button>
-                </div>
-              </form>
+      <dialog id="new-instance-dialog" class="dialog">
+        <div class="dialog-card">
+          <header class="dialog-head">
+            <div>
+              <h3 class="dialog-title">New instance</h3>
+              <p class="dialog-subtitle">
+                Give this stream instance a brief name
+              </p>
             </div>
-          </dialog>
-          <dialog
-            id="stream-preview-dialog"
-            class="dialog"
+            <button
+              type="button"
+              class="btn btn-ghost btn-icon dialog-close"
+              onclick="document.getElementById('new-instance-dialog').close()"
+            >
+              {{ template "icon-close" . }}
+            </button>
+          </header>
+          <form
+            method="post"
+            action="{{ .WorkflowPath }}/process/start"
+            class="input-form"
           >
-            <div class="dialog-card">
-              <header class="dialog-head">
-                <div>
-                  <h3 class="dialog-title">Stream preview</h3>
-                  <p class="dialog-subtitle">
-                    Inspect the stream timeline and form structure in read-only
-                    mode
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  class="btn btn-ghost btn-icon dialog-close"
-                  onclick="document.getElementById('stream-preview-dialog').close()"
-                >
-                  {{ template "icon-close" . }}
-                </button>
-              </header>
-              <div class="stream-preview-body">
-                {{ template "stream_timeline" .Preview.StreamTimeline }}
-              </div>
+            <div class="form-field">
+              <label for="instance-name">Instance name</label>
+              <input
+                id="instance-name"
+                name="name"
+                type="text"
+                maxlength="80"
+                autocomplete="off"
+              />
             </div>
-          </dialog>
-          <div class="stream-status-sections">
-            {{ range .ProcessGroups }}
-              <section
-                class="stream-status-section"
-                id="{{ .PanelID }}"
-                data-home-panel="{{ .Status }}"
-                {{ if ne .Status $.StatusFilter }}hidden{{ end }}
-              >
-                <div class="stream-status-section-head">
-                  <h3>{{ .Heading }}</h3>
-                </div>
-                {{ if .Processes }}
-                  <ul class="stream-instance-card-list">
-                    {{ range .Processes }}
-                      {{ template "stream_instance_card" . }}
-                    {{ end }}
-                  </ul>
-                {{ else }}
-                  <div class="stream-instance-card-empty">
-                    <p class="muted">{{ .EmptyMessage }}</p>
-                  </div>
-                {{ end }}
-                {{ if gt .TotalPages 1 }}
-                  <nav
-                    class="platform-admin-pagination platform-admin-pagination--inline"
-                    aria-label="{{ .PaginationAriaLabel }}"
-                  >
-                    <div class="platform-admin-pagination-pages">
-                      <a
-                        class="btn btn-secondary pagination-btn{{ if not .HasPreviousPage }} is-disabled{{ end }}"
-                        href="{{ .PreviousURL }}"
-                      >
-                        {{ template "icon-chevron-left" . }}
-                      </a>
-                      {{ range .PageLinks }}
-                        <a
-                          class="{{ if .IsCurrent }}
-                            btn btn-primary
-                          {{ else }}
-                            btn btn-secondary
-                          {{ end }}"
-                          href="{{ .URL }}"
-                          >{{ .Page }}</a
-                        >
-                      {{ end }}
-                      <a
-                        class="btn btn-secondary pagination-btn{{ if not .HasNextPage }} is-disabled{{ end }}"
-                        href="{{ .NextURL }}"
-                      >
-                        {{ template "icon-chevron-right" . }}
-                      </a>
-                    </div>
-                  </nav>
-                {{ end }}
-              </section>
-            {{ end }}
+            <div class="dialog-actions">
+              <button class="btn btn-primary" type="submit">
+                {{ template "icon-play" . }}
+                Start instance
+              </button>
+            </div>
+          </form>
+        </div>
+      </dialog>
+      <dialog id="stream-preview-dialog" class="dialog">
+        <div class="dialog-card">
+          <header class="dialog-head">
+            <div>
+              <h3 class="dialog-title">Stream preview</h3>
+              <p class="dialog-subtitle">
+                Inspect the stream timeline and form structure in read-only mode
+              </p>
+            </div>
+            <button
+              type="button"
+              class="btn btn-ghost btn-icon dialog-close"
+              onclick="document.getElementById('stream-preview-dialog').close()"
+            >
+              {{ template "icon-close" . }}
+            </button>
+          </header>
+          <div class="stream-preview-body">
+            {{ template "stream_timeline" .Preview.StreamTimeline }}
           </div>
         </div>
-      </div>
+      </dialog>
 
-      <script>
-        (function () {
-          const homeRoot = document.querySelector("[data-home-root]");
-          if (!homeRoot) {
-            return;
-          }
-
-          const panels = Array.from(homeRoot.querySelectorAll("[data-home-panel]"));
-          const statusPanelNames = panels.map((panel) =>
-            (panel.getAttribute("data-home-panel") || "").trim(),
-          );
-
-          const defaultPanelName = statusPanelNames.includes("all")
-            ? "all"
-            : statusPanelNames[0] || "";
-
-          const syncFilterURL = (panelName) => {
-            try {
-              const url = new URL(window.location.href);
-              if (panelName && panelName !== "all") {
-                url.searchParams.set("filter", panelName);
-              } else {
-                url.searchParams.delete("filter");
-              }
-              url.searchParams.delete("page");
-              url.hash = "";
-              window.history.replaceState({}, "", url);
-            } catch (_err) {}
-          };
-
-          const initialPanelName = () => {
-            const params = new URLSearchParams(window.location.search);
-            const filterParam = (params.get("filter") || "").trim().toLowerCase();
-            if (statusPanelNames.includes(filterParam)) {
-              return filterParam;
-            }
-
-            const hashPanelID = window.location.hash.replace(/^#/, "");
-            if (hashPanelID) {
-              const hashPanel = panels.find((panel) => panel.id === hashPanelID);
-              if (hashPanel) {
-                return (hashPanel.getAttribute("data-home-panel") || "").trim();
-              }
-            }
-
-            return defaultPanelName;
-          };
-
-          const filterSelect = homeRoot.querySelector(
-            "[data-home-filter-select]",
-          );
-
-          const showPanel = (panelName, options = {}) => {
-            if (!statusPanelNames.includes(panelName)) {
-              panelName = defaultPanelName;
-            }
-
-            const buttons = Array.from(
-              homeRoot.querySelectorAll("[data-home-nav]"),
-            );
-            buttons.forEach((button) => {
-              const currentName = button.getAttribute("data-home-nav");
-              const isActive = currentName === panelName;
-              button.classList.toggle("is-active", isActive);
-              button.setAttribute("aria-current", isActive ? "page" : "false");
-            });
-
-            panels.forEach((panel) => {
-              const currentName = panel.getAttribute("data-home-panel");
-              panel.hidden = currentName !== panelName;
-            });
-
-            if (filterSelect && statusPanelNames.includes(panelName)) {
-              filterSelect.value = panelName;
-            }
-
-            if (options.syncURL) {
-              syncFilterURL(panelName);
-            }
-          };
-
-          Array.from(homeRoot.querySelectorAll("[data-home-nav]")).forEach(
-            (button) => {
-              button.addEventListener("click", () => {
-                const panelName = (
-                  button.getAttribute("data-home-nav") || ""
-                ).trim();
-                if (panelName === "preview") {
-                  return;
-                }
-                showPanel(panelName, { syncURL: true });
-              });
-            },
-          );
-
-          if (filterSelect) {
-            filterSelect.addEventListener("change", () => {
-              showPanel(
-                (filterSelect.value || "").trim(),
-                { syncURL: true },
-              );
-            });
-          }
-
-          showPanel(initialPanelName(), { syncURL: true });
-        })();
-      </script>
+      {{ template "stream_dashboard_results" . }}
     {{ end }}
+  </div>
+{{ end }}
+
+{{ define "stream_dashboard_results" }}
+  <div id="stream-dashboard-results" class="rail-layout rail-layout-ready">
+    <section class="panel panel-sticky">
+      <div class="stream-status-filter">
+        <span class="stream-status-rail-label" id="stream-status-filter-label">
+          {{ template "icon-filter" . }}
+          Filter by status
+        </span>
+        <nav
+          class="stream-status-filter-nav"
+          aria-labelledby="stream-status-filter-label"
+        >
+          {{ range .FilterOptions }}
+            <a
+              class="stream-status-filter-option{{ if eq .Status $.StatusFilter }} is-active{{ end }}"
+              href="{{ $.WorkflowPath }}/{{- if or (ne .Status "all") (ne $.Sort "time_desc") -}}
+                ?{{- if ne .Status "all" -}}
+                  filter={{ .Status }}{{- if ne $.Sort "time_desc" -}}&{{ end -}}
+                {{- end -}}{{- if ne $.Sort "time_desc" -}}
+                  sort={{ $.Sort }}
+                {{- end -}}
+              {{- end -}}"
+              hx-get="{{ $.WorkflowPath }}/{{- if or (ne .Status "all") (ne $.Sort "time_desc") -}}
+                ?{{- if ne .Status "all" -}}
+                  filter={{ .Status }}{{- if ne $.Sort "time_desc" -}}&{{ end -}}
+                {{- end -}}{{- if ne $.Sort "time_desc" -}}
+                  sort={{ $.Sort }}
+                {{- end -}}
+              {{- end -}}"
+              hx-target="#stream-dashboard-results"
+              hx-select="#stream-dashboard-results"
+              hx-swap="outerHTML"
+              hx-push-url="true"
+              aria-controls="{{ .PanelID }}"
+              aria-current="{{ if eq .Status $.StatusFilter }}page{{ else }}false{{ end }}"
+              aria-label="{{ .NavAriaLabel }}"
+              title="{{ .NavTitle }}"
+            >
+              {{ template "status_tag" .Status }}
+            </a>
+          {{ end }}
+        </nav>
+        <form
+          method="get"
+          action="{{ .WorkflowPath }}/"
+          hx-get="{{ .WorkflowPath }}/"
+          hx-target="#stream-dashboard-results"
+          hx-select="#stream-dashboard-results"
+          hx-swap="outerHTML"
+          hx-push-url="true"
+          hx-trigger="change from:#stream-status-filter-select"
+        >
+          {{ if ne .Sort "time_desc" }}
+            <input type="hidden" name="sort" value="{{ .Sort }}" />
+          {{ end }}
+          <select
+            id="stream-status-filter-select"
+            class="stream-status-filter-select"
+            name="filter"
+            aria-labelledby="stream-status-filter-label"
+          >
+            <button type="button">
+              <selectedcontent></selectedcontent>
+            </button>
+            {{ range .FilterOptions }}
+              <option
+                value="{{ .Status }}"
+                {{ if eq .Status $.StatusFilter }}selected{{ end }}
+              >
+                {{ template "status_tag" .Status }}
+              </option>
+            {{ end }}
+          </select>
+        </form>
+      </div>
+      {{ range .ProcessGroups }}
+          <form
+            method="get"
+            action="{{ $.WorkflowPath }}/"
+            class="stream-status-sort"
+            hx-get="{{ $.WorkflowPath }}/"
+            hx-target="#stream-dashboard-results"
+            hx-select="#stream-dashboard-results"
+            hx-swap="outerHTML"
+            hx-push-url="true"
+            hx-trigger="change from:select"
+          >
+            {{ range .SortFields }}
+              <input type="hidden" name="{{ .Name }}" value="{{ .Value }}" />
+            {{ end }}
+            <label
+              class="stream-status-sort-control"
+              for="stream-sort-{{ .Status }}"
+            >
+              <span class="stream-status-rail-label">
+                {{ template "icon-sort" . }}
+                Sort by
+              </span>
+              <select id="stream-sort-{{ .Status }}" name="sort">
+                <option
+                  value="time_desc"
+                  {{ if eq .Sort "time_desc" }}selected{{ end }}
+                >
+                  Newest
+                </option>
+                <option
+                  value="time_asc"
+                  {{ if eq .Sort "time_asc" }}selected{{ end }}
+                >
+                  Oldest
+                </option>
+                <option
+                  value="progress_desc"
+                  {{ if eq .Sort "progress_desc" }}selected{{ end }}
+                >
+                  Most advanced
+                </option>
+                <option
+                  value="progress_asc"
+                  {{ if eq .Sort "progress_asc" }}selected{{ end }}
+                >
+                  Least advanced
+                </option>
+                <option
+                  value="status"
+                  {{ if eq .Sort "status" }}selected{{ end }}
+                >
+                  Status
+                </option>
+              </select>
+            </label>
+          </form>
+      {{ end }}
+    </section>
+
+    <div class="rail-layout-main home-workflow-panel-main">
+      {{ range .ProcessGroups }}
+          <section class="stream-status-section" id="{{ .PanelID }}">
+            <div class="stream-status-section-head">
+              <h3>{{ .Heading }}</h3>
+            </div>
+            {{ if .Processes }}
+              <ul class="stream-instance-card-list">
+                {{ range .Processes }}
+                  {{ template "stream_instance_card" . }}
+                {{ end }}
+              </ul>
+            {{ else }}
+              <div class="stream-instance-card-empty">
+                <p class="muted">{{ .EmptyMessage }}</p>
+              </div>
+            {{ end }}
+            {{ if gt .TotalPages 1 }}
+              <nav
+                class="platform-admin-pagination platform-admin-pagination--inline"
+                aria-label="{{ .PaginationAriaLabel }}"
+              >
+                <div class="platform-admin-pagination-pages">
+                  <a
+                    class="btn btn-secondary pagination-btn{{ if not .HasPreviousPage }} is-disabled{{ end }}"
+                    href="{{ .PreviousURL }}"
+                    hx-get="{{ .PreviousURL }}"
+                    hx-target="#stream-dashboard-results"
+                    hx-select="#stream-dashboard-results"
+                    hx-swap="outerHTML"
+                    hx-push-url="true"
+                  >
+                    {{ template "icon-chevron-left" . }}
+                  </a>
+                  {{ range .PageLinks }}
+                    <a
+                      class="{{ if .IsCurrent }}
+                        btn btn-primary
+                      {{ else }}
+                        btn btn-secondary
+                      {{ end }}"
+                      href="{{ .URL }}"
+                      hx-get="{{ .URL }}"
+                      hx-target="#stream-dashboard-results"
+                      hx-select="#stream-dashboard-results"
+                      hx-swap="outerHTML"
+                      hx-push-url="true"
+                      >{{ .Page }}</a
+                    >
+                  {{ end }}
+                  <a
+                    class="btn btn-secondary pagination-btn{{ if not .HasNextPage }} is-disabled{{ end }}"
+                    href="{{ .NextURL }}"
+                    hx-get="{{ .NextURL }}"
+                    hx-target="#stream-dashboard-results"
+                    hx-select="#stream-dashboard-results"
+                    hx-swap="outerHTML"
+                    hx-push-url="true"
+                  >
+                    {{ template "icon-chevron-right" . }}
+                  </a>
+                </div>
+              </nav>
+            {{ end }}
+          </section>
+      {{ end }}
+    </div>
   </div>
 {{ end }}
 

--- a/web/src/styles/layout/chrome.css
+++ b/web/src/styles/layout/chrome.css
@@ -17,7 +17,6 @@
 
   .nav .nav-action {
     color: var(--topbar-inverted-foreground);
-    border-color: var(--topbar-inverted-foreground);
   }
 }
 
@@ -72,7 +71,7 @@
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: var(--space-2);
+  gap: var(--space-1);
 }
 
 .nav .account-menu {
@@ -80,9 +79,15 @@
 }
 
 .nav .nav-action {
+  border-color: transparent;
   transition:
     background-color 140ms ease,
     border-color 140ms ease;
+}
+
+.nav .nav-action .icon-svg {
+  width: 20px;
+  height: 20px;
 }
 
 .nav .nav-action:hover,
@@ -99,16 +104,11 @@
   display: none;
 }
 
-.nav .account-icon {
-  width: 21px;
-  height: 21px;
-}
-
 .nav .account-dropdown {
   position: absolute;
   top: calc(100% + 8px);
   right: 0;
-  min-width: 220px;
+  width: 180px;
   border: 1px solid var(--border);
   border-radius: 4px;
   background: var(--card);
@@ -121,29 +121,30 @@
 }
 
 .nav .account-menu-section + .account-menu-section {
-  border-top: 1px solid var(--border);
   display: grid;
-  gap: 0.25rem;
 }
 
 .nav .account-menu-section:first-child {
   padding: var(--space-3) var(--space-4);
+  padding-bottom: 0;
 }
 
 .nav .account-menu-label {
   margin: 0;
   font-size: var(--text-xs);
   color: var(--muted-foreground);
+  opacity: 0.7;
 }
 
 .nav .account-menu-email {
-  margin: var(--space-2) 0 0;
-  font-size: var(--text-sm);
-  font-weight: 600;
-  color: var(--foreground);
+  margin: 0;
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  color: var(--muted-foreground);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  opacity: 0.7;
 }
 
 .nav .account-menu-section form {
@@ -158,12 +159,15 @@
   padding: 7px 9px;
   background: transparent;
   color: var(--foreground);
+  font-family: var(--font-sans);
   font-size: var(--text-sm);
-  font-weight: 600;
+  font-weight: var(--font-semibold);
+  line-height: var(--leading-normal);
   text-align: left;
   margin-left: 0;
   text-decoration: none;
   border-radius: 4px;
+  cursor: pointer;
 }
 
 .nav .account-menu-item .icon-svg {

--- a/web/src/styles/pages/stream.css
+++ b/web/src/styles/pages/stream.css
@@ -60,6 +60,7 @@
   min-width: 0;
   padding: var(--space-2);
   text-align: left;
+  text-decoration: none;
   border: 0;
   border-radius: 4px;
   background: transparent;
@@ -79,6 +80,7 @@
 
 .stream-status-filter-option:hover {
   background: color-mix(in srgb, var(--primary) 8%, var(--background));
+  text-decoration: none;
 }
 
 .stream-status-rail-label {


### PR DESCRIPTION
## Summary
- Unify remaining inline icons on Lucide stroke SVGs (theme/account, menus, trash, play, eye, share).
- Tighten topbar nav and account menu chrome (icon sizing, dropdown layout/typography).
- Add HTMX-driven filter, sort, and pagination on the stream dashboard (`stream_dashboard_results` partial swaps).

## Test plan
- [ ] Open stream dashboard (`/w/:key/`): filter by status, sort, and paginate via HTMX without full page reload
- [ ] Confirm status filter links do not show hover underline
- [ ] Check topbar theme toggle and account menu icons/layout on desktop and mobile
- [ ] Spot-check icon consistency across menus (trash, play, eye, share) against Lucide style
- [ ] Leave any uncommitted tip/step-summary WIP out of this PR (local only)


Made with [Cursor](https://cursor.com)