### PR TITLE
feat(ui): tip component for step-summary meta icons

### DIFF
--- a/.agents/skills/attesta-ui-components/SKILL.md
+++ b/.agents/skills/attesta-ui-components/SKILL.md
@@ -126,6 +126,7 @@ Also see:
 - `dialog` — modal shell (`.dialog`, `.dialog-card`, `.dialog-head`, `.dialog-actions`, … in `web/src/styles/components/dialog.css`); destructive titles stack `.dialog-title u-text-danger`; inline markup in `process.html`, `stream.html`, `home.html`, `org_admin.html`, `platform_admin.html`, `components/substep_body.html`
 - `button` — composable controls (`.btn` + variants/sizes/`btn-icon` in `web/src/styles/components/button.css`)
 - `list-row` — bordered list item with main + actions (`.list-rows`, `.list-row`, `.list-row-main`, `.list-row-actions` in `web/src/styles/components/list-row.css`); inline markup in `org_admin.html`, `platform_admin.html`
+- `tip` — inverted hover/focus label with caret (`.tip` in `web/src/styles/components/tip.css`); micro-partial `server/templates/components/tip.html` via `{{ template "tip" (dict "Tooltip" "…" …) }}` (`ImgSrc`/`ImgClass` or `Icon`/`InnerClass`; optional `Class`, `AriaLabel`, `Role`). Supported `Icon` values: `icon-clock`, `icon-list`, `icon-building-grid`.
 
 ## Docs and verification
 

--- a/.agents/skills/attesta-ui-components/SKILL.md
+++ b/.agents/skills/attesta-ui-components/SKILL.md
@@ -126,7 +126,7 @@ Also see:
 - `dialog` — modal shell (`.dialog`, `.dialog-card`, `.dialog-head`, `.dialog-actions`, … in `web/src/styles/components/dialog.css`); destructive titles stack `.dialog-title u-text-danger`; inline markup in `process.html`, `stream.html`, `home.html`, `org_admin.html`, `platform_admin.html`, `components/substep_body.html`
 - `button` — composable controls (`.btn` + variants/sizes/`btn-icon` in `web/src/styles/components/button.css`)
 - `list-row` — bordered list item with main + actions (`.list-rows`, `.list-row`, `.list-row-main`, `.list-row-actions` in `web/src/styles/components/list-row.css`); inline markup in `org_admin.html`, `platform_admin.html`
-- `tip` — inverted hover/focus label with caret (`.tip` in `web/src/styles/components/tip.css`); micro-partial `server/templates/components/tip.html` via `{{ template "tip" (dict "Tooltip" "…" …) }}` (`ImgSrc`/`ImgClass` or `Icon`/`InnerClass`; optional `Class`, `AriaLabel`, `Role`). Supported `Icon` values: `icon-clock`, `icon-list`, `icon-building-grid`.
+- `tip` — inverted hover/focus label with caret (`.tip` in `web/src/styles/components/tip.css`); micro-partial `server/templates/components/tip.html` via `{{ template "tip" (dict "Tooltip" "…" …) }}` (`ImgSrc`/`ImgClass` or `Icon`/`InnerClass`; optional `Class`, `AriaLabel`, `Role`). `Icon` is any template define name, executed via the `render` template func.
 
 ## Docs and verification
 

--- a/docs/css.md
+++ b/docs/css.md
@@ -85,6 +85,7 @@ Reused **markup patterns** backed by namespaced CSS, with **no** full Go templat
 | `dialog.css` | `.dialog`, `.dialog-card`, `.dialog-head`, `.dialog-actions` | See file header in `web/src/styles/components/dialog.css` |
 | `button.css` | `.btn`, `.btn-primary`, `.btn-secondary`, `.btn-ghost`, `.btn-ghost-danger`, `.btn-danger`, `.btn-outline`, `.btn-xs`, `.btn-sm`, `.btn-lg`, `.btn-icon` | See file header in `web/src/styles/components/button.css` |
 | `list-row.css` | `.list-rows`, `.list-row`, `.list-row-main`, `.list-row-actions` | See file header in `web/src/styles/components/list-row.css` |
+| `tip.css` | `.tip` | See file header in `web/src/styles/components/tip.css`; micro-partial `components/tip.html` |
 
 **Page header** — CSS-only. Inline the markup tree in page templates (no `PageHeaderView`, no full `page_header` define). Optional trail uses the full `breadcrumbs` component: `{{ template "breadcrumbs" .Breadcrumbs }}` with `BreadcrumbsView` assembled in Go (`BreadcrumbItem.Href` empty ⇒ current page). When right actions are needed, wrap `page-header-body` + `page-header-actions` in `div.page-header-head` (same idea as panel head-actions); omit the head wrapper when there are no actions. Process-instance ID under the title is **not** part of this component — it uses `.process-header-meta` / `.process-header-meta-id` in `pages/process.css`.
 
@@ -129,7 +130,7 @@ Other partials (`icons.html`, …) still live at `server/templates/` root until 
 | `pages/home.html` | `pages/home.css` | `components/stream-card.css`, `components/dialog.css`, `components/stream.css`, `layout/index.css` |
 | `pages/stream.html` | `pages/home.css`, `pages/stream.css` | `layout/grids.css` (`.rail-layout`), `components/dialog.css`, `components/panel.css`, `components/stream-instance-card.css`, `components/stream.css`, `components/stream-timeline.css`, `role-palette.css` |
 | `pages/process.html` | `pages/process.css` (incl. `.process-header-meta*`) | `components/page-header.css`, `components/dialog.css`, `components/substep-shell.css`, `components/stream-timeline.css`, `components/substep-body.css`, `layout/responsive.css` (`.layout-stack-separator`), `role-palette.css` |
-| `components/stream_step_summary.html` | `components/stream-step-summary.css` | — |
+| `components/stream_step_summary.html` | `components/stream-step-summary.css` | `components/tip.css` (`tip` micro-partial) |
 | `components/stream_timeline.html` | `components/stream-timeline.css` | `components/stream-step-summary.css`, `components/substep-body.css`, `role-palette.css` |
 | `components/dpp_history_step.html` | `pages/dpp.css` (`.dpp-history-*`) | `components/stream-timeline.css`, `components/stream-step-summary.css`, `components/substep-shell.css`, `components/substep-body.css`, `role-palette.css` |
 | `components/substep_shell.html` | `components/substep-shell.css` | `components/substep-body.css`, `role-palette.css` |

--- a/server/cmd/server/stream_step_summary_test.go
+++ b/server/cmd/server/stream_step_summary_test.go
@@ -30,19 +30,26 @@ func TestStepSummaryTemplateRendersExtendedMetadata(t *testing.T) {
 		`class="stream-step-summary-main"`,
 		`class="stream-step-summary-org-mark"`,
 		`src="https://example.com/logo.png"`,
+		`class="tip"`,
+		`data-tooltip="Organization"`,
 		`class="stream-step-summary-title"`,
 		`class="stream-step-summary-meta"`,
-		"<strong>Organization:</strong>",
+		`stream-step-summary-meta-icon`,
 		"Acme Org",
-		"<strong>Completed at:</strong>",
+		`data-tooltip="Completed at"`,
+		`aria-label="Completed at"`,
+		`datetime="2026-03-05T14:30:00Z"`,
 		"5 Mar 2026 at 14:30 UTC",
-		"<strong>Substeps:</strong>",
-		"Substeps:</strong> 3",
+		`data-tooltip="Steps"`,
+		`aria-label="Steps"`,
 		"Production",
 	} {
 		if !strings.Contains(compactBody, want) {
 			t.Fatalf("expected %q in rendered step summary, got: %s", want, body)
 		}
+	}
+	if !strings.Contains(compactBody, `</span> 3 </span>`) {
+		t.Fatalf("expected substep count 3 after Steps icon, got: %s", body)
 	}
 }
 
@@ -83,17 +90,20 @@ func TestStepSummaryTemplateOmitsOptionalFields(t *testing.T) {
 	}
 	body := out.String()
 
-	if strings.Contains(body, "Completed at:") {
-		t.Fatalf("did not expect completed-at line, got: %s", body)
+	if strings.Contains(body, `data-tooltip="Completed at"`) {
+		t.Fatalf("did not expect completed-at meta, got: %s", body)
 	}
-	if strings.Contains(body, "Substeps:") {
-		t.Fatalf("did not expect substep count line, got: %s", body)
+	if strings.Contains(body, `data-tooltip="Steps"`) {
+		t.Fatalf("did not expect substep count meta, got: %s", body)
 	}
 	if !strings.Contains(body, "No organization") {
 		t.Fatalf("expected no-organization fallback, got: %s", body)
 	}
-	if !strings.Contains(body, `class="icon-svg icon-svg-lg"`) {
-		t.Fatalf("expected org logo fallback icon, got: %s", body)
+	if strings.Contains(body, `class="stream-step-summary-org-mark"`) {
+		t.Fatalf("did not expect org mark square for building fallback, got: %s", body)
+	}
+	if !strings.Contains(body, `class="icon-svg icon-svg-md"`) {
+		t.Fatalf("expected building icon fallback, got: %s", body)
 	}
 }
 

--- a/server/cmd/server/stream_timeline_test.go
+++ b/server/cmd/server/stream_timeline_test.go
@@ -53,6 +53,8 @@ func TestStreamTimelineTemplateRendersStepsAndSubsteps(t *testing.T) {
 		`class="stream-timeline-step-summary"`,
 		`class="stream-step-summary-org-mark"`,
 		`src="https://example.com/logo.png"`,
+		`class="tip"`,
+		`data-tooltip="Organization"`,
 		`class="stream-timeline-substeps"`,
 		`class="substep substep-available"`,
 		`class="substep-accordion js-process-substep-panel"`,
@@ -61,9 +63,8 @@ func TestStreamTimelineTemplateRendersStepsAndSubsteps(t *testing.T) {
 		`class="stream-step-summary-meta"`,
 		`<span class="status" aria-label="Status: available">available</span>`,
 		"Production",
-		"<strong>Organization:</strong>",
 		"Acme Org",
-		"<strong>Substeps:</strong>",
+		`data-tooltip="Steps"`,
 		"Capture batch data",
 	} {
 		if !strings.Contains(body, want) {
@@ -113,11 +114,11 @@ func TestStreamTimelineTemplateRendersOrgLogoFallback(t *testing.T) {
 	if strings.Contains(body, `src="https://example.com/logo.png"`) {
 		t.Fatalf("did not expect org logo img when URL empty, got: %s", body)
 	}
-	if !strings.Contains(body, `class="stream-step-summary-org-mark"`) {
-		t.Fatalf("expected org mark fallback container, got: %s", body)
+	if strings.Contains(body, `class="stream-step-summary-org-mark"`) {
+		t.Fatalf("did not expect org mark square for building fallback, got: %s", body)
 	}
 	if !strings.Contains(body, `class="icon-svg"`) {
-		t.Fatalf("expected icon-no-org fallback svg, got: %s", body)
+		t.Fatalf("expected building icon fallback svg, got: %s", body)
 	}
 }
 

--- a/server/cmd/server/templates.go
+++ b/server/cmd/server/templates.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"html/template"
 	"path/filepath"
@@ -44,8 +45,22 @@ func templateFuncs() template.FuncMap {
 	}
 }
 
+// withTemplateFuncs registers shared funcs plus render, which executes a named
+// template by string (Go's {{ template }} action only accepts constant names).
+func withTemplateFuncs(tmpl *template.Template) *template.Template {
+	funcs := templateFuncs()
+	funcs["render"] = func(name string, data any) (template.HTML, error) {
+		var buf bytes.Buffer
+		if err := tmpl.ExecuteTemplate(&buf, name, data); err != nil {
+			return "", err
+		}
+		return template.HTML(buf.String()), nil
+	}
+	return tmpl.Funcs(funcs)
+}
+
 func parseTemplates() (*template.Template, error) {
-	tmpl := template.New("").Funcs(templateFuncs())
+	tmpl := withTemplateFuncs(template.New(""))
 	var err error
 	for _, pattern := range templateGlobPatterns {
 		tmpl, err = tmpl.ParseGlob(pattern)
@@ -58,7 +73,7 @@ func parseTemplates() (*template.Template, error) {
 
 func parseTestTemplates(t testing.TB) *template.Template {
 	t.Helper()
-	tmpl := template.New("").Funcs(templateFuncs())
+	tmpl := withTemplateFuncs(template.New(""))
 	for _, pattern := range templateGlobPatterns {
 		fullPattern := filepath.Join("..", "..", pattern)
 		var err error

--- a/server/cmd/server/tip_test.go
+++ b/server/cmd/server/tip_test.go
@@ -60,3 +60,33 @@ func TestTipTemplateRendersImageHost(t *testing.T) {
 		}
 	}
 }
+
+func TestTipTemplateRendersArbitraryIconDefine(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+
+	var out bytes.Buffer
+	data := map[string]any{
+		"Tooltip": "Search",
+		"Icon":    "icon-search",
+	}
+	if err := tmpl.ExecuteTemplate(&out, "tip", data); err != nil {
+		t.Fatalf("render tip template: %v", err)
+	}
+	body := out.String()
+	if !strings.Contains(body, `class="icon-svg`) {
+		t.Fatalf("expected icon-search svg via render, got: %s", body)
+	}
+}
+
+func TestTipTemplateUnknownIconErrors(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+
+	var out bytes.Buffer
+	data := map[string]any{
+		"Tooltip": "Missing",
+		"Icon":    "icon-does-not-exist",
+	}
+	if err := tmpl.ExecuteTemplate(&out, "tip", data); err == nil {
+		t.Fatal("expected error for unknown icon define")
+	}
+}

--- a/server/cmd/server/tip_test.go
+++ b/server/cmd/server/tip_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestTipTemplateRendersIconHost(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+
+	var out bytes.Buffer
+	data := map[string]any{
+		"Tooltip": "Completed at",
+		"Class":   "stream-step-summary-meta-icon",
+		"Icon":    "icon-clock",
+	}
+	if err := tmpl.ExecuteTemplate(&out, "tip", data); err != nil {
+		t.Fatalf("render tip template: %v", err)
+	}
+	body := out.String()
+	compactBody := strings.Join(strings.Fields(body), " ")
+
+	for _, want := range []string{
+		`class="tip stream-step-summary-meta-icon"`,
+		`data-tooltip="Completed at"`,
+		`aria-label="Completed at"`,
+		`tabindex="0"`,
+		`class="icon-svg icon-svg-md"`,
+	} {
+		if !strings.Contains(compactBody, want) {
+			t.Fatalf("expected %q in tip markup, got: %s", want, body)
+		}
+	}
+}
+
+func TestTipTemplateRendersImageHost(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+
+	var out bytes.Buffer
+	data := map[string]any{
+		"Tooltip":  "Organization",
+		"ImgSrc":   "https://example.com/logo.png",
+		"ImgClass": "stream-step-summary-org-mark",
+	}
+	if err := tmpl.ExecuteTemplate(&out, "tip", data); err != nil {
+		t.Fatalf("render tip template: %v", err)
+	}
+	body := out.String()
+
+	for _, want := range []string{
+		`class="tip"`,
+		`data-tooltip="Organization"`,
+		`src="https://example.com/logo.png"`,
+		`class="stream-step-summary-org-mark"`,
+		`alt=""`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in tip markup, got: %s", want, body)
+		}
+	}
+}

--- a/server/templates/components/stream_step_summary.html
+++ b/server/templates/components/stream_step_summary.html
@@ -3,40 +3,51 @@
 {{ define "stream_step_summary" }}
   <div class="stream-step-summary-main">
     <span class="pill pill-step-number pill-panel">{{ .StepID }}</span>
-    {{ if not .HideOrgMark }}
-      {{ if .OrgLogoURL }}
-        <img
-          src="{{ .OrgLogoURL }}"
-          alt=""
-          class="stream-step-summary-org-mark"
-        />
-      {{ else }}
-        <span class="stream-step-summary-org-mark">
-          {{ template "icon-no-org" . }}
-        </span>
-      {{ end }}
-    {{ end }}
     <span class="stream-step-summary-copy">
       <span class="stream-step-summary-title">{{ .Title }}</span>
       <div class="stream-step-summary-meta">
-        <span
-          ><strong>Organization:</strong>
+        <span class="stream-step-summary-org">
+          {{ if not .HideOrgMark }}
+            {{ if .OrgLogoURL }}
+              {{ template "tip" (dict
+                "Tooltip" "Organization"
+                "ImgSrc" .OrgLogoURL
+                "ImgClass" "stream-step-summary-org-mark"
+              ) }}
+            {{ else }}
+              {{ template "tip" (dict
+                "Tooltip" "Organization"
+                "Role" "img"
+                "Class" "stream-step-summary-meta-icon"
+                "Icon" "icon-building-grid"
+              ) }}
+            {{ end }}
+          {{ end }}
           {{ if .OrganizationName }}
             {{ .OrganizationName }}
           {{ else }}
             No organization
-          {{ end }}</span
-        >
+          {{ end }}
+        </span>
         {{ if .CompletedAtHuman }}
-          <span
-            ><strong>Completed at:</strong>
-            <time datetime="{{ .CompletedAt }}">{{ .CompletedAtHuman }}</time></span
-          >
+          <span class="stream-step-summary-meta-item">
+            {{ template "tip" (dict
+              "Tooltip" "Completed at"
+              "Class" "stream-step-summary-meta-icon"
+              "Icon" "icon-clock"
+            ) }}
+            <time datetime="{{ .CompletedAt }}">{{ .CompletedAtHuman }}</time>
+          </span>
         {{ end }}
         {{ if .SubstepCount }}
-          <span
-            ><strong>Substeps:</strong> {{ .SubstepCount }}</span
-          >
+          <span class="stream-step-summary-meta-item">
+            {{ template "tip" (dict
+              "Tooltip" "Steps"
+              "Class" "stream-step-summary-meta-icon"
+              "Icon" "icon-list"
+            ) }}
+            {{ .SubstepCount }}
+          </span>
         {{ end }}
       </div>
     </span>

--- a/server/templates/components/tip.html
+++ b/server/templates/components/tip.html
@@ -1,0 +1,25 @@
+{{/* Tip host with CSS caret tooltip. See tip.css for markup contract. */}}
+{{ define "tip" }}
+  <span
+    class="tip{{ if .Class }} {{ .Class }}{{ end }}"
+    data-tooltip="{{ .Tooltip }}"
+    aria-label="{{ if .AriaLabel }}{{ .AriaLabel }}{{ else }}{{ .Tooltip }}{{ end }}"
+    {{ if .Role }}role="{{ .Role }}"{{ end }}
+    tabindex="0"
+  >
+    {{ if .ImgSrc }}
+      <img
+        src="{{ .ImgSrc }}"
+        alt=""
+        {{ if .ImgClass }}class="{{ .ImgClass }}"{{ end }}
+      />
+    {{ else if .Icon }}
+      {{ if .InnerClass }}<span class="{{ .InnerClass }}">{{ end }}
+      {{ if eq .Icon "icon-clock" }}{{ template "icon-clock" . }}
+      {{ else if eq .Icon "icon-list" }}{{ template "icon-list" . }}
+      {{ else if eq .Icon "icon-building-grid" }}{{ template "icon-building-grid" . }}
+      {{ end }}
+      {{ if .InnerClass }}</span>{{ end }}
+    {{ end }}
+  </span>
+{{ end }}

--- a/server/templates/components/tip.html
+++ b/server/templates/components/tip.html
@@ -15,10 +15,7 @@
       />
     {{ else if .Icon }}
       {{ if .InnerClass }}<span class="{{ .InnerClass }}">{{ end }}
-      {{ if eq .Icon "icon-clock" }}{{ template "icon-clock" . }}
-      {{ else if eq .Icon "icon-list" }}{{ template "icon-list" . }}
-      {{ else if eq .Icon "icon-building-grid" }}{{ template "icon-building-grid" . }}
-      {{ end }}
+      {{ render .Icon . }}
       {{ if .InnerClass }}</span>{{ end }}
     {{ end }}
   </span>

--- a/server/templates/icons.html
+++ b/server/templates/icons.html
@@ -326,6 +326,44 @@
   </svg>
 {{ end }}
 
+{{ define "icon-clock" }}
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="icon-svg icon-svg-md"
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="10" />
+    <path d="M12 6v6l4 2" />
+  </svg>
+{{ end }}
+
+{{ define "icon-list" }}
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="icon-svg icon-svg-md"
+    aria-hidden="true"
+  >
+    <path d="M3 12h.01" />
+    <path d="M3 18h.01" />
+    <path d="M3 6h.01" />
+    <path d="M8 12h13" />
+    <path d="M8 18h13" />
+    <path d="M8 6h13" />
+  </svg>
+{{ end }}
+
 {{ define "icon-chevron-down" }}
   <svg
     xmlns="http://www.w3.org/2000/svg"

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -7,6 +7,7 @@
 @import url("./components/dialog.css");
 @import url("./components/button.css");
 @import url("./components/list-row.css");
+@import url("./components/tip.css");
 @import url("./components/shared.css");
 @import url("./components/stream-step-summary.css");
 @import url("./components/stream-timeline.css");

--- a/web/src/styles/components/stream-step-summary.css
+++ b/web/src/styles/components/stream-step-summary.css
@@ -6,26 +6,6 @@
   min-width: 0;
 }
 
-.stream-step-summary-org-mark {
-  width: 44px;
-  height: 44px;
-  border-radius: 4px;
-  border: 1px solid var(--border);
-  background: var(--card);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-  flex-shrink: 0;
-}
-
-.stream-step-summary-org-mark img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-}
-
 .stream-step-summary-copy {
   display: flex;
   flex-direction: column;
@@ -50,14 +30,46 @@
   line-height: var(--leading-tight);
 }
 
-.stream-step-summary-meta strong {
-  color: inherit;
-  font-weight: var(--font-medium);
+.stream-step-summary-org,
+.stream-step-summary-meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
 }
 
-@media (--sm-down) {
-  .stream-step-summary-org-mark {
-    width: 36px;
-    height: 36px;
-  }
+.stream-step-summary-meta-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--muted-foreground);
+}
+
+.stream-step-summary-meta-icon .icon-svg {
+  width: 14px;
+  height: 14px;
+}
+
+.stream-step-summary-org-mark {
+  width: 16px;
+  height: 16px;
+  border-radius: 2px;
+  border: 1px solid var(--border);
+  background: var(--card);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+img.stream-step-summary-org-mark {
+  object-fit: cover;
+  display: block;
+}
+
+.stream-step-summary-org-mark .icon-svg {
+  width: 10px;
+  height: 10px;
 }

--- a/web/src/styles/components/tip.css
+++ b/web/src/styles/components/tip.css
@@ -1,0 +1,64 @@
+/*
+ * Tip — inverted hover/focus label with caret (CSS + micro-partial).
+ *
+ * Native title= is unreliable inside <summary>; use this instead.
+ *
+ * Markup (via {{ template "tip" (dict …) }} or inline):
+ *   span.tip[data-tooltip][aria-label][tabindex="0"]
+ *     img? | span.inner? > icon | icon
+ *
+ * Dict keys: Tooltip (required), Class?, AriaLabel?, Role?,
+ *            ImgSrc?, ImgClass?, Icon? (template name), InnerClass?
+ */
+
+.tip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  outline: none;
+}
+
+.tip::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--topbar-inverted);
+  color: var(--topbar-inverted-foreground);
+  box-shadow: 0 4px 12px var(--shadow-dropdown);
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  line-height: 1.3;
+  white-space: nowrap;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  z-index: 30;
+}
+
+.tip::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 2px);
+  transform: translateX(-50%);
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 7px solid var(--topbar-inverted);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  z-index: 31;
+}
+
+.tip:hover::before,
+.tip:hover::after,
+.tip:focus-visible::before,
+.tip:focus-visible::after {
+  opacity: 1;
+  visibility: visible;
+}

--- a/web/src/styles/components/tip.css
+++ b/web/src/styles/components/tip.css
@@ -8,7 +8,8 @@
  *     img? | span.inner? > icon | icon
  *
  * Dict keys: Tooltip (required), Class?, AriaLabel?, Role?,
- *            ImgSrc?, ImgClass?, Icon? (template name), InnerClass?
+ *            ImgSrc?, ImgClass?, Icon? (any template define name via render),
+ *            InnerClass?
  */
 
 .tip {


### PR DESCRIPTION
## Summary
- Add shared `tip` CSS + micro-partial (inverted hover/focus label with caret) for reliable tooltips inside `<summary>`.
- Rework stream step-summary meta: org logo-as-icon (building fallback), clock/list tip icons, and “Steps” label instead of bold text labels.
- Document tip in `docs/css.md` and the attesta UI components skill; cover with tip + timeline template tests.

## Test plan
- [ ] `cd server && go test ./cmd/server/ -count=1 -run 'Tip|StepSummary|StreamTimeline'`
- [ ] Open a process/stream timeline: hover org mark, clock, and list icons — tooltips appear with caret
- [ ] Missing org logo shows building icon (not in a square)
- [ ] Completed-at still shows UTC human `<time>` (local datetime is a follow-up PR)


Made with [Cursor](https://cursor.com)