### PR TITLE
feat(ui): tip meta icons on substeps and lighter muted text

### DIFF
--- a/docs/css.md
+++ b/docs/css.md
@@ -134,7 +134,7 @@ Other partials (`icons.html`, …) still live at `server/templates/` root until 
 | `components/stream_step_summary.html` | `components/stream-step-summary.css` | `components/tip.css` (`tip` micro-partial) |
 | `components/stream_timeline.html` | `components/stream-timeline.css` | `components/stream-step-summary.css`, `components/substep-body.css`, `role-palette.css` |
 | `components/dpp_history_step.html` | `pages/dpp.css` (`.dpp-history-*`) | `components/stream-timeline.css`, `components/stream-step-summary.css`, `components/substep-shell.css`, `components/substep-body.css`, `role-palette.css` |
-| `components/substep_shell.html` | `components/substep-shell.css` | `components/substep-body.css`, `role-palette.css` |
+| `components/substep_shell.html` | `components/substep-shell.css` | `components/substep-body.css`, `components/tip.css` (`tip` micro-partial), `role-palette.css` |
 | `components/substep_body.html` | `components/substep-body.css` | `components/dialog.css`, `components/forms.css`, `role-palette.css` |
 | `pages/dpp.html` | `pages/dpp.css` | `components/dpp_history_step.html`, `components/stream-timeline.css`, `components/stream-step-summary.css`, `components/substep-shell.css`, `components/substep-body.css`, `role-palette.css` |
 | `pages/org_admin.html` | `pages/org-admin-page.css` | `layout/grids.css` (`.rail-layout`), `components/dialog.css`, `components/sidebar-nav.css`, `components/panel.css`, `components/org-admin.css`, `role-palette.css` |

--- a/server/cmd/server/dpp.go
+++ b/server/cmd/server/dpp.go
@@ -206,10 +206,7 @@ func gs1ElementString(gtin, lot, serial string) string {
 func buildDPPTraceabilityView(def WorkflowDef, process *Process, workflowKey string, roleIndex map[roleMetaKey]RoleMeta, cfgRoles []WorkflowRole, orgNames map[string]string) []TimelineStep {
 	return buildTimelineSteps(def, process, orgNames, workflowKey, roleIndex, cfgRoles, timelineStepsOptions{
 		emptyIfNilProcess: true,
-		decorateStep: func(row *TimelineStep) {
-			row.Summary.HideOrgMark = true
-		},
-		buildSubstep: buildDPPTraceabilitySubstep,
+		buildSubstep:      buildDPPTraceabilitySubstep,
 	})
 }
 

--- a/server/cmd/server/dpp_helpers_test.go
+++ b/server/cmd/server/dpp_helpers_test.go
@@ -297,8 +297,8 @@ func TestBuildDPPTraceabilityViewIncludesStepSummaryMetadata(t *testing.T) {
 	if step.Summary.OrganizationName != "Acme Org" {
 		t.Fatalf("organization name = %q, want Acme Org", step.Summary.OrganizationName)
 	}
-	if !step.Summary.HideOrgMark {
-		t.Fatal("expected HideOrgMark on DPP traceability steps")
+	if step.Summary.HideOrgMark {
+		t.Fatal("did not expect HideOrgMark on DPP traceability steps")
 	}
 	if step.Summary.CompletedAt != "2026-03-05T14:30:00Z" {
 		t.Fatalf("completedAt = %q, want RFC3339", step.Summary.CompletedAt)

--- a/server/cmd/server/stream_timeline_test.go
+++ b/server/cmd/server/stream_timeline_test.go
@@ -190,11 +190,12 @@ func TestStreamTimelineTemplateRendersDoneSubstepMetaClasses(t *testing.T) {
 		`class="substep-meta"`,
 		`class="substep-meta-time"`,
 		`class="substep-meta-actor"`,
-		"<strong>Completed at:</strong>",
+		`class="tip`,
+		`data-tooltip="Completed at"`,
 		`class="js-local-datetime"`,
 		`datetime="2026-03-05T14:30:00Z"`,
 		"5 Mar 2026 at 14:30 UTC",
-		"<strong>Operator:</strong>",
+		`data-tooltip="Operator"`,
 		"alice@example.com",
 	} {
 		if !strings.Contains(body, want) {

--- a/server/cmd/server/substep_shell_test.go
+++ b/server/cmd/server/substep_shell_test.go
@@ -234,11 +234,12 @@ func TestSubstepShellTemplateRendersDoneSubstepMetaClasses(t *testing.T) {
 		`class="substep-meta"`,
 		`class="substep-meta-time"`,
 		`class="substep-meta-actor"`,
-		"<strong>Completed at:</strong>",
+		`class="tip`,
+		`data-tooltip="Completed at"`,
 		`class="js-local-datetime"`,
 		`datetime="2026-03-05T14:30:00Z"`,
 		"5 Mar 2026 at 14:30 UTC",
-		"<strong>Operator:</strong>",
+		`data-tooltip="Operator"`,
 		"alice@example.com",
 	} {
 		if !strings.Contains(body, want) {

--- a/server/templates/components/substep_shell.html
+++ b/server/templates/components/substep_shell.html
@@ -19,15 +19,24 @@
             {{ if eq $shell.Status "done" }}
               <div class="substep-meta">
                 {{ if $shell.DoneAt }}
-                  <span class="substep-meta-time"
-                    ><strong>Completed at:</strong>
-                    {{ template "local_datetime" (dict "ISO" $shell.DoneAtISO "Human" $shell.DoneAt) }}</span
-                  >
+                  <span class="substep-meta-time">
+                    {{ template "tip" (dict
+                      "Tooltip" "Completed at"
+                      "Class" "substep-meta-icon"
+                      "Icon" "icon-clock"
+                    ) }}
+                    {{ template "local_datetime" (dict "ISO" $shell.DoneAtISO "Human" $shell.DoneAt) }}
+                  </span>
                 {{ end }}
                 {{ if $shell.DoneBy }}
-                  <span class="substep-meta-actor"
-                    ><strong>Operator:</strong> {{ $shell.DoneBy }}</span
-                  >
+                  <span class="substep-meta-actor">
+                    {{ template "tip" (dict
+                      "Tooltip" "Operator"
+                      "Class" "substep-meta-icon"
+                      "Icon" "icon-account"
+                    ) }}
+                    {{ $shell.DoneBy }}
+                  </span>
                 {{ end }}
               </div>
             {{ end }}

--- a/web/src/styles/components/stream-step-summary.css
+++ b/web/src/styles/components/stream-step-summary.css
@@ -49,6 +49,7 @@
 .stream-step-summary-meta-icon .icon-svg {
   width: 14px;
   height: 14px;
+  opacity: 0.6;
 }
 
 .stream-step-summary-org-mark {

--- a/web/src/styles/components/substep-shell.css
+++ b/web/src/styles/components/substep-shell.css
@@ -169,14 +169,27 @@
   min-width: 0;
 }
 
-.substep-meta strong {
-  color: inherit;
-  font-weight: var(--font-medium);
-}
-
-.substep-meta > * {
+.substep-meta-time,
+.substep-meta-actor {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
   min-width: 0;
   overflow-wrap: anywhere;
+}
+
+.substep-meta-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--muted-foreground);
+}
+
+.substep-meta-icon .icon-svg {
+  width: 14px;
+  height: 14px;
+  opacity: 0.6;
 }
 
 .substep-details {

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -56,7 +56,7 @@
   --card: #fff;
   --card-foreground: var(--foreground);
   --muted: #f8f9f4;
-  --muted-foreground: #4f5d47;
+  --muted-foreground: #737973;
   --secondary: #fff;
 
   /* Accent & semantic */
@@ -192,7 +192,7 @@
   --foreground: #ecf1eb;
   --card: #151c17;
   --muted: rgb(255 255 255 / 4%);
-  --muted-foreground: #a6b2a2;
+  --muted-foreground: #b2b7b2;
   --secondary: #0f1411;
 
   /* Accent & semantic */


### PR DESCRIPTION
## Summary
- Extend the tip component to done-substep meta (`Completed at` / `Operator`) so labels work inside `<summary>`
- Show organization tip/logo on DPP history steps (stop forcing `HideOrgMark`)
- Lighten/neutralize `--muted-foreground` and set meta icon opacity to 0.6

## Test plan
- [ ] Open a process with a done substep; hover clock/account icons for tip tooltips
- [ ] Open a DPP Digital Link page; confirm org logo/building tip appears next to org name
- [ ] Spot-check muted meta text contrast in light and dark theme
- [ ] `cd server && go test ./cmd/server/ -run 'SubstepShell|StreamTimeline|DPP|Tip' -count=1`
- [ ] `task css:lint`


Made with [Cursor](https://cursor.com)