### PR TITLE
feat(ui): local timezone datetime formatting

### DIFF
--- a/.agents/skills/attesta-ui-components/SKILL.md
+++ b/.agents/skills/attesta-ui-components/SKILL.md
@@ -127,6 +127,7 @@ Also see:
 - `button` — composable controls (`.btn` + variants/sizes/`btn-icon` in `web/src/styles/components/button.css`)
 - `list-row` — bordered list item with main + actions (`.list-rows`, `.list-row`, `.list-row-main`, `.list-row-actions` in `web/src/styles/components/list-row.css`); inline markup in `org_admin.html`, `platform_admin.html`
 - `tip` — inverted hover/focus label with caret (`.tip` in `web/src/styles/components/tip.css`); micro-partial `server/templates/components/tip.html` via `{{ template "tip" (dict "Tooltip" "…" …) }}` (`ImgSrc`/`ImgClass` or `Icon`/`InnerClass`; optional `Class`, `AriaLabel`, `Role`). `Icon` is any template define name, executed via the `render` template func.
+- `local_datetime` — micro-partial `server/templates/components/local_datetime.html` via `{{ template "local_datetime" (dict "ISO" "…" "Human" "…") }}`; client `formatLocalDateTimes` in `web/src/main.js` rewrites to `dd/mm/yyyy at HH:mm` in the viewer timezone.
 
 ## Docs and verification
 

--- a/docs/css.md
+++ b/docs/css.md
@@ -86,6 +86,7 @@ Reused **markup patterns** backed by namespaced CSS, with **no** full Go templat
 | `button.css` | `.btn`, `.btn-primary`, `.btn-secondary`, `.btn-ghost`, `.btn-ghost-danger`, `.btn-danger`, `.btn-outline`, `.btn-xs`, `.btn-sm`, `.btn-lg`, `.btn-icon` | See file header in `web/src/styles/components/button.css` |
 | `list-row.css` | `.list-rows`, `.list-row`, `.list-row-main`, `.list-row-actions` | See file header in `web/src/styles/components/list-row.css` |
 | `tip.css` | `.tip` | See file header in `web/src/styles/components/tip.css`; micro-partial `components/tip.html` |
+| — | `local_datetime` | Micro-partial `components/local_datetime.html`: `time.js-local-datetime[datetime]` + UTC human fallback; client formats in `web/src/main.js` |
 
 **Page header** — CSS-only. Inline the markup tree in page templates (no `PageHeaderView`, no full `page_header` define). Optional trail uses the full `breadcrumbs` component: `{{ template "breadcrumbs" .Breadcrumbs }}` with `BreadcrumbsView` assembled in Go (`BreadcrumbItem.Href` empty ⇒ current page). When right actions are needed, wrap `page-header-body` + `page-header-actions` in `div.page-header-head` (same idea as panel head-actions); omit the head wrapper when there are no actions. Process-instance ID under the title is **not** part of this component — it uses `.process-header-meta` / `.process-header-meta-id` in `pages/process.css`.
 

--- a/server/cmd/server/components.go
+++ b/server/cmd/server/components.go
@@ -35,11 +35,13 @@ type StreamInstanceCard struct {
 	StatusLabel     string
 	DetailHref      string
 	CreatedAt       string
+	CreatedAtISO    string
 	CreatedAtTime   time.Time
 	DoneSubsteps    int
 	TotalSubsteps   int
 	Percent         int
 	LastNotarizedAt string
+	LastNotarizedAtISO string
 	LastDigestShort string
 }
 
@@ -114,6 +116,7 @@ type SubstepBodyView struct {
 	Status           string
 	Mode             SubstepBodyMode
 	DoneAt         string
+	DoneAtISO      string
 	DoneBy         string
 	DoneRole       string
 	Values         []SubstepKV
@@ -156,6 +159,7 @@ type SubstepShellDisplay struct {
 	StatusLabel string
 	Palette     string
 	DoneAt      string
+	DoneAtISO   string
 	DoneBy      string
 }
 
@@ -170,6 +174,7 @@ func substepShellDisplay(sub TimelineSubstep) SubstepShellDisplay {
 			StatusLabel: processStatusLabel(status),
 			Palette:     sub.Body.Palette,
 			DoneAt:      sub.Body.DoneAt,
+			DoneAtISO:   sub.Body.DoneAtISO,
 			DoneBy:      sub.Body.DoneBy,
 		}
 	}
@@ -182,6 +187,7 @@ func substepShellDisplay(sub TimelineSubstep) SubstepShellDisplay {
 		StatusLabel: label,
 		Palette:     sub.Palette,
 		DoneAt:      sub.DoneAt,
+		DoneAtISO:   sub.DoneAtISO,
 		DoneBy:      sub.DoneBy,
 	}
 }
@@ -200,6 +206,7 @@ type TimelineSubstep struct {
 	DoneBy      string
 	DoneRole    string
 	DoneAt      string
+	DoneAtISO   string
 }
 
 // TimelineStep groups substeps under a blueprint step in the stream timeline.
@@ -230,6 +237,7 @@ type StreamTimelineSubstepView struct {
 
 // StreamTerminationDetailsView is the view model for templates/components/stream_termination_details.html.
 type StreamTerminationDetailsView struct {
+	EndedAt      string
 	EndedAtHuman string
 	EndedBy      string
 	SubstepID    string

--- a/server/cmd/server/dpp.go
+++ b/server/cmd/server/dpp.go
@@ -249,6 +249,7 @@ func buildDPPTraceabilitySubstep(ctx timelineSubstepBuildContext) TimelineSubste
 	detailMessage := ""
 	reason := ""
 	doneAtHuman := ""
+	doneAtISO := ""
 	doneBy := ""
 	palette := meta.Palette
 	var values []SubstepKV
@@ -272,6 +273,7 @@ func buildDPPTraceabilitySubstep(ctx timelineSubstepBuildContext) TimelineSubste
 		}
 		if progress.DoneAt != nil {
 			doneAtHuman = humanReadableTraceabilityTime(*progress.DoneAt)
+			doneAtISO = rfc3339UTC(*progress.DoneAt)
 		}
 		if progress.DoneBy != nil {
 			doneBy = progress.DoneBy.ID
@@ -319,6 +321,7 @@ func buildDPPTraceabilitySubstep(ctx timelineSubstepBuildContext) TimelineSubste
 		FormUISchema:   marshalJSONCompact(effective.UISchema),
 		Status:         status,
 		DoneAt:         doneAtHuman,
+		DoneAtISO:      doneAtISO,
 		DoneBy:         doneBy,
 		Values:         values,
 		Attachments:    attachments,
@@ -336,6 +339,7 @@ func buildDPPTraceabilitySubstep(ctx timelineSubstepBuildContext) TimelineSubste
 		Selected:  false,
 		DoneBy:    doneBy,
 		DoneAt:    doneAtHuman,
+		DoneAtISO: doneAtISO,
 		Body:      &body,
 	}
 }
@@ -345,6 +349,13 @@ func humanReadableTraceabilityTime(value time.Time) string {
 		return ""
 	}
 	return value.UTC().Format("2 Jan 2006 at 15:04 MST")
+}
+
+func rfc3339UTC(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339)
 }
 
 func dppTraceValues(sub WorkflowSub, progress ProcessStep) []SubstepKV {

--- a/server/cmd/server/helper_misc_test.go
+++ b/server/cmd/server/helper_misc_test.go
@@ -21,6 +21,16 @@ func TestHumanReadableTraceabilityTime(t *testing.T) {
 	}
 }
 
+func TestRFC3339UTC(t *testing.T) {
+	if got := rfc3339UTC(time.Time{}); got != "" {
+		t.Fatalf("rfc3339UTC(zero) = %q, want empty", got)
+	}
+	value := time.Date(2026, 3, 5, 14, 30, 0, 0, time.FixedZone("CET", 3600))
+	if got := rfc3339UTC(value); got != "2026-03-05T13:30:00Z" {
+		t.Fatalf("rfc3339UTC() = %q", got)
+	}
+}
+
 func TestShortHashLabel(t *testing.T) {
 	if got := shortHashLabel("  abcdef12345  "); got != "abcdef1" {
 		t.Fatalf("shortHashLabel(long) = %q, want abcdef1", got)

--- a/server/cmd/server/home_handler_test.go
+++ b/server/cmd/server/home_handler_test.go
@@ -1267,11 +1267,17 @@ func TestHandleWorkflowHomeUsesHumanReadableProcessDates(t *testing.T) {
 	}
 
 	body := rec.Body.String()
-	if !strings.Contains(body, "Created: 3 Feb 2026 at 10:00 UTC") {
+	if !strings.Contains(body, "Created:") || !strings.Contains(body, "3 Feb 2026 at 10:00 UTC") {
 		t.Fatalf("expected human readable created date, got %q", body)
 	}
-	if !strings.Contains(body, "Last notarized: 3 Feb 2026 at 11:30 UTC") {
+	if !strings.Contains(body, `datetime="2026-02-03T10:00:00Z"`) {
+		t.Fatalf("expected created datetime ISO, got %q", body)
+	}
+	if !strings.Contains(body, "Last notarized:") || !strings.Contains(body, "3 Feb 2026 at 11:30 UTC") {
 		t.Fatalf("expected human readable last notarized date, got %q", body)
+	}
+	if !strings.Contains(body, `datetime="2026-02-03T11:30:00Z"`) {
+		t.Fatalf("expected last notarized datetime ISO, got %q", body)
 	}
 }
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -1925,9 +1925,9 @@ func countWorkflowSubsteps(def WorkflowDef) int {
 	return count
 }
 
-func processProgressStats(def WorkflowDef, process *Process) (doneCount int, lastAt string, lastDigestShort string) {
+func processProgressStats(def WorkflowDef, process *Process) (doneCount int, lastDoneAt time.Time, lastDigestShort string) {
 	if process == nil {
-		return 0, "", ""
+		return 0, time.Time{}, ""
 	}
 	var latest time.Time
 	first := true
@@ -1954,9 +1954,9 @@ func processProgressStats(def WorkflowDef, process *Process) (doneCount int, las
 		}
 	}
 	if !first {
-		lastAt = humanReadableTraceabilityTime(latest)
+		lastDoneAt = latest
 	}
-	return doneCount, lastAt, lastDigestShort
+	return doneCount, lastDoneAt, lastDigestShort
 }
 
 func sortHomeProcessList(items []StreamInstanceCard, sortKey string) {
@@ -4793,24 +4793,26 @@ func (s *Server) buildWorkflowHomeView(ctx context.Context, r *http.Request, use
 	for _, process := range processesRaw {
 		process.Progress = normalizeProgressKeys(process.Progress)
 		status := deriveProcessStatus(cfg.Workflow, &process)
-		doneCount, lastAt, lastDigest := processProgressStats(cfg.Workflow, &process)
+		doneCount, lastDoneAt, lastDigest := processProgressStats(cfg.Workflow, &process)
 		percent := 0
 		if totalSubsteps > 0 {
 			percent = int(float64(doneCount) / float64(totalSubsteps) * 100)
 		}
 		item := StreamInstanceCard{
-			ID:              process.ID.Hex(),
-			Name:            strings.TrimSpace(process.Name),
-			Status:          status,
-			StatusLabel:     processStatusLabel(status),
-			DetailHref:      path + "/process/" + process.ID.Hex(),
-			CreatedAt:       humanReadableTraceabilityTime(process.CreatedAt),
-			CreatedAtTime:   process.CreatedAt,
-			DoneSubsteps:    doneCount,
-			TotalSubsteps:   totalSubsteps,
-			Percent:         percent,
-			LastNotarizedAt: lastAt,
-			LastDigestShort: lastDigest,
+			ID:                 process.ID.Hex(),
+			Name:               strings.TrimSpace(process.Name),
+			Status:             status,
+			StatusLabel:        processStatusLabel(status),
+			DetailHref:         path + "/process/" + process.ID.Hex(),
+			CreatedAt:          humanReadableTraceabilityTime(process.CreatedAt),
+			CreatedAtISO:       rfc3339UTC(process.CreatedAt),
+			CreatedAtTime:      process.CreatedAt,
+			DoneSubsteps:       doneCount,
+			TotalSubsteps:      totalSubsteps,
+			Percent:            percent,
+			LastNotarizedAt:    humanReadableTraceabilityTime(lastDoneAt),
+			LastNotarizedAtISO: rfc3339UTC(lastDoneAt),
+			LastDigestShort:    lastDigest,
 		}
 		if item.Status == "active" {
 			if _, ok := nextAuthorizedSubstepBody(cfg.Workflow, &process, workflowKey, actor, roleMeta, cfg.Roles); ok {

--- a/server/cmd/server/panel_markup_test.go
+++ b/server/cmd/server/panel_markup_test.go
@@ -90,6 +90,7 @@ func TestProcessTerminationDetailsPanelMarkup(t *testing.T) {
 	var out bytes.Buffer
 	view := StreamTerminationDetailsView{
 		Reason:       "Pilot ended early",
+		EndedAt:      "2026-03-05T14:30:00Z",
 		EndedAtHuman: "5 Mar 2026 at 14:30 UTC",
 		EndedBy:      "user-1",
 		SubstepID:    "2.1",

--- a/server/cmd/server/stream_instance_card_test.go
+++ b/server/cmd/server/stream_instance_card_test.go
@@ -20,6 +20,7 @@ func TestStreamInstanceCardTemplateRendersDetailLink(t *testing.T) {
 		DoneSubsteps:  1,
 		TotalSubsteps: 4,
 		CreatedAt:     "1 Mar 2026 at 10:00 UTC",
+		CreatedAtISO:  "2026-03-01T10:00:00Z",
 	}
 	if err := tmpl.ExecuteTemplate(&out, "stream_instance_card", card); err != nil {
 		t.Fatalf("render stream_instance_card template: %v", err)
@@ -41,6 +42,8 @@ func TestStreamInstanceCardTemplateRendersDetailLink(t *testing.T) {
 		`href="/w/workflow/process/process-1"`,
 		`class="status-tag status-tag-compact"`,
 		`data-stream-status="available"`,
+		`class="js-local-datetime"`,
+		`datetime="2026-03-01T10:00:00Z"`,
 		"Pilot batch",
 		"process-1",
 		"complete (25%)",

--- a/server/cmd/server/stream_instance_detail.go
+++ b/server/cmd/server/stream_instance_detail.go
@@ -137,6 +137,7 @@ func (s *Server) buildStreamTerminationDetailsView(ctx context.Context, def Work
 		return nil
 	}
 	return &StreamTerminationDetailsView{
+		EndedAt:      view.EndedAt,
 		EndedAtHuman: view.EndedAtHuman,
 		EndedBy:      terminationEndedByDisplay(view.EndedBy),
 		SubstepID:    view.SubstepID,

--- a/server/cmd/server/stream_step_summary_test.go
+++ b/server/cmd/server/stream_step_summary_test.go
@@ -38,6 +38,7 @@ func TestStepSummaryTemplateRendersExtendedMetadata(t *testing.T) {
 		"Acme Org",
 		`data-tooltip="Completed at"`,
 		`aria-label="Completed at"`,
+		`class="js-local-datetime"`,
 		`datetime="2026-03-05T14:30:00Z"`,
 		"5 Mar 2026 at 14:30 UTC",
 		`data-tooltip="Steps"`,

--- a/server/cmd/server/stream_termination_details_test.go
+++ b/server/cmd/server/stream_termination_details_test.go
@@ -11,6 +11,7 @@ func TestStreamTerminationDetailsTemplateRendersFields(t *testing.T) {
 
 	var out bytes.Buffer
 	view := StreamTerminationDetailsView{
+		EndedAt:      "2026-03-05T14:30:00Z",
 		EndedAtHuman: "5 Mar 2026 at 14:30 UTC",
 		EndedBy:      "operator@example.com",
 		SubstepID:    "2.1",
@@ -28,6 +29,8 @@ func TestStreamTerminationDetailsTemplateRendersFields(t *testing.T) {
 		`d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"`,
 		`class="stream-termination-details-fields"`,
 		">Ended at</dt>",
+		`class="js-local-datetime"`,
+		`datetime="2026-03-05T14:30:00Z"`,
 		"5 Mar 2026 at 14:30 UTC",
 		">Ended by</dt>",
 		"operator@example.com",

--- a/server/cmd/server/stream_timeline_test.go
+++ b/server/cmd/server/stream_timeline_test.go
@@ -148,6 +148,7 @@ func TestStreamTimelineTemplateRendersDoneSubstepMetaFromBody(t *testing.T) {
 	view.Timeline[0].Substeps[0].DoneBy = ""
 	view.Timeline[0].Substeps[0].Body.Status = "done"
 	view.Timeline[0].Substeps[0].Body.DoneAt = "5 Mar 2026 at 14:30 UTC"
+	view.Timeline[0].Substeps[0].Body.DoneAtISO = "2026-03-05T14:30:00Z"
 	view.Timeline[0].Substeps[0].Body.DoneBy = "alice@example.com"
 
 	var out bytes.Buffer
@@ -158,6 +159,8 @@ func TestStreamTimelineTemplateRendersDoneSubstepMetaFromBody(t *testing.T) {
 
 	for _, want := range []string{
 		`class="substep-meta"`,
+		`class="js-local-datetime"`,
+		`datetime="2026-03-05T14:30:00Z"`,
 		"5 Mar 2026 at 14:30 UTC",
 		"alice@example.com",
 	} {
@@ -174,6 +177,7 @@ func TestStreamTimelineTemplateRendersDoneSubstepMetaClasses(t *testing.T) {
 	view.Timeline[0].Substeps[0].Body = nil
 	view.Timeline[0].Substeps[0].Status = "done"
 	view.Timeline[0].Substeps[0].DoneAt = "5 Mar 2026 at 14:30 UTC"
+	view.Timeline[0].Substeps[0].DoneAtISO = "2026-03-05T14:30:00Z"
 	view.Timeline[0].Substeps[0].DoneBy = "alice@example.com"
 
 	var out bytes.Buffer
@@ -187,6 +191,8 @@ func TestStreamTimelineTemplateRendersDoneSubstepMetaClasses(t *testing.T) {
 		`class="substep-meta-time"`,
 		`class="substep-meta-actor"`,
 		"<strong>Completed at:</strong>",
+		`class="js-local-datetime"`,
+		`datetime="2026-03-05T14:30:00Z"`,
 		"5 Mar 2026 at 14:30 UTC",
 		"<strong>Operator:</strong>",
 		"alice@example.com",

--- a/server/cmd/server/substep_shell_test.go
+++ b/server/cmd/server/substep_shell_test.go
@@ -192,6 +192,7 @@ func TestSubstepShellTemplateRendersDoneSubstepMetaFromBody(t *testing.T) {
 	view.Substep.DoneBy = ""
 	view.Substep.Body.Status = "done"
 	view.Substep.Body.DoneAt = "5 Mar 2026 at 14:30 UTC"
+	view.Substep.Body.DoneAtISO = "2026-03-05T14:30:00Z"
 	view.Substep.Body.DoneBy = "alice@example.com"
 
 	var out bytes.Buffer
@@ -202,6 +203,8 @@ func TestSubstepShellTemplateRendersDoneSubstepMetaFromBody(t *testing.T) {
 
 	for _, want := range []string{
 		`class="substep-meta"`,
+		`class="js-local-datetime"`,
+		`datetime="2026-03-05T14:30:00Z"`,
 		"5 Mar 2026 at 14:30 UTC",
 		"alice@example.com",
 	} {
@@ -218,6 +221,7 @@ func TestSubstepShellTemplateRendersDoneSubstepMetaClasses(t *testing.T) {
 	view.Substep.Body = nil
 	view.Substep.Status = "done"
 	view.Substep.DoneAt = "5 Mar 2026 at 14:30 UTC"
+	view.Substep.DoneAtISO = "2026-03-05T14:30:00Z"
 	view.Substep.DoneBy = "alice@example.com"
 
 	var out bytes.Buffer
@@ -231,6 +235,8 @@ func TestSubstepShellTemplateRendersDoneSubstepMetaClasses(t *testing.T) {
 		`class="substep-meta-time"`,
 		`class="substep-meta-actor"`,
 		"<strong>Completed at:</strong>",
+		`class="js-local-datetime"`,
+		`datetime="2026-03-05T14:30:00Z"`,
 		"5 Mar 2026 at 14:30 UTC",
 		"<strong>Operator:</strong>",
 		"alice@example.com",

--- a/server/cmd/server/substep_views_builder.go
+++ b/server/cmd/server/substep_views_builder.go
@@ -112,6 +112,7 @@ func buildSubstepViews(def WorkflowDef, process *Process, workflowKey string, ac
 		formSchema := ""
 		formUISchema := ""
 		doneAt := ""
+		doneAtISO := ""
 		doneBy := ""
 		doneRole := ""
 		description := strings.TrimSpace(sub.InputKey)
@@ -122,6 +123,7 @@ func buildSubstepViews(def WorkflowDef, process *Process, workflowKey string, ac
 				description = processStepDescription(progress, sub)
 				if progress.DoneAt != nil {
 					doneAt = humanReadableTraceabilityTime(*progress.DoneAt)
+					doneAtISO = rfc3339UTC(*progress.DoneAt)
 				}
 				if progress.DoneBy != nil {
 					doneBy = strings.TrimSpace(progress.DoneBy.ID)
@@ -182,6 +184,7 @@ func buildSubstepViews(def WorkflowDef, process *Process, workflowKey string, ac
 			FormUISchema:   formUISchema,
 			Status:         status,
 			DoneAt:         doneAt,
+			DoneAtISO:      doneAtISO,
 			DoneBy:         doneBy,
 			DoneRole:       doneRole,
 			Values:         values,

--- a/server/cmd/server/timeline_builder.go
+++ b/server/cmd/server/timeline_builder.go
@@ -111,7 +111,7 @@ func buildTimeline(def WorkflowDef, process *Process, workflowKey string, roleIn
 	})
 }
 
-func buildTimelineSubstepShellBody(ctx timelineSubstepBuildContext, palette, doneBy, doneAtHuman string) SubstepBodyView {
+func buildTimelineSubstepShellBody(ctx timelineSubstepBuildContext, palette, doneBy, doneAtHuman, doneAtISO string) SubstepBodyView {
 	status := ctx.status
 	disabled := false
 	if status == "available" {
@@ -125,6 +125,7 @@ func buildTimelineSubstepShellBody(ctx timelineSubstepBuildContext, palette, don
 		Palette:   palette,
 		DoneBy:    doneBy,
 		DoneAt:    doneAtHuman,
+		DoneAtISO: doneAtISO,
 		Disabled:  disabled,
 	}
 }
@@ -156,12 +157,14 @@ func buildTimelineSubstep(ctx timelineSubstepBuildContext) TimelineSubstep {
 		}
 		if progress.DoneAt != nil {
 			entry.DoneAt = humanReadableTraceabilityTime(*progress.DoneAt)
+			entry.DoneAtISO = rfc3339UTC(*progress.DoneAt)
 		}
 	}
 	entry.StatusLabel = processStatusLabel(entry.Status)
 	doneBy := entry.DoneBy
 	doneAt := entry.DoneAt
-	shellBody := buildTimelineSubstepShellBody(ctx, entry.Palette, doneBy, doneAt)
+	doneAtISO := entry.DoneAtISO
+	shellBody := buildTimelineSubstepShellBody(ctx, entry.Palette, doneBy, doneAt, doneAtISO)
 	entry.Body = &shellBody
 	return entry
 }

--- a/server/cmd/server/timeline_builder_test.go
+++ b/server/cmd/server/timeline_builder_test.go
@@ -374,6 +374,9 @@ func TestBuildTimelineSubstepAttachesMinimalShellBody(t *testing.T) {
 	if entry.Body.DoneAt != "5 Mar 2026 at 14:30 UTC" {
 		t.Fatalf("body doneAt = %q", entry.Body.DoneAt)
 	}
+	if entry.Body.DoneAtISO != "2026-03-05T14:30:00Z" {
+		t.Fatalf("body doneAtISO = %q", entry.Body.DoneAtISO)
+	}
 }
 
 func TestSubstepShellDisplayRequiresBody(t *testing.T) {

--- a/server/templates/components/local_datetime.html
+++ b/server/templates/components/local_datetime.html
@@ -1,0 +1,8 @@
+{{/* Local datetime: ISO in datetime=, UTC human fallback text; JS rewrites to local dd/mm/yyyy at HH:mm. */}}
+{{ define "local_datetime" }}
+  {{- if .ISO -}}
+    <time class="js-local-datetime" datetime="{{ .ISO }}">{{ .Human }}</time>
+  {{- else -}}
+    {{ .Human }}
+  {{- end -}}
+{{ end }}

--- a/server/templates/components/stream_instance_card.html
+++ b/server/templates/components/stream_instance_card.html
@@ -43,9 +43,15 @@
             {{ .TotalSubsteps }}
             complete ({{ .Percent }}%)</span
           >
-          <span>Created: {{ .CreatedAt }}</span>
+          <span
+            >Created:
+            {{ template "local_datetime" (dict "ISO" .CreatedAtISO "Human" .CreatedAt) }}</span
+          >
           {{ if .LastNotarizedAt }}
-            <span>Last notarized: {{ .LastNotarizedAt }}</span>
+            <span
+              >Last notarized:
+              {{ template "local_datetime" (dict "ISO" .LastNotarizedAtISO "Human" .LastNotarizedAt) }}</span
+            >
           {{ end }}
         </div>
       </div>

--- a/server/templates/components/stream_step_summary.html
+++ b/server/templates/components/stream_step_summary.html
@@ -36,7 +36,7 @@
               "Class" "stream-step-summary-meta-icon"
               "Icon" "icon-clock"
             ) }}
-            <time datetime="{{ .CompletedAt }}">{{ .CompletedAtHuman }}</time>
+            {{ template "local_datetime" (dict "ISO" .CompletedAt "Human" .CompletedAtHuman) }}
           </span>
         {{ end }}
         {{ if .SubstepCount }}

--- a/server/templates/components/stream_termination_details.html
+++ b/server/templates/components/stream_termination_details.html
@@ -11,7 +11,9 @@
         {{ if .EndedAtHuman }}
           <div class="stream-termination-details-field">
             <dt class="field-label">Ended at</dt>
-            <dd>{{ .EndedAtHuman }}</dd>
+            <dd>
+              {{ template "local_datetime" (dict "ISO" .EndedAt "Human" .EndedAtHuman) }}
+            </dd>
           </div>
         {{ end }}
         {{ if .EndedBy }}

--- a/server/templates/components/substep_shell.html
+++ b/server/templates/components/substep_shell.html
@@ -20,7 +20,8 @@
               <div class="substep-meta">
                 {{ if $shell.DoneAt }}
                   <span class="substep-meta-time"
-                    ><strong>Completed at:</strong> {{ $shell.DoneAt }}</span
+                    ><strong>Completed at:</strong>
+                    {{ template "local_datetime" (dict "ISO" $shell.DoneAtISO "Human" $shell.DoneAt) }}</span
                   >
                 {{ end }}
                 {{ if $shell.DoneBy }}

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -3,6 +3,34 @@ import "./styles.css";
 const themeStorageKey = "attesta_theme";
 const themeToggle = document.getElementById("theme-toggle");
 
+const pad2 = (value) => String(value).padStart(2, "0");
+
+/** Format an ISO datetime as dd/mm/yyyy at HH:mm in the viewer's local timezone. */
+const formatLocalDateTimeLabel = (value) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return `${pad2(date.getDate())}/${pad2(date.getMonth() + 1)}/${date.getFullYear()} at ${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
+};
+
+const formatLocalDateTimes = (root = document) => {
+  const scope = root instanceof Element || root instanceof Document ? root : document;
+  for (const node of scope.querySelectorAll("time.js-local-datetime[datetime]")) {
+    if (!(node instanceof HTMLTimeElement)) {
+      continue;
+    }
+    const iso = (node.getAttribute("datetime") || "").trim();
+    if (!iso) {
+      continue;
+    }
+    const label = formatLocalDateTimeLabel(iso);
+    if (label) {
+      node.textContent = label;
+    }
+  }
+};
+
 const syncFormataDarkMode = (theme) => {
   const isDark = theme === "dark";
   const components = document.querySelectorAll("formata-form.js-formata-form");
@@ -237,6 +265,7 @@ const loadProcessContent = async (substepId = currentSelectedSubstep()) => {
     }
     const html = await response.text();
     processPageContent.innerHTML = html;
+    formatLocalDateTimes(processPageContent);
     await initializeFormataForms(processPageContent);
     markSelectedSubstep(currentSelectedSubstep());
     focusNextActionInput();
@@ -1128,6 +1157,7 @@ if (processId && workflowKey && processPageContent) {
 }
 
 document.addEventListener("DOMContentLoaded", () => {
+  formatLocalDateTimes(document);
   void initializeFormataForms(document);
   markSelectedSubstep(currentSelectedSubstep());
   focusNextActionInput();
@@ -1149,6 +1179,9 @@ document.addEventListener("click", (event) => {
 });
 
 document.body.addEventListener("htmx:afterSwap", (event) => {
+  if (event.target instanceof Element) {
+    formatLocalDateTimes(event.target);
+  }
   if (event.target && event.target.id === "process-page-content") {
     void initializeFormataForms(event.target);
     markSelectedSubstep(currentSelectedSubstep());
@@ -1408,6 +1441,7 @@ if (deptRoot) {
         }
         const html = await response.text();
         dashboard.innerHTML = html;
+        formatLocalDateTimes(dashboard);
       } catch (err) {
         // keep UI responsive even if SSE fails
       }


### PR DESCRIPTION
## Summary
- Add `local_datetime` micro-partial (`time.js-local-datetime[datetime]` + UTC human fallback).
- Wire RFC3339 ISO fields through stream cards, step summary, substep shell, and termination details.
- Client `formatLocalDateTimes` rewrites labels to `dd/mm/yyyy at HH:mm` in the viewer timezone on load, HTMX `afterSwap`, and SSE partial refresh.

## Test plan
- [ ] `cd server && go test ./cmd/server/ -count=1`
- [ ] Open a done process: completed-at / created / notarized / ended-at show local `dd/mm/yyyy at HH:mm` (not only UTC fallback)
- [ ] Trigger HTMX/SSE content refresh and confirm dates still rewrite
- [ ] With JS disabled, UTC human fallback remains visible


Made with [Cursor](https://cursor.com)