### PR TITLE
docs: refresh css guide and UI component skill

### DIFF
--- a/.agents/skills/attesta-ui-components/SKILL.md
+++ b/.agents/skills/attesta-ui-components/SKILL.md
@@ -22,7 +22,7 @@ Done when: you can name the **tier** and why the other two do not fit.
 
 Choose **full** when reused on 2+ pages or it is an HTMX/SSE swap target, with a stable field set assembled in Go.
 
-Choose **CSS-only** when the markup tree is reused, selectors form one family, and there is no mode dispatch / swap target. Examples: `page-header`, `panel`, `dialog`, `list-row`. Markup contract lives in the CSS file header and `docs/css.md`.
+Choose **CSS-only** when the markup tree is reused, selectors form one family, and there is no mode dispatch / swap target. Examples: `page-header`, `panel`, `dialog`, `list-row`. Markup contract lives in the CSS file header; layer/stem rules in `docs/css.md`.
 
 Choose **cluster** for single-class primitives (`.muted`, `.pill`), domain widget groups, or one-off markup with no dedicated styles.
 
@@ -85,7 +85,7 @@ Done when: the new or changed piece mirrors a same-tier neighbor (paths, define,
 
 Other full neighbors (same layout pattern): `stream_instance_card`, `stream_termination_details`, `breadcrumbs` (`Current: true` on last crumb; every crumb still has `Href`), `substep_shell` / `substep_body`, `dpp_history_step`.
 
-**CSS-only / micro-partial:** copy markup from an existing page or micro-partial (`status_tag`, `tip`, `local_datetime`); read the CSS file header + `docs/css.md` for the contract — do not invent a shared view struct.
+**CSS-only / micro-partial:** copy markup from an existing page or micro-partial (`status_tag`, `tip`, `local_datetime`); read the CSS file header for the contract — do not invent a shared view struct.
 
 ## 4. Done when
 

--- a/.agents/skills/attesta-ui-components/SKILL.md
+++ b/.agents/skills/attesta-ui-components/SKILL.md
@@ -1,65 +1,60 @@
 ---
 name: attesta-ui-components
 description: >-
-  Attesta server-rendered UI component conventions: when to extract a partial,
-  where templates/CSS/Go structs live, and naming rules. Use when adding or
-  refactoring templates, page headers, partials, view structs, or CSS in
-  server/templates/ and web/src/styles/.
+  Extract or place Attesta UI components (full / CSS-only / cluster).
+  Use when adding or changing server templates, view structs, or
+  web/src/styles component CSS; or when deciding whether to extract a partial.
 ---
 
 # Attesta UI components
 
-## When to extract a component
+Server-rendered UI in `server/templates/` + `web/src/styles/`. For CSS layers, tokens, and CSS-only markup contracts, open `docs/css.md` before writing selectors.
 
-**Three tiers:**
+## 1. Pick a tier
+
+Done when: you can name the **tier** and why the other two do not fit.
 
 | Tier | Template | CSS | Go view struct |
 |------|----------|-----|----------------|
-| **Full component** | `components/{name}.html` | `components/{name}.css` when ~10+ namespaced rules | Dedicated type in `components.go` |
-| **CSS-only component** | **None** (or a narrow micro-partial) — inline HTML in page templates | `components/{name}.css` with markup-tree header comment | **None** |
-| **Cluster / primitive** | inline | `shared.css`, `forms.css`, … | none |
+| **Full** | `components/{name}.html` | `components/{name}.css` when ~10+ namespaced rules | Dedicated type in `components.go` |
+| **CSS-only** | None (or a narrow micro-partial) — inline HTML in the page | `components/{name}.css` with markup-tree header | None |
+| **Cluster** | inline | existing cluster file (`shared.css`, `forms.css`, …) | none |
 
-**Full component** — reused 2+ pages or HTMX/SSE target; namespaced CSS; stable field set assembled in Go.
+Choose **full** when reused on 2+ pages or it is an HTMX/SSE swap target, with a stable field set assembled in Go.
 
-**CSS-only component** — reused markup tree + related selectors; no mode dispatch; see `docs/css.md` → CSS-only components. Examples: `panel.css`, `page-header.css` (optional trail via full `breadcrumbs`).
+Choose **CSS-only** when the markup tree is reused, selectors form one family, and there is no mode dispatch / swap target. Examples: `page-header`, `panel`, `dialog`, `list-row`. Markup contract lives in the CSS file header and `docs/css.md`.
 
-**Cluster instead:**
+Choose **cluster** for single-class primitives (`.muted`, `.pill`), domain widget groups, or one-off markup with no dedicated styles.
 
-- Single-class primitives (`.muted`, `.pill`) → `shared.css`
-- Domain groups (forms, org-admin widgets) → existing cluster files
-- One-off markup with no dedicated styles → inline in page template
+**Tracer** migration: **extract** or move **one** component per change.
 
-Migrate **one component at a time**. Do not move every partial in one pass.
+## 2. Place files
 
-## File layout
+Done when: paths match the tier, and define name / CSS prefix follow **stem** rules below.
 
-| Layer | Shared components | Full pages | Still at templates root |
-|-------|-------------------|------------|-------------------------|
-| Templates | `server/templates/components/{name}.html` | `server/templates/pages/{name}.html` | `error_banner.html`, `icons.html`, `attachment_carousel.html`, `role_palette_options.html`, `substep_override_editor.html` |
-| CSS | `web/src/styles/components/{name}.css` | `web/src/styles/pages/{name}.css` | cluster files under `components/` (`shared`, `forms`, …) |
-| Go view structs | `server/cmd/server/components.go` | handlers/page structs mostly in `main.go` | peeled assembly: `stream_instance_detail.go`, `substep_views_builder.go`, `timeline_builder.go`, `breadcrumbs.go` |
+| Layer | Shared (full / CSS-only module) | Page-specific |
+|-------|----------------------------------|---------------|
+| Templates | `server/templates/components/{name}.html` (full only) | `server/templates/pages/{name}.html` |
+| CSS | `web/src/styles/components/{name}.css` | `web/src/styles/pages/{name}.css` |
+| Go | view DTO in `components.go`; builders with real logic in peeled files (`breadcrumbs.go`, `stream_instance_detail.go`, …) | page fields on the page view / handler |
 
-`layout.html` stays at `server/templates/layout.html`.
+`layout.html` stays at `server/templates/layout.html`. Root leftovers (`error_banner.html`, `icons.html`, …) migrate only when the task needs them.
 
-Separate **reused** styles (`components/`) from **page-specific** styles (`pages/`). A selector lives in exactly one layer — architecture and module index: `docs/css.md`.
+Reused styles → `components/`; page-only → `pages/`. One selector, one layer (`docs/css.md`).
 
-## Naming
+### Stem naming
 
-- **Template define name = file stem** (basename without `.html`): `stream_card.html` → `{{ define "stream_card" }}`. Micro-partials may share a file (e.g. `status_tag.html` defines `status_tag` only).
-- Page wrappers: `{page}.html` define wrapping `layout.html` (e.g. `process.html`).
-- Page body blocks: `{page}_body` define (e.g. `process_body`).
-- CSS class prefix: kebab-case matching the component (`page-header-*`, `stream-card-*`, `breadcrumbs-*`).
+- Template define name = file **stem**: `stream_card.html` → `{{ define "stream_card" }}`
+- Page wrapper: `{page}.html`; body block: `{page}_body`
+- CSS class prefix: kebab-case matching the component (`stream-card-*`, `page-header-*`)
 
-## Go conventions
+### Go DTOs (full tier)
 
-- All shared component view DTOs in **one** `components.go` file.
-- **No** fluent `With*` methods on simple DTOs; use struct literals at call sites.
-- **No** page-specific preset functions in shared component code (e.g. no `streamPageHeader()`).
-- Extract a constructor only when there is real logic; page-specific constructors belong in peeled files or future `page_*.go`, not `components.go`. Trail builders such as `buildProcessBreadcrumbs` live in `breadcrumbs.go`.
-- Split a type out of `components.go` only when it grows non-trivial logic or large isolated tests (~80–100+ lines).
-- **CSS-only components** have **no** shared view struct. Put title/description/meta on the page view (or inline) and render the markup tree in the page template.
-
-Example (full component):
+- Shared view DTOs live in `components.go`
+- Call sites use struct literals (not fluent `With*` chains)
+- Page-specific builders live beside the page (`breadcrumbs.go`, `*_builder.go`), not as presets in `components.go`
+- Split a type out of `components.go` only when logic or tests grow large (~80–100+ lines)
+- CSS-only: title/description/meta on the **page** view; markup inlined in the page template
 
 ```go
 Card: StreamCardView{
@@ -69,81 +64,32 @@ Card: StreamCardView{
 },
 ```
 
-Example (CSS-only page header + full breadcrumbs trail):
-
 ```go
-// Page view fields used by inlined page-header markup (no PageHeaderView).
 Title:       cfg.Workflow.Name,
 Description: strings.TrimSpace(cfg.Workflow.Description),
-Breadcrumbs: buildStreamBreadcrumbs(workflowKey, cfg.Workflow.Name), // {{ template "breadcrumbs" .Breadcrumbs }}
+Breadcrumbs: buildStreamBreadcrumbs(workflowKey, cfg.Workflow.Name),
 ```
 
-## Template loading
+Templates load via `parseTemplates()` / `parseTestTemplates(t)` in `templates.go` (`templates/*.html`, `pages/*.html`, `components/*.html`).
 
-- Production: `parseTemplates()` in `server/cmd/server/templates.go`
-- Tests: `parseTestTemplates(t)` in the same file
+## 3. Match a tracer
 
-Globs: `templates/*.html`, `templates/pages/*.html`, `templates/components/*.html`.
+Done when: the new or changed piece mirrors a same-tier neighbor (paths, define, prefix, DTO shape).
 
-## Reference implementations
-
-`stream_card` — home stream picker card:
+**Full tracer — `stream_card`:**
 
 - `server/templates/components/stream_card.html`
 - `web/src/styles/components/stream-card.css`
 - `StreamCardView` in `components.go`
 - Tests: `stream_card_test.go`
 
-`stream_instance_card` — stream dashboard instance list row:
+Other full neighbors (same layout pattern): `stream_instance_card`, `stream_termination_details`, `breadcrumbs` (`Current: true` on last crumb; every crumb still has `Href`), `substep_shell` / `substep_body`, `dpp_history_step`.
 
-- `server/templates/components/stream_instance_card.html`
-- `web/src/styles/components/stream-instance-card.css`
-- `StreamInstanceCard` in `components.go`
-- Tests: `stream_instance_card_test.go`
-- Shared status tags remain in `components/stream.css` (`.status-tag*`)
+**CSS-only / micro-partial:** copy markup from an existing page or micro-partial (`status_tag`, `tip`, `local_datetime`); read the CSS file header + `docs/css.md` for the contract — do not invent a shared view struct.
 
-`stream_termination_details` — early-termination warning banner:
+## 4. Done when
 
-- `server/templates/components/stream_termination_details.html`
-- `web/src/styles/components/stream-termination-details.css`
-- `StreamTerminationDetailsView` in `components.go`
-- Builder: `buildStreamTerminationDetailsView` in `stream_instance_detail.go`
-- Tests: `stream_termination_details_test.go`
-- Call sites: `process.html`, `dpp.html`
-
-`breadcrumbs` — hierarchical page trail in page headers:
-
-- `server/templates/components/breadcrumbs.html`
-- `web/src/styles/components/breadcrumbs.css`
-- `BreadcrumbItem` / `BreadcrumbsView` in `components.go`
-- Builders: `breadcrumbs.go` (`buildStreamBreadcrumbs`, `buildProcessBreadcrumbs`, …)
-- Tests: `breadcrumbs_test.go`, `breadcrumbs_template_test.go`
-- Call site: `{{ template "breadcrumbs" .Breadcrumbs }}` (`Current: true` on last crumb ⇒ `aria-current="page"`; every crumb is a link)
-
-Also see:
-
-- `substep_shell` — accordion chrome wrapping `substep_body`
-- `substep_body` — inner panel with explicit `SubstepBodyView.Mode` dispatch
-- `dpp_history_step` — DPP traceability rail wrapper around `stream_timeline_step`
-
-### CSS-only / micro-partials
-
-- `page-header` — `page-header.css`; inline in pages; **no** `PageHeaderView`. Heading-only: `page-header-body` under `section.page-header`. With actions: `page-header-head` wraps body + actions. Optional trail: `breadcrumbs` (above).
-- `status_tag` — `status_tag.html`; pipeline is status **string**; `data-stream-status` → `--stream-color` / `.status-tag` in `stream.css`. Call: `{{ template "status_tag" .Status }}`
-- `panel` — `panel.css`; optional `.panel-sticky`; inline on process/stream/dpp/org_admin/platform_admin
-- `sidebar-nav` — `sidebar-nav.css`; inline in `org_admin.html`. Stream status filter uses `.stream-status-filter-*` in `pages/stream.css`, not this component.
-- `dialog` — `dialog.css`; destructive titles stack `.dialog-title u-text-danger`; inline on process/stream/home/org_admin/platform_admin/`substep_body`
-- `button` — `.btn` + variants in `button.css`
-- `list-row` — `list-row.css`; inline on org_admin / platform_admin
-- `tip` — `tip.css` + `tip.html` via `{{ template "tip" (dict …) }}` (`ImgSrc`/`ImgClass` or `Icon`/`InnerClass`; optional `Class`, `AriaLabel`, `Role`). `Icon` is any template define name via the `render` func.
-- `local_datetime` — `local_datetime.html` via `{{ template "local_datetime" (dict "ISO" "…" "Human" "…") }}`; client `formatLocalDateTimes` in `main.js`.
-
-## Docs and verification
-
-- CSS architecture and template ↔ CSS index: `docs/css.md`
-- Repo layout: `AGENTS.md`
-
-Before claiming done:
+Every touched template/CSS path is accounted for, and:
 
 ```bash
 cd server && go test ./cmd/server/ -count=1
@@ -151,8 +97,4 @@ cd server && go test ./cmd/server/ -run 'Breadcrumbs|StreamCard|StreamInstance|S
 task css:lint
 ```
 
-## Out of scope (for now)
-
-- Further peeling of `page_*.go` from `main.go`
-- `ErrorBannerView` / migrating `error_banner.html` (legacy define name) until a handler owns a proper DTO
-- Renaming legacy defines such as `role-palette-options` — align when each partial is migrated
+Narrow the `-run` filter to components you actually changed when the full package test already passed.

--- a/.agents/skills/attesta-ui-components/SKILL.md
+++ b/.agents/skills/attesta-ui-components/SKILL.md
@@ -19,9 +19,9 @@ description: >-
 | **CSS-only component** | **None** (or a narrow micro-partial) — inline HTML in page templates | `components/{name}.css` with markup-tree header comment | **None** |
 | **Cluster / primitive** | inline | `shared.css`, `forms.css`, … | none |
 
-**Full component** — all apply: reused 2+ pages or HTMX/SSE target; namespaced CSS; stable field set assembled in Go.
+**Full component** — reused 2+ pages or HTMX/SSE target; namespaced CSS; stable field set assembled in Go.
 
-**CSS-only component** — reused markup tree + related selectors; no mode dispatch; see `docs/css.md` → CSS-only components. Example: panel section headers → `panel.css` (read file header for markup). Page headers → `page-header.css` (inline in pages; optional trail via full `breadcrumbs` component).
+**CSS-only component** — reused markup tree + related selectors; no mode dispatch; see `docs/css.md` → CSS-only components. Examples: `panel.css`, `page-header.css` (optional trail via full `breadcrumbs`).
 
 **Cluster instead:**
 
@@ -33,31 +33,31 @@ Migrate **one component at a time**. Do not move every partial in one pass.
 
 ## File layout
 
-| Layer | Shared components | Full pages | Not yet migrated |
-|-------|-------------------|------------|------------------|
-| Templates | `server/templates/components/{name}.html` | `server/templates/pages/{name}.html` | `server/templates/{name}.html` (root) |
-| CSS | `web/src/styles/components/{name}.css` | `web/src/styles/pages/{name}.css` | cluster files at `components/` |
-| Go view structs | `server/cmd/server/components.go` | handlers and page structs mostly in `main.go` | peeled view assembly: `stream_instance_detail.go`, `substep_views_builder.go`, `timeline_builder.go` |
+| Layer | Shared components | Full pages | Still at templates root |
+|-------|-------------------|------------|-------------------------|
+| Templates | `server/templates/components/{name}.html` | `server/templates/pages/{name}.html` | `error_banner.html`, `icons.html`, `attachment_carousel.html`, `role_palette_options.html`, `substep_override_editor.html` |
+| CSS | `web/src/styles/components/{name}.css` | `web/src/styles/pages/{name}.css` | cluster files under `components/` (`shared`, `forms`, …) |
+| Go view structs | `server/cmd/server/components.go` | handlers/page structs mostly in `main.go` | peeled assembly: `stream_instance_detail.go`, `substep_views_builder.go`, `timeline_builder.go`, `breadcrumbs.go` |
 
 `layout.html` stays at `server/templates/layout.html`.
 
-Separate **reused** styles (`components/`) from **page-specific** styles (`pages/`). A selector lives in exactly one layer (see `docs/css.md`).
+Separate **reused** styles (`components/`) from **page-specific** styles (`pages/`). A selector lives in exactly one layer — architecture and module index: `docs/css.md`.
 
 ## Naming
 
 - **Template define name = file stem** (basename without `.html`): `stream_card.html` → `{{ define "stream_card" }}`. Micro-partials may share a file (e.g. `status_tag.html` defines `status_tag` only).
 - Page wrappers: `{page}.html` define wrapping `layout.html` (e.g. `process.html`).
 - Page body blocks: `{page}_body` define (e.g. `process_body`).
-- CSS class prefix: kebab-case matching the component (`page-header-*` for page header; `stream-card-*` for `stream_card`; `breadcrumbs-*` for `breadcrumbs`).
+- CSS class prefix: kebab-case matching the component (`page-header-*`, `stream-card-*`, `breadcrumbs-*`).
 
 ## Go conventions
 
 - All shared component view DTOs in **one** `components.go` file.
 - **No** fluent `With*` methods on simple DTOs; use struct literals at call sites.
 - **No** page-specific preset functions in shared component code (e.g. no `streamPageHeader()`).
-- Extract a constructor only when there is real logic (validation, computed fields); page-specific constructors belong in peeled files (`stream_instance_detail.go`, `substep_views_builder.go`, …) or future `page_*.go`, not `components.go`. Trail builders such as `buildProcessBreadcrumbs` live in `breadcrumbs.go` next to the component.
+- Extract a constructor only when there is real logic; page-specific constructors belong in peeled files or future `page_*.go`, not `components.go`. Trail builders such as `buildProcessBreadcrumbs` live in `breadcrumbs.go`.
 - Split a type out of `components.go` only when it grows non-trivial logic or large isolated tests (~80–100+ lines).
-- **CSS-only components** (page header, panel, dialog, list-row, …) have **no** shared view struct. Put title/description/meta strings on the page view (or inline in the template) and render the markup tree in the page template.
+- **CSS-only components** have **no** shared view struct. Put title/description/meta on the page view (or inline) and render the markup tree in the page template.
 
 Example (full component):
 
@@ -91,43 +91,52 @@ Globs: `templates/*.html`, `templates/pages/*.html`, `templates/components/*.htm
 
 - `server/templates/components/stream_card.html`
 - `web/src/styles/components/stream-card.css`
-- `StreamCardView` in `server/cmd/server/components.go`
-- Tests: `server/cmd/server/stream_card_test.go`
+- `StreamCardView` in `components.go`
+- Tests: `stream_card_test.go`
 
 `stream_instance_card` — stream dashboard instance list row:
 
 - `server/templates/components/stream_instance_card.html`
 - `web/src/styles/components/stream-instance-card.css`
-- `StreamInstanceCard` in `server/cmd/server/components.go`
-- Tests: `server/cmd/server/stream_instance_card_test.go`
+- `StreamInstanceCard` in `components.go`
+- Tests: `stream_instance_card_test.go`
 - Shared status tags remain in `components/stream.css` (`.status-tag*`)
+
+`stream_termination_details` — early-termination warning banner:
+
+- `server/templates/components/stream_termination_details.html`
+- `web/src/styles/components/stream-termination-details.css`
+- `StreamTerminationDetailsView` in `components.go`
+- Builder: `buildStreamTerminationDetailsView` in `stream_instance_detail.go`
+- Tests: `stream_termination_details_test.go`
+- Call sites: `process.html`, `dpp.html`
 
 `breadcrumbs` — hierarchical page trail in page headers:
 
 - `server/templates/components/breadcrumbs.html`
 - `web/src/styles/components/breadcrumbs.css`
-- `BreadcrumbItem` / `BreadcrumbsView` in `server/cmd/server/components.go`
-- Builders: `server/cmd/server/breadcrumbs.go` (`buildStreamBreadcrumbs`, `buildProcessBreadcrumbs`, …)
-- Tests: `server/cmd/server/breadcrumbs_test.go`, `breadcrumbs_template_test.go`
+- `BreadcrumbItem` / `BreadcrumbsView` in `components.go`
+- Builders: `breadcrumbs.go` (`buildStreamBreadcrumbs`, `buildProcessBreadcrumbs`, …)
+- Tests: `breadcrumbs_test.go`, `breadcrumbs_template_test.go`
 - Call site: `{{ template "breadcrumbs" .Breadcrumbs }}` (`Current: true` on last crumb ⇒ `aria-current="page"`; every crumb is a link)
 
 Also see:
 
-- `substep_shell` — accordion chrome wrapping `substep_body` (`components/substep_shell.html`, `substep-shell.css`)
+- `substep_shell` — accordion chrome wrapping `substep_body`
 - `substep_body` — inner panel with explicit `SubstepBodyView.Mode` dispatch
 - `dpp_history_step` — DPP traceability rail wrapper around `stream_timeline_step`
 
-### CSS-only components
+### CSS-only / micro-partials
 
-- `page-header` — page chrome title block (`web/src/styles/components/page-header.css`); inline markup in page templates under `server/templates/pages/`; **no** `PageHeaderView` / full `page_header` define. Heading-only: `page-header-body` directly under `section.page-header`. With actions: `page-header-head` wraps `page-header-body` + `page-header-actions`. Optional trail: `{{ template "breadcrumbs" .Breadcrumbs }}` (full component above).
-- `status_tag` — stream status pill micro-partial (`server/templates/components/status_tag.html`); pipeline is status **string**; renders `<span class="status-tag status-tag-compact" data-stream-status="{{ . }}">`; colors from `data-stream-status` → `--stream-color` in `role-palette.css` / `.status-tag` in `stream.css`. Call site: `{{ template "status_tag" .Status }}`
-- `panel` — card container and section headers (`web/src/styles/components/panel.css`); optional `.panel-sticky`; inline markup in `process.html`, `stream.html`, `dpp.html`, `org_admin.html`, `platform_admin.html`
-- `sidebar-nav` — section switcher tiles (`.sidebar-nav`, `.sidebar-nav-link`, … in `web/src/styles/components/sidebar-nav.css`); inline markup in `org_admin.html`. Stream status filter uses bespoke `.stream-status-filter-*` in `pages/stream.css`, not this component.
-- `dialog` — modal shell (`.dialog`, `.dialog-card`, `.dialog-head`, `.dialog-actions`, … in `web/src/styles/components/dialog.css`); destructive titles stack `.dialog-title u-text-danger`; inline markup in `process.html`, `stream.html`, `home.html`, `org_admin.html`, `platform_admin.html`, `components/substep_body.html`
-- `button` — composable controls (`.btn` + variants/sizes/`btn-icon` in `web/src/styles/components/button.css`)
-- `list-row` — bordered list item with main + actions (`.list-rows`, `.list-row`, `.list-row-main`, `.list-row-actions` in `web/src/styles/components/list-row.css`); inline markup in `org_admin.html`, `platform_admin.html`
-- `tip` — inverted hover/focus label with caret (`.tip` in `web/src/styles/components/tip.css`); micro-partial `server/templates/components/tip.html` via `{{ template "tip" (dict "Tooltip" "…" …) }}` (`ImgSrc`/`ImgClass` or `Icon`/`InnerClass`; optional `Class`, `AriaLabel`, `Role`). `Icon` is any template define name, executed via the `render` template func.
-- `local_datetime` — micro-partial `server/templates/components/local_datetime.html` via `{{ template "local_datetime" (dict "ISO" "…" "Human" "…") }}`; client `formatLocalDateTimes` in `web/src/main.js` rewrites to `dd/mm/yyyy at HH:mm` in the viewer timezone.
+- `page-header` — `page-header.css`; inline in pages; **no** `PageHeaderView`. Heading-only: `page-header-body` under `section.page-header`. With actions: `page-header-head` wraps body + actions. Optional trail: `breadcrumbs` (above).
+- `status_tag` — `status_tag.html`; pipeline is status **string**; `data-stream-status` → `--stream-color` / `.status-tag` in `stream.css`. Call: `{{ template "status_tag" .Status }}`
+- `panel` — `panel.css`; optional `.panel-sticky`; inline on process/stream/dpp/org_admin/platform_admin
+- `sidebar-nav` — `sidebar-nav.css`; inline in `org_admin.html`. Stream status filter uses `.stream-status-filter-*` in `pages/stream.css`, not this component.
+- `dialog` — `dialog.css`; destructive titles stack `.dialog-title u-text-danger`; inline on process/stream/home/org_admin/platform_admin/`substep_body`
+- `button` — `.btn` + variants in `button.css`
+- `list-row` — `list-row.css`; inline on org_admin / platform_admin
+- `tip` — `tip.css` + `tip.html` via `{{ template "tip" (dict …) }}` (`ImgSrc`/`ImgClass` or `Icon`/`InnerClass`; optional `Class`, `AriaLabel`, `Role`). `Icon` is any template define name via the `render` func.
+- `local_datetime` — `local_datetime.html` via `{{ template "local_datetime" (dict "ISO" "…" "Human" "…") }}`; client `formatLocalDateTimes` in `main.js`.
 
 ## Docs and verification
 
@@ -138,12 +147,12 @@ Before claiming done:
 
 ```bash
 cd server && go test ./cmd/server/ -count=1
-cd server && go test ./cmd/server/ -run 'Breadcrumbs|StreamCard|DialogMarkup|ListRowMarkup' -count=1
+cd server && go test ./cmd/server/ -run 'Breadcrumbs|StreamCard|StreamInstance|StreamTermination|DialogMarkup|ListRowMarkup|PanelMarkup' -count=1
 task css:lint
 ```
 
 ## Out of scope (for now)
 
 - Further peeling of `page_*.go` from `main.go`
-- `ErrorBannerView` until a handler passes it
-- Renaming legacy partial defines (`action_detail_content.html`, `role-palette-options`, …) — align when each partial is migrated
+- `ErrorBannerView` / migrating `error_banner.html` (legacy define name) until a handler owns a proper DTO
+- Renaming legacy defines such as `role-palette-options` — align when each partial is migrated

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This repo is a small end-to-end demo:
 - **Frontend**: Vite-built JS/CSS bundle, plus **HTMX** in templates and **SSE** for live updates.
 - **Authorization**: **Cerbos** policy engine for “can complete substep” checks.
 
-See: `README.md`, `QUICKSTART.md`, `DOCKER.md`, `docs/css.md` (main app styling).
+See: `README.md`, `QUICKSTART.md`, `DOCKER.md`, `docs/css.md` (CSS rules), `.agents/skills/attesta-ui-components` (extract/place UI components).
 
 ## Current auth/org status (2026-07)
 - Demo impersonation has been removed from production code paths.
@@ -41,6 +41,7 @@ When acting as a coding agent in this repository:
 - Do not refactor for style or architecture unless explicitly requested
 - Match existing patterns, even if they are imperfect
 - Read `docs/css.md` before changing templates or styles in `web/src/styles/`
+- Use `.agents/skills/attesta-ui-components` when extracting or placing templates, view structs, or component CSS
 - Read relevant code before making changes (especially `server/cmd/server/main.go`)
 - Ask before making breaking changes to routes, workflow config, or persistence
 
@@ -205,9 +206,9 @@ Download endpoint `handleDownloadProcessAttachment` streams GridFS content and s
 
 ## Templates and static assets
 - Templates load from `server/templates/*.html`, `server/templates/pages/*.html`, and `server/templates/components/*.html` via `parseTemplates()` in `server/cmd/server/templates.go`. Custom funcs in `templateFuncs()` include `dict` for inline map literals and typed wrappers such as `streamTimelineStep` / `streamTimelineSubstep` (e.g. `{{ template "stream_timeline_step" (streamTimelineStep . $.HideStatus) }}`).
-- **Template define names** match the file stem (no extension): e.g. `components/stream_card.html` → `{{ define "stream_card" }}`. Page wrappers and body blocks still use legacy `*.html` / `*_body` defines until migrated.
+- **Template define names** match the file stem (no extension): e.g. `components/stream_card.html` → `{{ define "stream_card" }}`. Page wrappers and body blocks still use legacy `*.html` / `*_body` defines until migrated. Primary CSS uses the same stem under `web/src/styles/components/` or `pages/` (underscore → kebab); exceptions in `docs/css.md`.
 - **Shared view structs** for reusable components live in `server/cmd/server/components.go` (`SubstepBodyView`, `StreamInstanceDetailView`, `StreamCardView`, …). Use struct literals at call sites — no fluent `With*` builders unless there is real logic. Page/view assembly is partially peeled (`stream_instance_detail.go`, `substep_views_builder.go`, `timeline_builder.go`); remaining handlers stay in `main.go`.
-- **Component tiers:** full template components (`templates/components/` + view struct in `components.go`); **CSS-only components** (see `docs/css.md`) — reused markup with a dedicated CSS module and inline HTML, no full template partial (examples: page-header in `page-header.css`, panel in `panel.css`, dialog in `dialog.css`, list-row in `list-row.css`); primitives in `shared.css`. Full component example for trails: `breadcrumbs` (`breadcrumbs.html` + `BreadcrumbsView`). Migrate one at a time.
+- **Component tiers** (full / CSS-only / cluster): see `.agents/skills/attesta-ui-components`. CSS-only markup contracts and layer rules: `docs/css.md`. Migrate one component at a time.
 - Substep bodies (`server/templates/components/substep_body.html`) dispatch on explicit **`Mode`** (`preview`|`actionable`|`result`|`message`) via `effectiveSubstepBodyMode`; builders set `SubstepBodyView.Mode` (`resolveSubstepBodyMode` in `components.go`).
 - Stream timeline (`server/templates/components/stream_timeline.html`) renders the step/substep accordion tree on stream instance detail and stream dashboard preview; inner define `stream_timeline_step` calls `substep_shell` via `(streamTimelineSubstep . $.HideStatus)`; `substep_shell` dispatches to `substep_body` with `TimelineSubstep.Body` (`*SubstepBodyView`).
 - Stream instance detail partial (`stream_instance_detail_content`) is built by `buildStreamInstanceDetailView` in `stream_instance_detail.go` and exposed on `ProcessPageView.Detail` (`StreamInstanceDetailView`).

--- a/docs/css.md
+++ b/docs/css.md
@@ -1,92 +1,62 @@
 # CSS style guide (main Attesta app)
 
-Source of truth for styling the server-rendered Attesta UI: CSS architecture, theming, role palettes, template rules, and lint.
+Rules for styling the server-rendered Attesta UI.
 
 **Scope:** `web/src/styles/`, `server/templates/**/*.html`. Formata embed and Formata Builder (`formata-arch/`) are out of scope.
 
-For extract-vs-inline decisions and Go view structs, see `.agents/skills/attesta-ui-components/SKILL.md`.
+**Extract / place components:** `.agents/skills/attesta-ui-components/SKILL.md`.  
+**Token values:** open `web/src/styles/tokens.css` (and `utilities.css` for `u-*`) — this doc does not mirror those catalogs.
 
 ## Layer stack
 
-Styles load in this order from `web/src/styles.css`:
+Load order from `web/src/styles.css`:
 
-| Layer | File | Contains |
-|-------|------|----------|
-| Breakpoints | `breakpoints.css` | Sole source of `@custom-media` aliases (Tailwind v3 widths) |
-| Tokens | `tokens.css` | `:root`, `[data-theme="dark"]`, font/type tokens (Google Fonts load in `layout.html`) |
-| Role palette | `role-palette.css` | `data-role-palette` and `data-stream-status` attribute maps |
-| Reset | `reset.css` | `*`, `body`, `a`, `button`, heading defaults, focus rings, reduced motion |
-| Utilities | `utilities.css` | `u-*` spacing/typography/layout primitives |
-| Layout | `layout/index.css` | Barrel: `chrome.css`, `grids.css` (`.rail-layout`), `responsive.css` |
-| Components | `components.css` | Barrel importing `components/*.css` — see that file for the live import list |
-| Pages | `pages.css` | Barrel importing `pages/*.css` — see that file for the live import list |
+1. `breakpoints.css` — sole `@custom-media` definitions  
+2. `tokens.css` — `:root`, `[data-theme="dark"]`, type/spacing tokens  
+3. `role-palette.css` — `data-role-palette` / `data-stream-status` maps  
+4. `reset.css`  
+5. `utilities.css` — `u-*`  
+6. `layout/index.css` — chrome, grids (`.rail-layout`), responsive shell  
+7. `components.css` — barrel; live import list is the file itself  
+8. `pages.css` — barrel; live import list is the file itself  
 
-**Placement rule:** token → utility → layout shell/grids → component → page. A selector lives in exactly one layer.
+**Placement:** token → utility → layout → component → page. A selector lives in exactly one layer.
 
-**Responsive placement:** co-locate `@media (--…)` blocks at the **bottom** of the owning module (component or page CSS). Shared chrome/grid breakpoints belong in `layout/` (`grids.css`, `responsive.css`).
+**Responsive:** co-locate `@media (--…)` at the **bottom** of the owning module. Shared chrome/grid breakpoints belong in `layout/` (`grids.css`, `responsive.css`).
 
-### Page modules (`pages/`)
+## Stem naming
 
-| File | Prefix / scope | Templates |
-|------|----------------|-----------|
-| `pages/process.css` | `.process-*` | `pages/process.html` |
-| `pages/dpp.css` | `.dpp-*` | `pages/dpp.html` |
-| `pages/home.css` | `.home-*`, `.preview-panel`, `.instances-panel` | `pages/home.html`, `pages/stream.html` (nav panels) |
-| `pages/stream.css` | `.stream-*` | `pages/stream.html` |
-| `pages/org-admin-page.css` | `.org-admin-*`, `.org-profile-*` (page shell) | `pages/org_admin.html` |
-| `pages/platform-admin.css` | `.platform-admin-*` | `pages/platform_admin.html` |
+Primary CSS for a template is the same **stem** under `components/` or `pages/` (underscore → kebab):
 
-Org-admin forms and pickers live in `components/org-admin.css`, not the page module. App-wide modal shells live in `components/dialog.css`.
+- `components/stream_card.html` → `components/stream-card.css` (classes `.stream-card-*`)
+- `pages/process.html` → `pages/process.css` (classes `.process-*`)
 
-### Component modules (`components/`)
+If there is no matching CSS file, the markup is **CSS-only** (inline in the page; contract in the CSS file header) or a **cluster** (`shared.css`, `forms.css`, `org-admin.css`, `stream.css`).
 
-| File | Prefix / scope | Templates / markup |
-|------|----------------|--------------------|
-| `components/page-header.css` | `.page-header`, `.page-header-*` | CSS-only — inline in pages; optional trail via `breadcrumbs`; optional `.page-header-actions` |
-| `components/breadcrumbs.css` | `.breadcrumbs`, `.breadcrumbs-*` | `components/breadcrumbs.html` |
-| `components/stream-card.css` | `.stream-card-*` | `components/stream_card.html` |
-| `components/stream-instance-card.css` | `.stream-instance-card-*` | `components/stream_instance_card.html` |
-| `components/stream-termination-details.css` | `.stream-termination-details*` | `components/stream_termination_details.html` |
-| `components/substep-body.css` | `.substep-body-*` | `components/substep_body.html`, `attachment_carousel.html` |
-| `components/stream-step-summary.css` | `.stream-step-summary-*` | `components/stream_step_summary.html` |
-| `components/stream-timeline.css` | `.stream-timeline-list`, `.stream-timeline-step*` | `components/stream_timeline.html` |
-| `components/substep-shell.css` | `.substep*`, accordion shell | `components/substep_shell.html` |
-| `components/substep-override.css` | `.substep-override-*`, `.js-open-substep-override` | `substep_override_editor.html` |
-| `components/panel.css` | `.panel`, `.panel-sticky`, `.panel-heading`, … | CSS-only — see file header |
-| `components/sidebar-nav.css` | `.sidebar-nav`, `.sidebar-nav-*` | CSS-only — see file header |
-| `components/dialog.css` | `.dialog`, `.dialog-card`, … | CSS-only — see file header |
-| `components/button.css` | `.btn`, `.btn-*` | CSS-only — see file header |
-| `components/list-row.css` | `.list-rows`, `.list-row*` | CSS-only — see file header |
-| `components/tip.css` | `.tip` | Micro-partial `components/tip.html` |
-| `components/stream.css` | `.process-toolbar`, `.process-control`, `.status-tag*` | Sort toolbar in `pages/stream.html`; status pills via `status_tag` |
-| `components/forms.css` | form controls / auth forms | Auth pages; dialogs that host forms |
-| `components/org-admin.css` | org-admin widgets / pickers | `pages/org_admin.html` |
-| `components/shared.css` | `.stack`, `.muted`, `.pill`, … | Cross-cutting primitives |
+Import new component/page modules from the matching barrel (`components.css` / `pages.css`).
 
-Cluster files (`forms.css`, `org-admin.css`, `shared.css`, `stream.css`) hold domain groups or primitives — not full extractable components.
+### Exceptions (not inventable from the stem)
 
-### CSS-only components
+- `pages/home.css` also styles stream dashboard nav panels used by `pages/stream.html`
+- `pages/org-admin-page.css` ↔ `pages/org_admin.html` (page shell); widgets/pickers stay in `components/org-admin.css`
+- `components/stream.css` is a cluster (sort toolbar, `.status-tag*` via `status_tag`) — not paired 1:1 with a `stream_*.html` component
+- `components/dpp_history_step.html` styles live under `pages/dpp.css` (`.dpp-history-*`)
+- `attachment_carousel.html` (templates root) → `components/substep-body.css`
+- `substep_override_editor.html` (templates root) → `components/substep-override.css`
+- Auth pages (`login`, `signup`, `invite`, `reset_*`) → `components/forms.css` (no per-page CSS module)
 
-Reused **markup patterns** backed by namespaced CSS, with **no** full Go template partial / view struct. Templates inline the HTML; the CSS file header comment is the markup contract.
+Root templates still pending migration (`error_banner.html`, `icons.html`, `role_palette_options.html`, …) live under `server/templates/`. Migrate one at a time when a task needs them.
 
-**Use when:** reused on 2+ pages; coherent selector family; data varies only in text/attributes (no mode dispatch, no HTMX swap target).
+## CSS-only components
 
-**Do not use when:** Go assembles a stable field set → full component + view struct; or the partial is an HTMX/SSE swap target → `components/{name}.html`.
+Reused markup + namespaced CSS, **no** full Go template partial / view struct. Inline HTML in pages; the CSS file header is the markup contract.
 
-**Adding one:** create `web/src/styles/components/{name}.css` with a markup-tree header; import from `components.css`; add a row above. Do **not** add `templates/components/{name}.html` unless it graduates (narrow micro-partials such as `status_tag` / `tip` are exceptions).
+**Use when:** 2+ pages; coherent selector family; no mode dispatch / HTMX swap target.  
+**Otherwise:** full component + view struct, or a cluster file.
 
-| Module | Primary classes | Notes |
-|--------|-----------------|-------|
-| `page-header.css` | `.page-header`, `.page-header-head`, `.page-header-body`, `.page-header-actions`, `.page-header-subtitle` | Markup tree in file header (below) |
-| `panel.css` | `.panel`, `.panel-sticky`, `.panel-heading`, `.panel-head-actions`, `.panel-actions`, `.panel-block` | File header |
-| `sidebar-nav.css` | `.sidebar-nav`, `.sidebar-nav-link`, `.sidebar-nav-title`, `.sidebar-nav-copy` | File header |
-| `dialog.css` | `.dialog`, `.dialog-card`, `.dialog-head`, `.dialog-actions` | File header; page-scoped sizing stays in page CSS |
-| `button.css` | `.btn`, variants, sizes, `.btn-icon` | File header |
-| `list-row.css` | `.list-rows`, `.list-row`, `.list-row-main`, `.list-row-actions` | File header |
-| `tip.css` | `.tip` | Micro-partial `components/tip.html` |
-| — | `local_datetime` | Micro-partial only: `components/local_datetime.html` + `web/src/main.js` |
+**Add one:** create `components/{name}.css` with a markup-tree header; import from `components.css`. Do not add `templates/components/{name}.html` unless it graduates (`status_tag`, `tip`, `local_datetime` are the narrow micro-partial exceptions).
 
-**Page header** — CSS-only. No `PageHeaderView` / `page_header` define. Optional trail: `{{ template "breadcrumbs" .Breadcrumbs }}` with `BreadcrumbsView` (`Current: true` on the last crumb ⇒ `aria-current="page"`; every crumb still has `Href`). When right actions are needed, wrap `page-header-body` + `page-header-actions` in `div.page-header-head`; omit the head wrapper when there are no actions. Process-instance ID under the title uses `.process-header-meta*` in `pages/process.css`, not this component.
+**Page header** (worked example): CSS-only — no `PageHeaderView`. Optional trail via full `breadcrumbs` (`Current: true` on last crumb; every crumb still has `Href`). With actions, wrap body + actions in `.page-header-head`; omit the head when there are no actions. Process-instance ID under the title is `.process-header-meta*` in `pages/process.css`, not page-header.
 
 ```
 Heading only:
@@ -106,188 +76,110 @@ section.page-header
       button | form | …
 ```
 
-Root templates still pending migration (`attachment_carousel.html`, `error_banner.html`, `icons.html`, `role_palette_options.html`, `substep_override_editor.html`) live under `server/templates/`. Migrate one at a time.
-
-### Template ↔ CSS index
-
-| Template | Primary CSS | Also uses |
-|----------|-------------|-----------|
-| `layout.html` | `layout/index.css` | `components/shared.css` |
-| Inline page headers | `components/page-header.css` | Optional `breadcrumbs` |
-| `components/breadcrumbs.html` | `components/breadcrumbs.css` | — |
-| `components/stream_card.html` | `components/stream-card.css` | `components/dialog.css` |
-| `components/stream_instance_card.html` | `components/stream-instance-card.css` | `components/stream.css` (via `status_tag`) |
-| `components/stream_termination_details.html` | `components/stream-termination-details.css` | `components/shared.css` (`.warning`, `.muted`); `local_datetime` |
-| Inline panel / dialog / sidebar-nav / list-row | matching `components/*.css` | `button.css`, page/domain modules as needed |
-| Inline rail shell (stream, org_admin) | `layout/grids.css` (`.rail-layout`) | `panel.css` (`.panel-sticky`); org_admin also `sidebar-nav.css` |
-| `pages/home.html` | `pages/home.css` | `stream-card`, `dialog`, `stream`, layout |
-| `pages/stream.html` | `pages/home.css`, `pages/stream.css` | rail, dialog, panel, instance-card, stream, timeline, role-palette |
-| `pages/process.html` | `pages/process.css` | page-header, dialog, substep-shell, timeline, substep-body, termination-details, layout, role-palette |
-| `components/stream_step_summary.html` | `components/stream-step-summary.css` | `tip` |
-| `components/stream_timeline.html` | `components/stream-timeline.css` | step-summary, substep-body, role-palette |
-| `components/dpp_history_step.html` | `pages/dpp.css` (`.dpp-history-*`) | timeline, step-summary, substep-shell/body, role-palette |
-| `components/substep_shell.html` | `components/substep-shell.css` | substep-body, tip, role-palette |
-| `components/substep_body.html` | `components/substep-body.css` | dialog, forms, role-palette |
-| `pages/dpp.html` | `pages/dpp.css` | dpp_history_step + timeline stack, termination-details, role-palette |
-| `pages/org_admin.html` | `pages/org-admin-page.css` | rail, dialog, sidebar-nav, panel, org-admin, role-palette |
-| `pages/platform_admin.html` | `pages/platform-admin.css` | dialog, shared |
-| Auth pages (`login`, `signup`, `invite`, `reset_*`) | `components/forms.css` | button, shared |
-| `attachment_carousel.html` | `components/substep-body.css` | — |
-| `substep_override_editor.html` | `components/substep-override.css` | — |
-
-### `data-*` contract (templates → CSS / JS)
-
-| Attribute | Set in | Consumed by |
-|-----------|--------|-------------|
-| `data-theme` | `main.js` on `<html>` | `tokens.css` (`[data-theme="dark"]`) |
-| `data-role-palette` | role badges, timeline substeps | `role-palette.css` |
-| `data-stream-status` | `status_tag`; `stream.html` section heads | `role-palette.css` (`--stream-color`) |
-| `data-progress` (via `style="--progress: …"`) | `stream_instance_card.html` | `.stream-instance-card-progress-fill` |
-| `data-org-admin-nav`, `data-org-admin-panel`, `data-org-admin-default-panel`, `data-org-admin-ready` | `org_admin.html` | `pages/org-admin-page.css`, inline script |
-| `data-home-nav`, `data-home-panel`, `data-home-filter-select` | `stream.html` | inline script (panel + query sync; select is `--md-down` twin of filter nav) |
-| `data-process-id`, `data-workflow-key`, `data-selected-substep`, `data-substep-id` | `process.html` | `main.js` (SSE, accordion) |
-| `data-formata-*`, `data-active-role-*` | `substep_body.html` | `main.js` |
-| `data-override-url` | `substep_body.html` | `main.js` |
-| `data-carousel-*` | `attachment_carousel.html` | `main.js`, `substep-body.css` |
-| `data-copy-text`, `data-copy-label`, `data-share-url`, `data-share-label` | `dpp.html` | `main.js` |
-| `data-target` | password visibility toggles | `main.js` |
-| `data-value`, `data-label`, `data-selected` | org-admin role pickers | `org-admin.css`, inline script |
-| `data-role-color` | `role_palette_options.html` | org-admin palette picker script |
-
-Behavior hooks use a `js-*` class prefix alongside `data-*` where needed; do not style `js-*` classes in CSS.
+Other CSS-only modules (`panel`, `dialog`, `sidebar-nav`, `button`, `list-row`, …): read the matching file header. Page-scoped dialog sizing stays in page CSS (e.g. `#stream-preview-dialog` in `pages/stream.css`). Destructive dialog titles stack `.dialog-title u-text-danger`.
 
 ## Theming
 
-- Light/dark mode toggles `data-theme="light|dark"` on `<html>` (`web/src/main.js`).
-- Use design tokens (`var(--foreground)`, `var(--card)`, `var(--primary)`, …) — do not hardcode hex/rgb in templates or new CSS.
-- Role hue and stream status tokens use CSS `light-dark()` in `:root`; `[data-theme="dark"]` keeps only non-role overrides.
-- Token names follow shadcn-style `{role}` + `{role}-foreground` pairs (see `tokens.css`).
+- Light/dark: `data-theme="light|dark"` on `<html>` (`web/src/main.js`).
+- Use tokens (`var(--foreground)`, `var(--card)`, `var(--primary)`, …) — no hardcoded hex/rgb in templates or new CSS.
+- Role / stream hues use `light-dark()` in `:root`; `[data-theme="dark"]` keeps only non-role overrides.
+- Token names follow shadcn-style `{role}` + `{role}-foreground` pairs.
 
 ### Breakpoints
 
-**Tailwind v3 widths** (sm → 2xl) are the canonical thresholds:
+Tailwind v3 widths; aliases only in `breakpoints.css`:
 
-| Tailwind | Width | `@custom-media` up | `@custom-media` down |
-|----------|-------|--------------------|----------------------|
-| sm | 640px | `--sm-up` `(width >= 640px)` | `--sm-down` `(width < 640px)` |
+| Tailwind | Width | up | down |
+|----------|-------|----|------|
+| sm | 640px | `--sm-up` | `--sm-down` |
 | md | 768px | `--md-up` | `--md-down` |
 | lg | 1024px | `--lg-up` | `--lg-down` |
 | xl | 1280px | `--xl-up` | `--xl-down` |
 | 2xl | 1536px | `--2xl-up` | — |
 
-- **`breakpoints.css`** is the **only** file that may define `@custom-media`.
-- Modules use `@media (--sm-down) { … }` — do not repeat `@custom-media` or write `@media (width … 640px)` in component/page CSS.
-- **PostCSS:** `postcss-custom-media` expands aliases at build time (`web/postcss.config.js`).
+Modules use `@media (--sm-down) { … }`. Never redefine `@custom-media` or write `@media (width … 640px)` in component/page CSS. PostCSS (`postcss-custom-media`) expands aliases at build time.
 
-**JS sync:** match CSS with the equivalent `matchMedia`. Example: `--md-down` ↔ `matchMedia("(max-width: 767px)")` (as in `org_admin.html`).
+**JS sync:** `--md-down` ↔ `matchMedia("(max-width: 767px)")` (as in `org_admin.html`). Keep new JS literals aligned with the table.
 
-### Font tokens
+### Fonts and type
 
-| Token | Value |
-|-------|-------|
-| `--font-sans` | Inter stack (body, buttons, UI copy, `h2`–`h4`) |
-| `--font-display` | Space Grotesk stack (literal `h1` only) |
-| `--font-mono` | JetBrains Mono stack (hashes, codes, meta ids) |
+| Token | Use |
+|-------|-----|
+| `--font-sans` | Body, buttons, UI copy, `h2`–`h4` (Inter) |
+| `--font-display` | Literal `h1` only (Space Grotesk) |
+| `--font-mono` | Hashes, codes, meta ids (JetBrains Mono) |
 
-Google Fonts load from `server/templates/layout.html`. Do **not** `@import` fonts from `tokens.css`.
+Google Fonts load from `layout.html` — do not `@import` fonts from `tokens.css`.
 
-### Type scale
+Type / weight / leading tokens live in `tokens.css`. Heading defaults in `reset.css`: `h1` → `--text-3xl` + `--font-display`; `h2` → `--text-xl`; `h3` → `--text-lg`; `h4` → `--text-base`; all `--font-semibold` + `--leading-tight`. Prefer tokens over raw `font-size`.
 
-Canonical tokens in `tokens.css` (Tailwind-aligned, rem-based). Index ≈ size: `--text-sm` = `0.875rem` = 14px.
+Buttons: `button.css` (default height `--btn-height`). Form labels `--text-sm`; inputs `--text-base`.
 
-| Token | rem | px | Typical use |
-|-------|-----|----|-------------|
-| `--text-xs` | `0.75rem` | 12 | Captions, pills, compact tags, meta IDs |
-| `--text-sm` | `0.875rem` | 14 | Labels, secondary UI, toolbar, form labels, buttons |
-| `--text-base` | `1rem` | 16 | Body, inputs |
-| `--text-lg` | `1.125rem` | 18 | Card/dialog titles |
-| `--text-xl` | `1.25rem` | 20 | Section headings (`h2`; nested `h3`) |
-| `--text-2xl` | `1.5rem` | 24 | Large titles |
-| `--text-3xl` | `1.875rem` | 30 | Page titles (`h1` default) |
+### Spacing and elevation
 
-**Line-height:** `--leading-none` `1`, `--leading-tight` `1.25`, `--leading-normal` `1.5`, `--leading-relaxed` `1.625`.
+`--space-1` … `--space-12` on a 4px grid in `tokens.css`. Prefer `u-*` or component classes over raw `px` in templates.
 
-**Weight:** `--font-normal` `400`, `--font-medium` `500`, `--font-semibold` `600`, `--font-bold` `700` (Inter faces loaded to match).
+**`px` exceptions:** layout dimensions, `border-radius`, `border-width`, scroll anchors, composite off-scale padding. Use type tokens for `font-size`.
 
-**Heading defaults** in `reset.css`: `h1` → `--text-3xl` + `--font-display`; `h2` → `--text-xl`; `h3` → `--text-lg`; `h4` → `--text-base`; all `--font-semibold` + `--leading-tight`. Prefer tokens over raw `font-size`.
-
-**Controls:** buttons use `button.css` (default height `--btn-height` / 36px). Form labels `--text-sm`; inputs `--text-base`.
-
-### Spacing scale
-
-Canonical `--space-N` in `tokens.css` on a 4px grid (`--space-4` = `1rem` = 16px). Scale runs `--space-1` … `--space-12`. Prefer `u-*` utilities or component classes over raw `px` in templates.
-
-**Intentional `px` exceptions:** layout dimensions, `border-radius`, `border-width`, scroll anchors, and composite padding with off-scale values. Use type tokens for `font-size`.
-
-### Elevation and backdrop tokens
-
-`--shadow`, `--shadow-elevated`, `--shadow-dropdown`, `--backdrop-modal`, `--backdrop-fullscreen`, `--inset-highlight` — see `tokens.css`. New shadow/backdrop tints get a semantic token there, not an inline `rgb()`.
+Shadows / backdrops (`--shadow*`, `--backdrop-*`, `--inset-highlight`): define new tints as tokens in `tokens.css`, not inline `rgb()`.
 
 ## Role palette
 
-Role badge colors resolve at runtime from **Appwrite team prefs**, not workflow YAML or inline CSS.
+Runtime colors come from **Appwrite team prefs**, not workflow YAML or inline CSS.
 
 ```
-Appwrite team prefs          Backend (roleMetaIndex)          Templates + CSS
-{ slug, name, palette }  →   (orgSlug, roleSlug) → key   →   data-role-palette="blue"
-                                                                      ↓
-                                                             role-palette.css → --role-*
+Appwrite { slug, name, palette }  →  backend (orgSlug, roleSlug)  →  data-role-palette="blue"
+                                                                         ↓
+                                                                role-palette.css → --role-*
 ```
 
 | Layer | Responsibility |
 |-------|----------------|
-| Appwrite | Canonical `{ slug, name, palette }` named key |
-| Backend | Org-scoped `(orgSlug, roleSlug)` → palette key; never emits `var(--role-*-*)` to templates |
-| Workflow YAML | Slug/org/name for validation; `color` fields ignored by Go |
+| Appwrite | Canonical named `palette` key |
+| Backend | Resolve `(orgSlug, roleSlug)` → key; never emit `var(--role-*-*)` to templates |
+| Workflow YAML | Slug/org/name only; `color` ignored by Go |
 | Templates | `data-role-palette="{{ .Palette }}"` on `.role-pill` / timeline substeps |
-| `tokens.css` + `role-palette.css` | Appearance map |
+| `tokens.css` + `role-palette.css` | Appearance |
 
-**Storage:** writes persist `palette` only; reads prefer `palette`, with legacy `color` CSS-var strings falling back via `rolePaletteKeyFromStyle()`. `GET /api/catalog` returns `palette` per role. Unknown/missing → `"fallback"`.
-
-**Lookup:** step with `organization:` → `(stepOrg, roleSlug)`; else first org containing the slug; else `"fallback"`. Symbols: `roleMetaIndex`, `roleMetaFor`, `rolePaletteKeyFromStyle`.
-
-Named palette keys live in `rolePaletteStyles` / `rolePaletteKeys` (Go) and `role-palette.css`. `TestRolePaletteKeysMatchCSS` keeps them in sync.
+Writes persist `palette` only; legacy `color` CSS-var strings fall back via `rolePaletteKeyFromStyle()`. `GET /api/catalog` returns `palette`. Unknown → `"fallback"`. Lookup: step `organization:` → `(stepOrg, roleSlug)`; else first org containing the slug. Keys stay in sync via `TestRolePaletteKeysMatchCSS`.
 
 ```html
 <span class="role-pill" data-role-palette="{{ .Palette }}">{{ .Label }}</span>
 {{ template "status_tag" .Status }}
 ```
 
-`status_tag` renders `<span class="status-tag status-tag-compact" data-stream-status="…">` (pipeline = status string). `.status-tag` uses `var(--stream-color)`. Static presets: `.pill-accent`, `.pill-panel`.
+`status_tag` (pipeline = status string) sets `data-stream-status`; `.status-tag` uses `var(--stream-color)`. Static presets: `.pill-accent`, `.pill-panel`.
+
+## Shared `data-*` (CSS theming)
+
+| Attribute | Consumer |
+|-----------|----------|
+| `data-theme` | `tokens.css` |
+| `data-role-palette` | `role-palette.css` |
+| `data-stream-status` | `role-palette.css` → `--stream-color` |
+| `style="--progress: …%"` | `.stream-instance-card-progress-fill` only |
+
+Page-local hooks (`data-org-admin-*`, `data-home-*`, `data-process-id`, `data-formata-*`, carousel/copy/share, …) stay next to their template / `main.js` — do not catalog them here.
+
+Behavior hooks may use a `js-*` class alongside `data-*`; **never style `js-*` in CSS**.
 
 ## Utilities (`u-*`)
 
-Generic helpers in `utilities.css`. Add a utility when the same spacing/typography pattern appears in multiple templates. Prefer component classes for domain-specific patterns.
+Generic, domain-agnostic helpers in `utilities.css`. Add a `u-*` when the same spacing/typography pattern appears in multiple templates; prefer component classes for domain patterns. New utilities get a one-line PR justification.
 
-| Class | Effect |
-|-------|--------|
-| `u-mx-auto` | `margin-inline: auto` |
-| `u-max-w-prose` | `max-width: 65ch` |
-| `u-max-w-7xl` | `max-width: 80rem` |
-| `u-m-0` | `margin: 0` |
-| `u-mb-2` / `u-mb-4` / `u-mb-5` | bottom margin via `--space-*` |
-| `u-ml-1` | `margin-left: var(--space-1)` |
-| `u-pre-line` | `white-space: pre-line` |
-| `u-text-xs` / `u-text-sm` / `u-text-base` / `u-text-lg` | type scale (`u-text-sm` also semibold) |
-| `u-flex` / `u-flex-center` | flex / flex + center |
-| `u-gap-2` / `u-gap-4` / `u-gap-12` | gap via `--space-*` |
-| `u-divider` / `u-divider-5` / `u-divider-10` | `<hr>` with vertical `--space-*` margin |
-| `u-divider-flush` | `<hr>` with `margin: 0` |
-| `u-text-danger` | `color: var(--destructive)` |
-
-`.stack.u-gap-2` and `.stack.u-gap-4` override the default stack gap (`var(--space-6)`). New `u-*` utilities should include a one-line justification in the PR.
+`.stack.u-gap-*` overrides the default stack gap (`var(--space-6)`).
 
 ## Inline `style=` in templates
 
-**Do not** use inline styles for static layout, spacing, or typography.
+No inline styles for static layout, spacing, or typography.
 
-**Allowed** — runtime values from Go:
+**Allowed** (runtime from Go):
 
 | Pattern | Example | Consumer |
 |---------|---------|----------|
 | Progress width | `style="--progress: {{ .Percent }}%;"` | `.stream-instance-card-progress-fill` |
 
-All other dynamic theming uses `data-*` (`data-role-palette`, `data-stream-status`), not inline custom properties.
+All other dynamic theming uses `data-*`, not inline custom properties.
 
 ## Build and lint
 
@@ -296,21 +188,19 @@ cd web && npm run build   # → web/dist/assets/main.css (served at /static/)
 task css:lint
 ```
 
-`task css:lint` runs:
+`task css:lint`:
 
-1. **Template inline styles** — `deployment/scripts/check-template-inline-styles.sh`
-2. **Breakpoint guard** — `deployment/scripts/check-css-breakpoints.sh` (no literal `@media (width … px)` outside `breakpoints.css`)
-3. **stylelint** — `web/src/styles/**/*.css` (no hex/rgb outside `tokens.css`, no new `!important`)
+1. Template inline styles — `deployment/scripts/check-template-inline-styles.sh`
+2. Breakpoint guard — no literal `@media (width … px)` outside `breakpoints.css`
+3. stylelint — no hex/rgb outside `tokens.css`, no new `!important`
 
 ## Adding new UI
 
-1. Check for an existing component class, CSS-only module, or utility.
-2. If spacing/typography repeats across templates, add a `u-*` utility.
-3. If domain-specific, add a component or page class.
-4. Use tokens for colors; never hardcode hex in templates.
-5. Run `task css:lint` before opening a PR.
+1. Prefer an existing component, CSS-only module, or `u-*`.
+2. New domain styles → component or page module (stem rule + barrel import).
+3. Tokens for color; run `task css:lint` before the PR.
 
 ## Out of scope
 
-- **Formata embed** shadow-DOM styling in `web/src/main.js` (`!important` overrides).
-- **New palette key** — update `rolePaletteStyles`, `role-palette.css`, and the org-admin palette picker (not Go string passthrough to templates).
+- Formata embed shadow-DOM styling in `web/src/main.js`
+- New palette key → `rolePaletteStyles`, `role-palette.css`, and the org-admin picker (not Go string passthrough)

--- a/docs/css.md
+++ b/docs/css.md
@@ -4,6 +4,8 @@ Source of truth for styling the server-rendered Attesta UI: CSS architecture, th
 
 **Scope:** `web/src/styles/`, `server/templates/**/*.html`. Formata embed and Formata Builder (`formata-arch/`) are out of scope.
 
+For extract-vs-inline decisions and Go view structs, see `.agents/skills/attesta-ui-components/SKILL.md`.
+
 ## Layer stack
 
 Styles load in this order from `web/src/styles.css`:
@@ -15,13 +17,13 @@ Styles load in this order from `web/src/styles.css`:
 | Role palette | `role-palette.css` | `data-role-palette` and `data-stream-status` attribute maps |
 | Reset | `reset.css` | `*`, `body`, `a`, `button`, heading defaults, focus rings, reduced motion |
 | Utilities | `utilities.css` | `u-*` spacing/typography/layout primitives |
-| Layout | `layout/index.css` | Barrel: `chrome.css` (topbar, nav, stack, footer), `grids.css` (page grids + `.rail-layout`), `responsive.css` (shell breakpoint tweaks) |
-| Components | `components.css` | Barrel importing `components/*.css` (panel, dialog, page-header, breadcrumbs, stream-card, stream-instance-card, substep-shell, stream-timeline, forms, org-admin, stream, shared) |
-| Pages | `pages.css` | Barrel importing `pages/*.css` (DPP, home, stream, process, org-admin shell, platform admin) |
+| Layout | `layout/index.css` | Barrel: `chrome.css`, `grids.css` (`.rail-layout`), `responsive.css` |
+| Components | `components.css` | Barrel importing `components/*.css` — see that file for the live import list |
+| Pages | `pages.css` | Barrel importing `pages/*.css` — see that file for the live import list |
 
 **Placement rule:** token → utility → layout shell/grids → component → page. A selector lives in exactly one layer.
 
-**Responsive placement:** co-locate `@media (--…)` blocks at the **bottom** of the owning module (component or page CSS). Shared page chrome and grid breakpoint behavior belongs in `layout/` (`grids.css`, `responsive.css`), not in separate breakpoint files.
+**Responsive placement:** co-locate `@media (--…)` blocks at the **bottom** of the owning module (component or page CSS). Shared chrome/grid breakpoints belong in `layout/` (`grids.css`, `responsive.css`).
 
 ### Page modules (`pages/`)
 
@@ -38,59 +40,53 @@ Org-admin forms and pickers live in `components/org-admin.css`, not the page mod
 
 ### Component modules (`components/`)
 
-| File | Prefix / scope | Templates |
-|------|----------------|-----------|
-| `components/page-header.css` | `.page-header`, `.page-header-*` | Inline markup per `page-header.css` header (CSS-only); optional `nav.breadcrumbs` via full `breadcrumbs` component; optional `.page-header-actions` |
+| File | Prefix / scope | Templates / markup |
+|------|----------------|--------------------|
+| `components/page-header.css` | `.page-header`, `.page-header-*` | CSS-only — inline in pages; optional trail via `breadcrumbs`; optional `.page-header-actions` |
 | `components/breadcrumbs.css` | `.breadcrumbs`, `.breadcrumbs-*` | `components/breadcrumbs.html` |
 | `components/stream-card.css` | `.stream-card-*` | `components/stream_card.html` |
 | `components/stream-instance-card.css` | `.stream-instance-card-*` | `components/stream_instance_card.html` |
+| `components/stream-termination-details.css` | `.stream-termination-details*` | `components/stream_termination_details.html` |
 | `components/substep-body.css` | `.substep-body-*` | `components/substep_body.html`, `attachment_carousel.html` |
 | `components/stream-step-summary.css` | `.stream-step-summary-*` | `components/stream_step_summary.html` |
 | `components/stream-timeline.css` | `.stream-timeline-list`, `.stream-timeline-step*` | `components/stream_timeline.html` |
 | `components/substep-shell.css` | `.substep*`, accordion shell | `components/substep_shell.html` |
 | `components/substep-override.css` | `.substep-override-*`, `.js-open-substep-override` | `substep_override_editor.html` |
-| `components/panel.css` | `.panel`, `.panel-sticky`, `.panel-heading`, `.panel-head-actions`, `.panel-block` | Inline markup per `panel.css` header (CSS-only) |
-| `components/sidebar-nav.css` | `.sidebar-nav`, `.sidebar-nav-link`, `.sidebar-nav-title`, `.sidebar-nav-copy` | Inline markup per `sidebar-nav.css` header (CSS-only) |
-| `components/dialog.css` | `.dialog`, `.dialog-card`, `.dialog-head`, `.dialog-actions`, … | Inline markup per `dialog.css` header (CSS-only) |
-| `components/list-row.css` | `.list-rows`, `.list-row`, `.list-row-main`, `.list-row-actions` | Inline markup per `list-row.css` header (CSS-only) |
-| `components/stream.css` | `.process-toolbar`, `.process-control`, `.status-tag*` | Sort toolbar in `pages/stream.html`; status pills via micro-partial `status_tag` |
+| `components/panel.css` | `.panel`, `.panel-sticky`, `.panel-heading`, … | CSS-only — see file header |
+| `components/sidebar-nav.css` | `.sidebar-nav`, `.sidebar-nav-*` | CSS-only — see file header |
+| `components/dialog.css` | `.dialog`, `.dialog-card`, … | CSS-only — see file header |
+| `components/button.css` | `.btn`, `.btn-*` | CSS-only — see file header |
+| `components/list-row.css` | `.list-rows`, `.list-row*` | CSS-only — see file header |
+| `components/tip.css` | `.tip` | Micro-partial `components/tip.html` |
+| `components/stream.css` | `.process-toolbar`, `.process-control`, `.status-tag*` | Sort toolbar in `pages/stream.html`; status pills via `status_tag` |
+| `components/forms.css` | form controls / auth forms | Auth pages; dialogs that host forms |
+| `components/org-admin.css` | org-admin widgets / pickers | `pages/org_admin.html` |
+| `components/shared.css` | `.stack`, `.muted`, `.pill`, … | Cross-cutting primitives |
+
+Cluster files (`forms.css`, `org-admin.css`, `shared.css`, `stream.css`) hold domain groups or primitives — not full extractable components.
 
 ### CSS-only components
 
-Reused **markup patterns** backed by namespaced CSS, with **no** full Go template partial / view struct. Templates inline the HTML under `server/templates/pages/`; the CSS file header comment is the markup contract.
+Reused **markup patterns** backed by namespaced CSS, with **no** full Go template partial / view struct. Templates inline the HTML; the CSS file header comment is the markup contract.
 
-**Use when:**
+**Use when:** reused on 2+ pages; coherent selector family; data varies only in text/attributes (no mode dispatch, no HTMX swap target).
 
-- The pattern is reused on 2+ pages
-- Selectors form a coherent family (3+ related rules)
-- Data varies only in text/attributes at the call site (no mode dispatch, no HTMX partial target)
+**Do not use when:** Go assembles a stable field set → full component + view struct; or the partial is an HTMX/SSE swap target → `components/{name}.html`.
 
-**Do not use when:**
+**Adding one:** create `web/src/styles/components/{name}.css` with a markup-tree header; import from `components.css`; add a row above. Do **not** add `templates/components/{name}.html` unless it graduates (narrow micro-partials such as `status_tag` / `tip` are exceptions).
 
-- Go assembles a stable field set → full template component + view struct (e.g. `stream_card`, `substep_body`)
-- The partial is an HTMX/SSE swap target → extract to `components/{name}.html`
+| Module | Primary classes | Notes |
+|--------|-----------------|-------|
+| `page-header.css` | `.page-header`, `.page-header-head`, `.page-header-body`, `.page-header-actions`, `.page-header-subtitle` | Markup tree in file header (below) |
+| `panel.css` | `.panel`, `.panel-sticky`, `.panel-heading`, `.panel-head-actions`, `.panel-actions`, `.panel-block` | File header |
+| `sidebar-nav.css` | `.sidebar-nav`, `.sidebar-nav-link`, `.sidebar-nav-title`, `.sidebar-nav-copy` | File header |
+| `dialog.css` | `.dialog`, `.dialog-card`, `.dialog-head`, `.dialog-actions` | File header; page-scoped sizing stays in page CSS |
+| `button.css` | `.btn`, variants, sizes, `.btn-icon` | File header |
+| `list-row.css` | `.list-rows`, `.list-row`, `.list-row-main`, `.list-row-actions` | File header |
+| `tip.css` | `.tip` | Micro-partial `components/tip.html` |
+| — | `local_datetime` | Micro-partial only: `components/local_datetime.html` + `web/src/main.js` |
 
-**Adding one:**
-
-1. Create `web/src/styles/components/{name}.css` with a markup-tree comment at the top.
-2. Import it from `web/src/styles/components.css`.
-3. Add a row to the table below.
-4. Do **not** create a matching `templates/components/{name}.html` unless it graduates (narrow micro-partials such as `status_tag` are the exception, not the rule).
-
-| Module | Primary classes | Markup contract |
-|--------|-----------------|-----------------|
-| `page-header.css` | `.page-header`, `.page-header-head`, `.page-header-body`, `.page-header-actions`, `.page-header-subtitle` | See file header in `web/src/styles/components/page-header.css`; intended tree below |
-| `panel.css` | `.panel`, `.panel-sticky`, `.panel-heading`, `.panel-head-actions`, `.panel-actions`, `.panel-block` | See file header in `web/src/styles/components/panel.css` |
-| `sidebar-nav.css` | `.sidebar-nav`, `.sidebar-nav-link`, `.sidebar-nav-title`, `.sidebar-nav-copy` | See file header in `web/src/styles/components/sidebar-nav.css` |
-| `dialog.css` | `.dialog`, `.dialog-card`, `.dialog-head`, `.dialog-actions` | See file header in `web/src/styles/components/dialog.css` |
-| `button.css` | `.btn`, `.btn-primary`, `.btn-secondary`, `.btn-ghost`, `.btn-ghost-danger`, `.btn-danger`, `.btn-outline`, `.btn-xs`, `.btn-sm`, `.btn-lg`, `.btn-icon` | See file header in `web/src/styles/components/button.css` |
-| `list-row.css` | `.list-rows`, `.list-row`, `.list-row-main`, `.list-row-actions` | See file header in `web/src/styles/components/list-row.css` |
-| `tip.css` | `.tip` | See file header in `web/src/styles/components/tip.css`; micro-partial `components/tip.html` |
-| — | `local_datetime` | Micro-partial `components/local_datetime.html`: `time.js-local-datetime[datetime]` + UTC human fallback; client formats in `web/src/main.js` |
-
-**Page header** — CSS-only. Inline the markup tree in page templates (no `PageHeaderView`, no full `page_header` define). Optional trail uses the full `breadcrumbs` component: `{{ template "breadcrumbs" .Breadcrumbs }}` with `BreadcrumbsView` assembled in Go (`BreadcrumbItem.Href` empty ⇒ current page). When right actions are needed, wrap `page-header-body` + `page-header-actions` in `div.page-header-head` (same idea as panel head-actions); omit the head wrapper when there are no actions. Process-instance ID under the title is **not** part of this component — it uses `.process-header-meta` / `.process-header-meta-id` in `pages/process.css`.
-
-Intended markup contract (also the target CSS file header comment):
+**Page header** — CSS-only. No `PageHeaderView` / `page_header` define. Optional trail: `{{ template "breadcrumbs" .Breadcrumbs }}` with `BreadcrumbsView` (`Current: true` on the last crumb ⇒ `aria-current="page"`; every crumb still has `Href`). When right actions are needed, wrap `page-header-body` + `page-header-actions` in `div.page-header-head`; omit the head wrapper when there are no actions. Process-instance ID under the title uses `.process-header-meta*` in `pages/process.css`, not this component.
 
 ```
 Heading only:
@@ -110,36 +106,32 @@ section.page-header
       button | form | …
 ```
 
-**Dialog placement:** generic shell in `dialog.css`; `#stream-preview-dialog` sizing in `pages/stream.css`; org-admin role pill wrapper in `org-admin.css`. Destructive titles use `u-text-danger` (color only) stacked on `.dialog-title`. Wide shell modifier `.dialog-wide` deferred until a second page needs it.
-
-Other partials (`icons.html`, …) still live at `server/templates/` root until migrated one by one. Split reused styles into `components/` and page-specific styles into `pages/`.
+Root templates still pending migration (`attachment_carousel.html`, `error_banner.html`, `icons.html`, `role_palette_options.html`, `substep_override_editor.html`) live under `server/templates/`. Migrate one at a time.
 
 ### Template ↔ CSS index
 
 | Template | Primary CSS | Also uses |
 |----------|-------------|-----------|
 | `layout.html` | `layout/index.css` | `components/shared.css` |
-| Inline page headers (home, stream, process, dpp, org_admin, platform_admin, …) | `components/page-header.css` | Optional `components/breadcrumbs.html` + `components/breadcrumbs.css` |
+| Inline page headers | `components/page-header.css` | Optional `breadcrumbs` |
 | `components/breadcrumbs.html` | `components/breadcrumbs.css` | — |
 | `components/stream_card.html` | `components/stream-card.css` | `components/dialog.css` |
-| `components/stream_instance_card.html` | `components/stream-instance-card.css` | `components/stream.css` (`.status-tag*` via `status_tag` micro-partial) |
-| Inline panel sections (process, stream, dpp, org_admin, platform_admin) | `components/panel.css` | `components/button.css`, `components/shared.css` (`.muted`); optional `.panel-sticky` |
-| Inline dialog modals (process, stream, home, org_admin, platform_admin, substep_body) | `components/dialog.css` | `pages/stream.css` (#stream-preview-dialog), `components/org-admin.css` (role pill), `components/substep-body.css` (active-role spacing), `components/forms.css` |
-| Inline sidebar nav (org_admin) | `components/sidebar-nav.css` | `components/panel.css` (`.panel-sticky`), `layout/grids.css` (`.rail-layout`) |
-| Inline rail shell (stream, org_admin) | `layout/grids.css` (`.rail-layout`) | `components/panel.css` (`.panel-sticky`); org_admin also `components/sidebar-nav.css` |
-| Inline list rows (org_admin roles/users, platform_admin orgs) | `components/list-row.css` | `components/button.css`; domain: `org-admin.css` (`.user-email`, `.user-tags`), `pages/platform-admin.css` (copy/status) |
-| `pages/home.html` | `pages/home.css` | `components/stream-card.css`, `components/dialog.css`, `components/stream.css`, `layout/index.css` |
-| `pages/stream.html` | `pages/home.css`, `pages/stream.css` | `layout/grids.css` (`.rail-layout`), `components/dialog.css`, `components/panel.css`, `components/stream-instance-card.css`, `components/stream.css`, `components/stream-timeline.css`, `role-palette.css` |
-| `pages/process.html` | `pages/process.css` (incl. `.process-header-meta*`) | `components/page-header.css`, `components/dialog.css`, `components/substep-shell.css`, `components/stream-timeline.css`, `components/substep-body.css`, `layout/responsive.css` (`.layout-stack-separator`), `role-palette.css` |
-| `components/stream_step_summary.html` | `components/stream-step-summary.css` | `components/tip.css` (`tip` micro-partial) |
-| `components/stream_timeline.html` | `components/stream-timeline.css` | `components/stream-step-summary.css`, `components/substep-body.css`, `role-palette.css` |
-| `components/dpp_history_step.html` | `pages/dpp.css` (`.dpp-history-*`) | `components/stream-timeline.css`, `components/stream-step-summary.css`, `components/substep-shell.css`, `components/substep-body.css`, `role-palette.css` |
-| `components/substep_shell.html` | `components/substep-shell.css` | `components/substep-body.css`, `components/tip.css` (`tip` micro-partial), `role-palette.css` |
-| `components/substep_body.html` | `components/substep-body.css` | `components/dialog.css`, `components/forms.css`, `role-palette.css` |
-| `pages/dpp.html` | `pages/dpp.css` | `components/dpp_history_step.html`, `components/stream-timeline.css`, `components/stream-step-summary.css`, `components/substep-shell.css`, `components/substep-body.css`, `role-palette.css` |
-| `pages/org_admin.html` | `pages/org-admin-page.css` | `layout/grids.css` (`.rail-layout`), `components/dialog.css`, `components/sidebar-nav.css`, `components/panel.css`, `components/org-admin.css`, `role-palette.css` |
-| `pages/platform_admin.html` | `pages/platform-admin.css` | `components/dialog.css`, `components/shared.css` |
-| `pages/login.html`, `pages/signup.html`, `pages/invite.html`, `pages/reset_*.html` | `components/forms.css` | `components/button.css`, `components/shared.css` |
+| `components/stream_instance_card.html` | `components/stream-instance-card.css` | `components/stream.css` (via `status_tag`) |
+| `components/stream_termination_details.html` | `components/stream-termination-details.css` | `components/shared.css` (`.warning`, `.muted`); `local_datetime` |
+| Inline panel / dialog / sidebar-nav / list-row | matching `components/*.css` | `button.css`, page/domain modules as needed |
+| Inline rail shell (stream, org_admin) | `layout/grids.css` (`.rail-layout`) | `panel.css` (`.panel-sticky`); org_admin also `sidebar-nav.css` |
+| `pages/home.html` | `pages/home.css` | `stream-card`, `dialog`, `stream`, layout |
+| `pages/stream.html` | `pages/home.css`, `pages/stream.css` | rail, dialog, panel, instance-card, stream, timeline, role-palette |
+| `pages/process.html` | `pages/process.css` | page-header, dialog, substep-shell, timeline, substep-body, termination-details, layout, role-palette |
+| `components/stream_step_summary.html` | `components/stream-step-summary.css` | `tip` |
+| `components/stream_timeline.html` | `components/stream-timeline.css` | step-summary, substep-body, role-palette |
+| `components/dpp_history_step.html` | `pages/dpp.css` (`.dpp-history-*`) | timeline, step-summary, substep-shell/body, role-palette |
+| `components/substep_shell.html` | `components/substep-shell.css` | substep-body, tip, role-palette |
+| `components/substep_body.html` | `components/substep-body.css` | dialog, forms, role-palette |
+| `pages/dpp.html` | `pages/dpp.css` | dpp_history_step + timeline stack, termination-details, role-palette |
+| `pages/org_admin.html` | `pages/org-admin-page.css` | rail, dialog, sidebar-nav, panel, org-admin, role-palette |
+| `pages/platform_admin.html` | `pages/platform-admin.css` | dialog, shared |
+| Auth pages (`login`, `signup`, `invite`, `reset_*`) | `components/forms.css` | button, shared |
 | `attachment_carousel.html` | `components/substep-body.css` | — |
 | `substep_override_editor.html` | `components/substep-override.css` | — |
 
@@ -149,26 +141,25 @@ Other partials (`icons.html`, …) still live at `server/templates/` root until 
 |-----------|--------|-------------|
 | `data-theme` | `main.js` on `<html>` | `tokens.css` (`[data-theme="dark"]`) |
 | `data-role-palette` | role badges, timeline substeps | `role-palette.css` |
-| `data-stream-status` | `status_tag` micro-partial; `stream.html` section heads | `role-palette.css` (`--stream-color`) |
-| `data-progress` (via `style="--progress: …"`) | `components/stream_instance_card.html` | `.stream-instance-card-progress-fill` in `components/stream-instance-card.css` |
-| `data-org-admin-nav`, `data-org-admin-panel`, `data-org-admin-default-panel`, `data-org-admin-ready` | `org_admin.html` | `pages/org-admin-page.css`, inline script in `org_admin.html` |
-| `data-home-nav`, `data-home-panel`, `data-home-filter-select` | `stream.html` | inline script in `stream.html` (panel switching + `?filter=` / `?sort=` / `?page=` sync; select is `--md-down` twin of filter nav) |
-| `data-process-id`, `data-workflow-key`, `data-selected-substep`, `data-substep-id` | `process.html` | `main.js` (SSE refresh, accordion) |
-| `data-formata-*`, `data-active-role-*` | `components/substep_body.html` | `main.js` (Formata embed, role picker) |
-| `data-override-url` | `components/substep_body.html` | `main.js` (substep override editor) |
-| `data-carousel-*` | `attachment_carousel.html` | `main.js`, `components/substep-body.css` |
-| `data-copy-text`, `data-copy-label` | `dpp.html` | `main.js` (clipboard) |
-| `data-share-url`, `data-share-label` | `dpp.html` | `main.js` (share link) |
+| `data-stream-status` | `status_tag`; `stream.html` section heads | `role-palette.css` (`--stream-color`) |
+| `data-progress` (via `style="--progress: …"`) | `stream_instance_card.html` | `.stream-instance-card-progress-fill` |
+| `data-org-admin-nav`, `data-org-admin-panel`, `data-org-admin-default-panel`, `data-org-admin-ready` | `org_admin.html` | `pages/org-admin-page.css`, inline script |
+| `data-home-nav`, `data-home-panel`, `data-home-filter-select` | `stream.html` | inline script (panel + query sync; select is `--md-down` twin of filter nav) |
+| `data-process-id`, `data-workflow-key`, `data-selected-substep`, `data-substep-id` | `process.html` | `main.js` (SSE, accordion) |
+| `data-formata-*`, `data-active-role-*` | `substep_body.html` | `main.js` |
+| `data-override-url` | `substep_body.html` | `main.js` |
+| `data-carousel-*` | `attachment_carousel.html` | `main.js`, `substep-body.css` |
+| `data-copy-text`, `data-copy-label`, `data-share-url`, `data-share-label` | `dpp.html` | `main.js` |
 | `data-target` | password visibility toggles | `main.js` |
-| `data-value`, `data-label`, `data-selected` | org-admin role pickers | `components/org-admin.css`, inline script |
+| `data-value`, `data-label`, `data-selected` | org-admin role pickers | `org-admin.css`, inline script |
 | `data-role-color` | `role_palette_options.html` | org-admin palette picker script |
 
 Behavior hooks use a `js-*` class prefix alongside `data-*` where needed; do not style `js-*` classes in CSS.
 
 ## Theming
 
-- Light/dark mode toggles `data-theme="light|dark"` on `<html>` (see `web/src/main.js`).
-- Use design tokens (`var(--foreground)`, `var(--card)`, `var(--primary)`, etc.) — do not hardcode hex/rgb in templates or new CSS.
+- Light/dark mode toggles `data-theme="light|dark"` on `<html>` (`web/src/main.js`).
+- Use design tokens (`var(--foreground)`, `var(--card)`, `var(--primary)`, …) — do not hardcode hex/rgb in templates or new CSS.
 - Role hue and stream status tokens use CSS `light-dark()` in `:root`; `[data-theme="dark"]` keeps only non-role overrides.
 - Token names follow shadcn-style `{role}` + `{role}-foreground` pairs (see `tokens.css`).
 
@@ -184,11 +175,11 @@ Behavior hooks use a `js-*` class prefix alongside `data-*` where needed; do not
 | xl | 1280px | `--xl-up` | `--xl-down` |
 | 2xl | 1536px | `--2xl-up` | — |
 
-- **`breakpoints.css`** is imported first in `styles.css` and is the **only** file that may define `@custom-media`.
-- **Stylesheet modules** use `@media (--sm-down) { … }` (or other aliases). Do **not** repeat `@custom-media` or write `@media (width … 640px)` in component/page CSS.
-- **PostCSS:** `postcss-custom-media` (see `web/postcss.config.js`) expands aliases at build time; Vite runs PostCSS on the bundled CSS.
+- **`breakpoints.css`** is the **only** file that may define `@custom-media`.
+- Modules use `@media (--sm-down) { … }` — do not repeat `@custom-media` or write `@media (width … 640px)` in component/page CSS.
+- **PostCSS:** `postcss-custom-media` expands aliases at build time (`web/postcss.config.js`).
 
-**JS sync:** when JavaScript needs the same threshold as CSS, use the equivalent `matchMedia` query. Example: `--md-down` `(width < 768px)` ↔ `matchMedia("(max-width: 767px)")` (as in `org_admin.html` for mobile panel scrolling). Keep JS literals aligned with the table above when adding new breakpoint checks.
+**JS sync:** match CSS with the equivalent `matchMedia`. Example: `--md-down` ↔ `matchMedia("(max-width: 767px)")` (as in `org_admin.html`).
 
 ### Font tokens
 
@@ -198,89 +189,43 @@ Behavior hooks use a `js-*` class prefix alongside `data-*` where needed; do not
 | `--font-display` | Space Grotesk stack (literal `h1` only) |
 | `--font-mono` | JetBrains Mono stack (hashes, codes, meta ids) |
 
-Google Fonts load from `server/templates/layout.html` (`preconnect` + stylesheet `<link>` with `display=swap`). Do **not** `@import` fonts from `tokens.css`. Use `var(--font-sans)` / `var(--font-display)` / `var(--font-mono)` in new CSS — do not repeat font family strings.
+Google Fonts load from `server/templates/layout.html`. Do **not** `@import` fonts from `tokens.css`.
 
 ### Type scale
 
-Canonical type tokens in `tokens.css` — Tailwind-aligned, rem-based. The index tracks size: `--text-sm` = `0.875rem` = 14px.
+Canonical tokens in `tokens.css` (Tailwind-aligned, rem-based). Index ≈ size: `--text-sm` = `0.875rem` = 14px.
 
 | Token | rem | px | Typical use |
 |-------|-----|----|-------------|
 | `--text-xs` | `0.75rem` | 12 | Captions, pills, compact tags, meta IDs |
-| `--text-sm` | `0.875rem` | 14 | Labels, secondary UI, toolbar copy, form labels, buttons |
-| `--text-base` | `1rem` | 16 | Body, inputs, default prose |
-| `--text-lg` | `1.125rem` | 18 | Card titles, dialog titles, emphasis headings |
-| `--text-xl` | `1.25rem` | 20 | Section headings (`h2` in panels; `h3` for nested/subsection titles) |
-| `--text-2xl` | `1.5rem` | 24 | Large titles, emphasis page headings |
+| `--text-sm` | `0.875rem` | 14 | Labels, secondary UI, toolbar, form labels, buttons |
+| `--text-base` | `1rem` | 16 | Body, inputs |
+| `--text-lg` | `1.125rem` | 18 | Card/dialog titles |
+| `--text-xl` | `1.25rem` | 20 | Section headings (`h2`; nested `h3`) |
+| `--text-2xl` | `1.5rem` | 24 | Large titles |
 | `--text-3xl` | `1.875rem` | 30 | Page titles (`h1` default) |
 
-**Line-height tokens**
+**Line-height:** `--leading-none` `1`, `--leading-tight` `1.25`, `--leading-normal` `1.5`, `--leading-relaxed` `1.625`.
 
-| Token | Value | Use |
-|-------|-------|-----|
-| `--leading-none` | `1` | Pills, single-line badges |
-| `--leading-tight` | `1.25` | Headings, compact titles |
-| `--leading-normal` | `1.5` | Body, form fields, paragraphs |
-| `--leading-relaxed` | `1.625` | Long-form muted copy (rare) |
+**Weight:** `--font-normal` `400`, `--font-medium` `500`, `--font-semibold` `600`, `--font-bold` `700` (Inter faces loaded to match).
 
-**Weight tokens**
+**Heading defaults** in `reset.css`: `h1` → `--text-3xl` + `--font-display`; `h2` → `--text-xl`; `h3` → `--text-lg`; `h4` → `--text-base`; all `--font-semibold` + `--leading-tight`. Prefer tokens over raw `font-size`.
 
-| Token | Value | Loaded face |
-|-------|-------|-------------|
-| `--font-normal` | `400` | Inter 400 |
-| `--font-medium` | `500` | Inter 500 |
-| `--font-semibold` | `600` | Inter 600 |
-| `--font-bold` | `700` | Inter 700 |
-
-**Heading defaults** are set in `reset.css` (`h1`–`h4`): `h1` → `--text-3xl` + `--font-display`, `h2` → `--text-xl`, `h3` → `--text-lg`, `h4` → `--text-base`, all with `--font-semibold` and `--leading-tight`. Prefer tokens over raw `font-size` in component CSS; remove redundant heading `font-size` overrides when they only duplicate semantics.
-
-**Control sizing pattern:** buttons use the `btn` system in `button.css` (default height `--btn-height` / 36px). Form labels use `--text-sm` (`forms.css`); inputs use `--text-base`.
+**Controls:** buttons use `button.css` (default height `--btn-height` / 36px). Form labels `--text-sm`; inputs `--text-base`.
 
 ### Spacing scale
 
-Canonical spacing tokens in `tokens.css` — a Tailwind-aligned scale on a 4px grid, expressed in `rem` (migrate incrementally; legacy `px` literals remain valid). The index tracks size: `--space-N` ≈ `N × 4px` (`--space-4` = `1rem` = 16px):
+Canonical `--space-N` in `tokens.css` on a 4px grid (`--space-4` = `1rem` = 16px). Scale runs `--space-1` … `--space-12`. Prefer `u-*` utilities or component classes over raw `px` in templates.
 
-| Token | Value | px | Typical use |
-|-------|-------|----|-------------|
-| `--space-1` | `0.25rem` | 4 | Tight inline gaps |
-| `--space-2` | `0.5rem` | 8 | Default small gap, compact lists |
-| `--space-3` | `0.75rem` | 12 | Card padding, compact control padding |
-| `--space-4` | `1rem` | 16 | Grid gaps, card/list item padding |
-| `--space-5` | `1.25rem` | 20 | Panel padding, section margins/gaps |
-| `--space-6` | `1.5rem` | 24 | Stack default gap |
-| `--space-7` | `1.75rem` | 28 | Large section rhythm |
-| `--space-8` | `2rem` | 32 | Section gaps, chrome padding |
-| `--space-9` | `2.25rem` | 36 | Generous section rhythm |
-| `--space-10` | `2.5rem` | 40 | Page-level spacing |
-| `--space-11` | `2.75rem` | 44 | Wide section rhythm |
-| `--space-12` | `3rem` | 48 | Multi-column grid gaps |
-
-The scale is monotonic: `--space-N` is always larger than `--space-(N-1)`. Do not reintroduce off-grid values (6/10/14/18px) or non-monotonic indices.
-
-Prefer `u-*` utilities or component classes over raw `px` in templates. New page CSS should use spacing tokens where practical.
-
-**Intentional `px` exceptions** (not on the spacing scale): layout dimensions (`width`/`height`), `border-radius`, `border-width`, scroll anchors (`44px`, `140px`), and composite padding with off-scale values (e.g. `32px` horizontal chrome). Use type tokens for `font-size` — not raw `px`.
+**Intentional `px` exceptions:** layout dimensions, `border-radius`, `border-width`, scroll anchors, and composite padding with off-scale values. Use type tokens for `font-size`.
 
 ### Elevation and backdrop tokens
 
-| Token | Use |
-|-------|-----|
-| `--shadow` | Default panel shadow |
-| `--shadow-elevated` | Raised controls (carousel nav) |
-| `--shadow-dropdown` | Floating menus |
-| `--backdrop-modal` | Dialog `::backdrop` tint |
-| `--backdrop-fullscreen` | Fullscreen modal backdrop |
-| `--inset-highlight` | Inset top edge on gradient fields |
-
-### Documented color literal exceptions
-
-No compositional color literals remain outside `tokens.css`. If you need a new shadow or backdrop tint, add a semantic token in `tokens.css` rather than an inline `rgb()`.
+`--shadow`, `--shadow-elevated`, `--shadow-dropdown`, `--backdrop-modal`, `--backdrop-fullscreen`, `--inset-highlight` — see `tokens.css`. New shadow/backdrop tints get a semantic token there, not an inline `rgb()`.
 
 ## Role palette
 
-Role badge colors are resolved at runtime from **Appwrite team prefs**, not from workflow YAML or inline CSS values.
-
-### Data flow
+Role badge colors resolve at runtime from **Appwrite team prefs**, not workflow YAML or inline CSS.
 
 ```
 Appwrite team prefs          Backend (roleMetaIndex)          Templates + CSS
@@ -291,56 +236,28 @@ Appwrite team prefs          Backend (roleMetaIndex)          Templates + CSS
 
 | Layer | Responsibility |
 |-------|----------------|
-| Appwrite | Canonical store: `{ slug, name, palette }` where `palette` is a named key (`blue`, `emerald`, …) |
-| Backend | Resolves org-scoped `(orgSlug, roleSlug)` to a palette key; never emits `var(--role-*-*)` strings to workflow templates |
-| Workflow YAML | Slug/org/name for validation only; `color` fields are ignored by Go |
-| Templates | Set `data-role-palette="{{ .Palette }}"` on `.role-pill` and timeline substeps |
-| `tokens.css` + `role-palette.css` | Single source of appearance; maps palette key → `--role-*` tokens |
+| Appwrite | Canonical `{ slug, name, palette }` named key |
+| Backend | Org-scoped `(orgSlug, roleSlug)` → palette key; never emits `var(--role-*-*)` to templates |
+| Workflow YAML | Slug/org/name for validation; `color` fields ignored by Go |
+| Templates | `data-role-palette="{{ .Palette }}"` on `.role-pill` / timeline substeps |
+| `tokens.css` + `role-palette.css` | Appearance map |
 
-### Storage and API
+**Storage:** writes persist `palette` only; reads prefer `palette`, with legacy `color` CSS-var strings falling back via `rolePaletteKeyFromStyle()`. `GET /api/catalog` returns `palette` per role. Unknown/missing → `"fallback"`.
 
-- **Writes** persist `palette` only (no `color`).
-- **Reads** use `palette` when present; legacy rows with `color` CSS var strings fall back to `rolePaletteKeyFromStyle()`.
-- **`GET /api/catalog`** returns `palette` per role (no `color`).
-- **Unknown or missing role** → palette key `"fallback"` (not YAML-embedded colors).
+**Lookup:** step with `organization:` → `(stepOrg, roleSlug)`; else first org containing the slug; else `"fallback"`. Symbols: `roleMetaIndex`, `roleMetaFor`, `rolePaletteKeyFromStyle`.
 
-### Lookup rules
-
-Resolution is org-scoped via `(orgSlug, roleSlug)`:
-
-| Caller context | Lookup key |
-|----------------|------------|
-| Substep on a step with `organization: <org>` | `(stepOrg, roleSlug)` |
-| Substep with no step org; role unique in workflow | first org from config or identity catalog containing the slug |
-| Unknown org or missing role in Appwrite | `"fallback"`; label from slug |
-
-Key backend symbols: `roleMetaIndex`, `roleMetaFor`, `rolePaletteKeyFromStyle` in `server/cmd/server/`.
-
-### Frontend styling
-
-17 named palette keys (`red`, `orange`, `amber`, … `rose`) are defined in `rolePaletteStyles` / `rolePaletteKeys` (Go) and mapped in `role-palette.css`. `TestRolePaletteKeysMatchCSS` keeps Go and CSS keys in sync.
-
-Role pills on `process`, `substep_body`, `dpp`, and `org_admin` use:
+Named palette keys live in `rolePaletteStyles` / `rolePaletteKeys` (Go) and `role-palette.css`. `TestRolePaletteKeysMatchCSS` keeps them in sync.
 
 ```html
 <span class="role-pill" data-role-palette="{{ .Palette }}">{{ .Label }}</span>
-```
-
-Timeline substeps use the same attribute on `.substep`. Appearance is a soft-badge: text/border from the bg token with a 10% tint background (`color-mix`). The org-admin palette picker sets transient `--swatch-bg` on preview swatches only (not on role pill rows).
-
-Stream status uses `data-stream-status="{{ .Status }}"` (mapped in `role-palette.css` to `--stream-color`). Section heads and the `status_tag` micro-partial both set it; `.status-tag` consumes `var(--stream-color)`.
-
-```html
 {{ template "status_tag" .Status }}
 ```
 
-renders `<span class="status-tag status-tag-compact" data-stream-status="…">…</span>` (pipeline is the status string).
-
-Static pill presets use CSS classes instead: `.pill-accent`, `.pill-panel`.
+`status_tag` renders `<span class="status-tag status-tag-compact" data-stream-status="…">` (pipeline = status string). `.status-tag` uses `var(--stream-color)`. Static presets: `.pill-accent`, `.pill-panel`.
 
 ## Utilities (`u-*`)
 
-Generic, domain-agnostic helpers in `utilities.css`. Add a new utility when the same spacing or typography pattern appears in multiple templates.
+Generic helpers in `utilities.css`. Add a utility when the same spacing/typography pattern appears in multiple templates. Prefer component classes for domain-specific patterns.
 
 | Class | Effect |
 |-------|--------|
@@ -348,88 +265,52 @@ Generic, domain-agnostic helpers in `utilities.css`. Add a new utility when the 
 | `u-max-w-prose` | `max-width: 65ch` |
 | `u-max-w-7xl` | `max-width: 80rem` |
 | `u-m-0` | `margin: 0` |
-| `u-mb-2` | `margin-bottom: var(--space-2)` (8px) |
-| `u-mb-4` | `margin-bottom: var(--space-4)` (16px) |
-| `u-mb-5` | `margin-bottom: var(--space-5)` (20px) |
-| `u-ml-1` | `margin-left: var(--space-1)` (4px) |
+| `u-mb-2` / `u-mb-4` / `u-mb-5` | bottom margin via `--space-*` |
+| `u-ml-1` | `margin-left: var(--space-1)` |
 | `u-pre-line` | `white-space: pre-line` |
-| `u-text-xs` | `font-size: var(--text-xs)` |
-| `u-text-sm` | `font-size: var(--text-sm); font-weight: var(--font-semibold)` |
-| `u-text-base` | `font-size: var(--text-base)` |
-| `u-text-lg` | `font-size: var(--text-lg)` |
-| `u-flex` | `display: flex` |
-| `u-flex-center` | `display: flex; align-items: center` |
-| `u-gap-2` | `gap: var(--space-2)` (8px) |
-| `u-gap-4` | `gap: var(--space-4)` (16px) |
-| `u-divider` | Horizontal rule, `var(--space-6)` vertical margin |
+| `u-text-xs` / `u-text-sm` / `u-text-base` / `u-text-lg` | type scale (`u-text-sm` also semibold) |
+| `u-flex` / `u-flex-center` | flex / flex + center |
+| `u-gap-2` / `u-gap-4` / `u-gap-12` | gap via `--space-*` |
+| `u-divider` / `u-divider-5` / `u-divider-10` | `<hr>` with vertical `--space-*` margin |
 | `u-divider-flush` | `<hr>` with `margin: 0` |
-| `u-divider-5` | Horizontal rule, `var(--space-5)` vertical margin |
 | `u-text-danger` | `color: var(--destructive)` |
 
-**Stack gap modifiers:** `.stack.u-gap-2` and `.stack.u-gap-4` override the default `var(--space-6)` stack gap.
-
-**Prefer component classes** for domain-specific patterns (e.g. `.role-pill-label`, `.stream-card-footer`). New `u-*` utilities should include a one-line justification in the PR.
+`.stack.u-gap-2` and `.stack.u-gap-4` override the default stack gap (`var(--space-6)`). New `u-*` utilities should include a one-line justification in the PR.
 
 ## Inline `style=` in templates
 
-**Do not** use inline styles for static layout, spacing, or typography. Use utilities or component classes.
+**Do not** use inline styles for static layout, spacing, or typography.
 
-**Allowed** inline styles — runtime values from Go template data:
+**Allowed** — runtime values from Go:
 
 | Pattern | Example | Consumer |
 |---------|---------|----------|
-| Progress width | `style="--progress: {{ .Percent }}%;"` | `.stream-instance-card-progress-fill` via `width: var(--progress, 0%)` |
+| Progress width | `style="--progress: {{ .Percent }}%;"` | `.stream-instance-card-progress-fill` |
 
-All other dynamic theming uses `data-*` attributes (`data-role-palette`, `data-stream-status`), not inline custom properties.
+All other dynamic theming uses `data-*` (`data-role-palette`, `data-stream-status`), not inline custom properties.
 
-## Common component classes
-
-| Class | Use |
-|-------|-----|
-| `.page-header`, `.page-header-head`, `.page-header-body`, `.page-header-actions`, … | Page chrome title block — see `page-header.css` header (CSS-only; trail via `breadcrumbs`) |
-| `.breadcrumbs`, `.breadcrumbs-list`, `.breadcrumbs-item`, `.breadcrumbs-link`, `.breadcrumbs-current` | Hierarchical page trail — see `breadcrumbs.css` / `breadcrumbs.html` |
-| `.panel`, `.panel-heading`, `.panel-head-actions`, `.panel-block` | Card sections — see `panel.css` header for markup tree (CSS-only component) |
-| `.panel-sticky` | Optional sticky rail modifier on `.panel` (active at `--md-up`) |
-| `.rail-layout`, `.rail-layout-ready`, `.rail-layout-main` | Sticky sidebar + main shell — see `layout/grids.css` (row at `--md-up`) |
-| `.sidebar-nav`, `.sidebar-nav-link`, `.sidebar-nav-title`, `.sidebar-nav-copy` | Section switcher tiles — see `sidebar-nav.css` header |
-| `.dialog`, `.dialog-card`, `.dialog-head`, `.dialog-actions`, … | Modal shells — see `dialog.css` header (CSS-only component) |
-| `.list-rows`, `.list-row`, `.list-row-main`, `.list-row-actions` | Admin list rows with actions — see `list-row.css` header |
-| `.stack` | Vertical rhythm |
-| `.muted` | Secondary text color |
-| `.pill`, `.role-pill` | Badges; pair with `data-role-palette` for role colors |
-| `.is-disabled` | Disabled pagination / non-interactive controls |
-| `.pagination-btn` | Chevron pagination buttons |
-| `.site-footer` | Page footer (no inline styles) |
-
-## Build
+## Build and lint
 
 ```bash
-cd web && npm run build   # produces web/dist/assets/main.css
-```
-
-Go serves the bundle at `/static/`.
-
-## Lint
-
-```bash
+cd web && npm run build   # → web/dist/assets/main.css (served at /static/)
 task css:lint
 ```
 
-Runs three checks:
+`task css:lint` runs:
 
-1. **Template inline styles** — `deployment/scripts/check-template-inline-styles.sh` fails on disallowed `style=` attributes in `server/templates/` (allowed patterns listed above).
-2. **Breakpoint guard** — `deployment/scripts/check-css-breakpoints.sh` fails when any file under `web/src/styles/` (except `breakpoints.css`) contains `@media (width …)` with literal `px` values; use `@media (--sm-down)` etc. instead.
-3. **stylelint** — CSS rules on `web/src/styles/**/*.css` (no hex/rgb outside `tokens.css`, no new `!important`).
+1. **Template inline styles** — `deployment/scripts/check-template-inline-styles.sh`
+2. **Breakpoint guard** — `deployment/scripts/check-css-breakpoints.sh` (no literal `@media (width … px)` outside `breakpoints.css`)
+3. **stylelint** — `web/src/styles/**/*.css` (no hex/rgb outside `tokens.css`, no new `!important`)
 
 ## Adding new UI
 
-1. Check for an existing component class, CSS-only module (**CSS-only components** above), or utility.
+1. Check for an existing component class, CSS-only module, or utility.
 2. If spacing/typography repeats across templates, add a `u-*` utility.
-3. If the pattern is domain-specific, add a component or page class (see **Page modules**).
+3. If domain-specific, add a component or page class.
 4. Use tokens for colors; never hardcode hex in templates.
 5. Run `task css:lint` before opening a PR.
 
-## Out of scope / known gaps
+## Out of scope
 
-- **Formata embed** shadow-DOM styling in `web/src/main.js` (`!important` overrides) — separate effort; not covered here.
-- **Adding a new palette key** requires updates to `rolePaletteStyles`, `role-palette.css`, and the org-admin palette picker — not Go string passthrough to templates.
+- **Formata embed** shadow-DOM styling in `web/src/main.js` (`!important` overrides).
+- **New palette key** — update `rolePaletteStyles`, `role-palette.css`, and the org-admin palette picker (not Go string passthrough to templates).

--- a/docs/css.md
+++ b/docs/css.md
@@ -49,34 +49,13 @@ Root templates still pending migration (`error_banner.html`, `icons.html`, `role
 
 ## CSS-only components
 
-Reused markup + namespaced CSS, **no** full Go template partial / view struct. Inline HTML in pages; the CSS file header is the markup contract.
+When to choose CSS-only vs full vs cluster: `.agents/skills/attesta-ui-components`.
 
-**Use when:** 2+ pages; coherent selector family; no mode dispatch / HTMX swap target.  
-**Otherwise:** full component + view struct, or a cluster file.
+Markup contract = the CSS file header (e.g. `page-header.css`, `panel.css`, `dialog.css`). Inline HTML in pages; no shared view struct. Micro-partial exceptions: `status_tag`, `tip`, `local_datetime`.
 
-**Add one:** create `components/{name}.css` with a markup-tree header; import from `components.css`. Do not add `templates/components/{name}.html` unless it graduates (`status_tag`, `tip`, `local_datetime` are the narrow micro-partial exceptions).
+**Add one:** create `components/{name}.css` with a markup-tree header; import from `components.css`. Do not add `templates/components/{name}.html` unless it graduates.
 
-**Page header** (worked example): CSS-only — no `PageHeaderView`. Optional trail via full `breadcrumbs` (`Current: true` on last crumb; every crumb still has `Href`). With actions, wrap body + actions in `.page-header-head`; omit the head when there are no actions. Process-instance ID under the title is `.process-header-meta*` in `pages/process.css`, not page-header.
-
-```
-Heading only:
-section.page-header
-  nav.breadcrumbs?
-  div.page-header-body
-    h1                              (optional span[aria-hidden] + span.page-header-subtitle)
-    p?
-
-With actions:
-section.page-header
-  nav.breadcrumbs?
-  div.page-header-head
-    div.page-header-body
-      …
-    div.page-header-actions
-      button | form | …
-```
-
-Other CSS-only modules (`panel`, `dialog`, `sidebar-nav`, `button`, `list-row`, …): read the matching file header. Page-scoped dialog sizing stays in page CSS (e.g. `#stream-preview-dialog` in `pages/stream.css`). Destructive dialog titles stack `.dialog-title u-text-danger`.
+**Notes:** Process-instance ID under the title is `.process-header-meta*` in `pages/process.css`, not page-header. Page-scoped dialog sizing stays in page CSS (e.g. `#stream-preview-dialog` in `pages/stream.css`). Destructive dialog titles stack `.dialog-title u-text-danger`.
 
 ## Theming
 
@@ -196,9 +175,7 @@ task css:lint
 
 ## Adding new UI
 
-1. Prefer an existing component, CSS-only module, or `u-*`.
-2. New domain styles → component or page module (stem rule + barrel import).
-3. Tokens for color; run `task css:lint` before the PR.
+Follow `.agents/skills/attesta-ui-components` (tier → place → tracer). Then run `task css:lint`.
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary
- Fix stale guidance in `docs/css.md` (breadcrumbs use `Current`, not empty `Href`; utilities and component inventory catch up to the tree)
- Document `stream_termination_details` and point layer barrels at the live import files instead of duplicated lists
- Trim overlap with `.agents/skills/attesta-ui-components`, drop obsolete `action_detail_content` backlog item, and broaden the skill smoke-test filter

## Test plan
- [ ] Skim `docs/css.md` against `web/src/styles/components.css` / `pages.css` import lists
- [ ] Confirm skill still points agents to `docs/css.md` for architecture and keeps extract/Go rules intact
- [ ] No code/CSS changes — docs/skill only

Made with [Cursor](https://cursor.com)