### PR TITLE
feat(routes): authenticated app under /my, public homepage at /

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,10 +12,12 @@ See: `README.md`, `QUICKSTART.md`, `DOCKER.md`, `docs/css.md` (main app styling)
 ## Current auth/org status (2026-07)
 - Demo impersonation has been removed from production code paths.
 - Session auth is active (`attesta_session` cookie). Regular users store an Appwrite session secret; platform admin uses a separate env-derived session value (`platform-admin:…`).
-- Stream dashboard is `/w/:key/` (lists stream instances for one stream). Legacy `/dashboard` and `/w/:key/dashboard` are not registered.
+- Public homepage is `/` (marketing/landing). Authenticated stream picker is `/my` (`appHomePath`). No auto-redirect from `/` to `/my` when logged in.
+- Stream dashboard is `/my/streams/:key/` (lists stream instances for one stream).
+- Legacy `/w/`, `/org-admin/`, `/dashboard`, and `/w/:key/dashboard` are not registered (hard cut → 404).
 - Admin consoles:
   - Platform admin: `/admin/orgs` (create/edit/delete orgs, upload logos, invite org admins)
-  - Org admin: `/org-admin/profile`, `/org-admin/roles`, `/org-admin/members` (legacy `GET /org-admin/users` redirects to profile)
+  - Org admin: `/my/organization/profile`, `/my/organization/roles`, `/my/organization/members` (forms `POST /my/organization/users`, `POST /my/organization/roles`)
 - Platform admin is env-driven (`ADMIN_EMAIL`, `ADMIN_PASSWORD`). On startup the server ensures that account exists in Appwrite (`bootstrapPlatformAdminIdentity`). Cerbos policy `platform_admin_console` gates console access.
 - Auth/org state now lives in Appwrite:
   - orgs -> teams
@@ -25,10 +27,10 @@ See: `README.md`, `QUICKSTART.md`, `DOCKER.md`, `docs/css.md` (main app styling)
   - signup/login/reset -> Appwrite account/session/recovery flows
 - Global topbar now renders role-aware admin links on authenticated pages:
   - Platform admin sees `Orgs` (`/admin/orgs`)
-  - Org admin with org context sees `My Org` (`/org-admin/profile`)
+  - Org admin with org context sees `My Org` (`/my/organization/profile`)
 - Workflow YAML supports `organizations`, `roles`, step-level `organization`, and substep `roles`.
 - Slug collisions on org and role creation now surface explicit `... slug already exists` errors in admin UIs.
-- Org admin members section (`/org-admin/members`; forms still `POST /org-admin/users`) supports:
+- Org admin members section (`/my/organization/members`; forms still `POST /my/organization/users`) supports:
   - invites with zero-to-many roles (`roles` multi-select, `intent=invite`)
   - "Invites I sent" with derived statuses (`pending`, `accepted`, `expired`)
   - user role editing (`intent=set_roles`) and soft-delete (`intent=delete_user`) with self-protection checks.
@@ -129,31 +131,36 @@ Workflow YAML lives under `server/config/` (and optional `WORKFLOW_CONFIG_DIR`).
 
 ## Backend architecture notes (what to know before changing things)
 ### HTTP routes
-Global routes are registered in `Server.newMux()` (`server/cmd/server/main.go`). Workflow-scoped routes mount at `/w/` via `handleWorkflowRoutes` → `handleProcessRoutes`.
+Global routes are registered in `Server.newMux()` (`server/cmd/server/main.go`). Authenticated app routes mount at `/my/` via `handleMyRoutes` → `handleStreamRoutes` / `handleOrganizationRoutes` → `handleProcessRoutes`. URL helpers live in `paths.go` (`appHomePath`, `streamPath`, `streamInstancePath`, `organizationPath`).
 
-**Global (non-workflow):**
-- `GET /` — stream picker (`handleHome`)
-- `GET/POST /login`, `GET/POST /signup`, `POST /logout`
+**Global (public / auth entry):**
+- `GET /` — public homepage (`handlePublicHome`)
+- `GET/POST /login`, `GET/POST /signup`, `POST /logout` (login default redirect → `/my`)
 - `GET /invite/…`, `GET/POST /reset`, `GET/POST /reset/…`
 - `GET/POST /admin/orgs`, `GET/POST /admin/orgs/` (platform admin org console; logo at `/admin/orgs/logo/:id`)
-- `GET /org-admin/profile`, `/org-admin/roles`, `/org-admin/members` (org settings sections); `GET /org-admin/users` → profile; `POST /org-admin/users`, `POST /org-admin/roles`; `/org-admin/formata-builder`, …
+- `GET /organization/logo/:slug` — public org logo asset
 - `GET /01/…` — public DPP Digital Link
-- `GET /events` — legacy SSE mux entry (production UI uses workflow-scoped path below)
+- `GET /events` — legacy SSE mux entry (production UI uses stream-scoped path below)
 
-**Workflow-scoped (`/w/:key/…`):**
-- `GET /w/:key/` — stream dashboard (instance list + timeline preview)
-- `POST /w/:key/process/start`
-- `GET /w/:key/process/:id` — stream instance detail page
-- `GET /w/:key/process/:id/content` — HTMX/SSE content partial (replaces old `/timeline`)
-- `GET /w/:key/process/:id/downloads` — downloads partial
-- `POST /w/:key/process/:id/terminate`
-- `POST /w/:key/process/:id/substep/:substepId/complete`
-- `GET/POST /w/:key/process/:id/substep/:substepId/override`
-- `GET /w/:key/process/:id/attachment/:attachmentId/file` — attachment download
-- Export downloads: `files.zip`, `notarized.json`, `merkle.json` under `/w/:key/process/:id/…`
-- `GET /w/:key/events?processId=…` or `?role=…` — workflow-scoped SSE (used by `web/src/main.js`)
+**Authenticated (`/my/…`):**
+- `GET /my` — stream picker (`handleHome`)
+- `GET /my/organization/profile`, `/my/organization/roles`, `/my/organization/members` (org settings sections); `POST /my/organization/users`, `POST /my/organization/roles`; `/my/organization/formata-builder`, …
 
-Legacy `/dashboard` and `/w/:key/dashboard` return 404 (`workflow_coverage_test`).
+**Stream-scoped (`/my/streams/:key/…`):**
+- `GET /my/streams/:key/` — stream dashboard (instance list + timeline preview)
+- `POST /my/streams/:key/instance/start`
+- `GET /my/streams/:key/instance/:id` — stream instance detail page
+- `GET /my/streams/:key/instance/:id/content` — HTMX/SSE content partial (replaces old `/timeline`)
+- `GET /my/streams/:key/instance/:id/downloads` — downloads partial
+- `POST /my/streams/:key/instance/:id/terminate`
+- `POST /my/streams/:key/instance/:id/substep/:substepId/complete`
+- `GET/POST /my/streams/:key/instance/:id/substep/:substepId/override`
+- `GET /my/streams/:key/instance/:id/attachment/:attachmentId/file` — attachment download
+- Export downloads: `files.zip`, `notarized.json`, `merkle.json` under `/my/streams/:key/instance/:id/…`
+- `GET /my/streams/:key/events?processId=…` or `?role=…` — stream-scoped SSE (used by `web/src/main.js`)
+- `POST /my/streams/:key/delete` — delete saved Formata stream (when permitted)
+
+Legacy `/w/`, `/org-admin/`, `/dashboard`, and `/w/:key/dashboard` return 404 (`TestLegacyRoutesGone`, `TestLegacyOrgAdminRoutesReturnNotFound`).
 
 ### Actor/role identity
 Session auth via `attesta_session` cookie:
@@ -190,7 +197,7 @@ Download endpoint `handleDownloadProcessAttachment` streams GridFS content and s
 - Backend emits:
   - `event: process-updated` for process streams
   - `event: role-updated` for role dashboards
-  (see `handleEvents()` in `main.go`; workflow-scoped at `/w/:key/events`).
+  (see `handleEvents()` in `main.go`; stream-scoped at `/my/streams/:key/events`).
 - Frontend listens via `EventSource` and refreshes partial HTML via `fetch()` (`web/src/main.js`).
 
 ### DPP / GS1 Digital Link

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,15 +27,15 @@ The view of one stream instance: its timeline (steps and substeps), completion c
 _Avoid_: Process page, action list
 
 **Stream picker**:
-The screen at `/` where an operator chooses which stream (blueprint) to open.
+The authenticated screen at `/my` where an operator chooses which stream (blueprint) to open. Public marketing content lives at `/` and does not redirect logged-in users to `/my`.
 _Avoid_: Home, workflow picker
 
 **Stream dashboard**:
-The screen at `/w/:key/` listing stream instances for one stream, with status navigation and a read-only timeline preview.
+The screen at `/my/streams/:key/` listing stream instances for one stream, with status navigation and a read-only timeline preview.
 _Avoid_: Home, workflow home
 
 **Stream instance detail page**:
-The full page at `/w/:key/process/:id`. Comprises a stable outer shell (process metadata, SSE hooks) and an inner **content partial** swapped via HTMX/SSE after substep completion or live updates.
+The full page at `/my/streams/:key/instance/:id`. Comprises a stable outer shell (process metadata, SSE hooks) and an inner **content partial** swapped via HTMX/SSE after substep completion or live updates.
 _Avoid_: Process page
 
 ### Stream instance detail UI

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -31,7 +31,7 @@ docker compose -f deployment/docker-compose.local.yaml up -d attesta
 ## Migration Notes
 - Existing Mongo-backed sessions are not migrated. After Appwrite credentials are configured, users must log in again through Appwrite.
 - Existing Mongo invite and password-reset tokens are not migrated. Re-issue any still-needed invite or reset from the Appwrite-backed Attesta flows.
-- If you are cutting over an existing demo dataset, migrate organizations, roles, and active users into Appwrite before relying on `/org-admin/*`.
+- If you are cutting over an existing demo dataset, migrate organizations, roles, and active users into Appwrite before relying on `/my/organization/*`.
 
 ## Build frontend assets
 ```bash
@@ -49,11 +49,12 @@ go run ./cmd/server
 
 ## Open the demo
 - Appwrite Console: http://localhost
-- Home: http://localhost:3030
+- Public homepage: http://localhost:3030/
+- Stream picker (after login): http://localhost:3030/my
 - Backoffice: http://localhost:3030/backoffice
 - Mailpit: http://localhost:8025
 
-The entry pages are workflow pickers. Business routes are workflow-scoped under `/w/{workflowKey}/...`.
+After login, the stream picker is at `/my`. Stream and instance routes live under `/my/streams/{workflowKey}/...` (legacy `/w/` and `/org-admin/` paths return 404).
 
 ## Configure DPP Digital Link (optional)
 Edit `server/config/workflow.yaml` and add:

--- a/docs/superpowers/plans/2026-07-23-my-routes.md
+++ b/docs/superpowers/plans/2026-07-23-my-routes.md
@@ -1,0 +1,988 @@
+# `/my` Routes Rewrite Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `/` a public blank homepage and move the authenticated app under `/my/*` (`/my/streams/...`, `/my/organization/...`), with a hard cut of `/w/` and `/org-admin/`.
+
+**Architecture:** Introduce path helpers as the single source of truth for URLs. Remount handlers in `newMux()` under `/my`, adapt stream/instance and org routers to the new path segments (`streams` / `instance` / `organization`), update templates/JS/Goa design, then sweep tests and docs. No compatibility redirects.
+
+**Tech Stack:** Go `net/http` ServeMux, Go `html/template`, Vite JS (`web/src/main.js`), Goa design (`server/design/design.go` + `task goa:generate`).
+
+**Spec:** `docs/superpowers/specs/2026-07-23-my-routes-design.md`
+
+## Global Constraints
+
+- Auth prefix is `/my` (not `/dashboard`)
+- Stream picker at `GET /my`; stream dashboard at `GET /my/streams/:streamId`
+- Instance at `GET /my/streams/:streamId/instance/:instanceId` (segment `instance`, not `process`)
+- Org settings at `/my/organization/...`; platform admin stays at `/admin/...`
+- Hard cut: `/w/*`, `/org-admin/*`, `/dashboard/*` → 404 (no redirects)
+- Authenticated `GET /` stays on blank public homepage (no auto-redirect to `/my`)
+- Login/app-home default → `/my`; breadcrumbs “Streams” → `/my`
+- Prefer minimal diffs; do not rename Cerbos resources, Mongo progress keys, or Appwrite models
+- Internal Go type names (`Process`, `handleProcess*`) may stay; public paths use `instance`
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `server/cmd/server/paths.go` | URL helpers: `appHomePath`, `streamPath`, `streamInstancePath`, `organizationPath`, etc. |
+| `server/cmd/server/paths_test.go` | Unit tests for path helpers |
+| `server/cmd/server/main.go` | `newMux`, handlers, redirects, hardcoded path strings |
+| `server/cmd/server/breadcrumbs.go` | Trail hrefs under `/my` |
+| `server/cmd/server/formata_builder.go` | Builder URLs under `/my/organization` |
+| `server/cmd/server/stream_instance_detail.go` | Any hardcoded `/w/` in view assembly |
+| `server/cmd/server/substep_views_builder.go` | Override/complete URLs if hardcoded |
+| `server/templates/pages/public_home.html` | Blank public homepage |
+| `server/templates/pages/home.html` | Comment: used on `/my` |
+| `server/templates/pages/org_admin.html` | Form actions + nav JS → `/my/organization` |
+| `server/templates/layout.html` | My Org link → `/my/organization/profile` |
+| `server/templates/components/stream_card.html` | Formata builder href |
+| `web/src/main.js` | Fetch + EventSource under `/my/streams` |
+| `server/design/design.go` | Goa HTTP paths |
+| `server/cmd/server/*_test.go` | Assert new paths; legacy 404 |
+| `AGENTS.md`, `QUICKSTART.md`, `CONTEXT.md` | Document new routes |
+
+---
+
+### Task 1: Path helpers
+
+**Files:**
+- Create: `server/cmd/server/paths.go`
+- Create: `server/cmd/server/paths_test.go`
+- Modify: `server/cmd/server/main.go` — delete `workflowPath` (moved); keep call sites compiling by re-export or immediate rename in this task
+
+**Interfaces:**
+- Consumes: none
+- Produces:
+  - `const appHomePath = "/my"`
+  - `func streamPath(key string) string` → `/my/streams/{key}`
+  - `func streamInstancePath(key, instanceID string) string` → `/my/streams/{key}/instance/{id}`
+  - `func organizationPath(rest string) string` → `/my/organization` + optional `/` + rest
+  - Keep `workflowPath` as a thin alias to `streamPath` only if needed for a one-commit transition; prefer deleting it and updating call sites in Task 3
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `server/cmd/server/paths_test.go`:
+
+```go
+package main
+
+import "testing"
+
+func TestStreamPath(t *testing.T) {
+	if got := streamPath("  wf-a  "); got != "/my/streams/wf-a" {
+		t.Fatalf("streamPath = %q", got)
+	}
+}
+
+func TestStreamInstancePath(t *testing.T) {
+	if got := streamInstancePath("wf-a", "abc123"); got != "/my/streams/wf-a/instance/abc123" {
+		t.Fatalf("streamInstancePath = %q", got)
+	}
+}
+
+func TestOrganizationPath(t *testing.T) {
+	cases := []struct {
+		rest string
+		want string
+	}{
+		{"", "/my/organization"},
+		{"profile", "/my/organization/profile"},
+		{"/roles", "/my/organization/roles"},
+		{"formata-builder?stream=x", "/my/organization/formata-builder?stream=x"},
+	}
+	for _, tc := range cases {
+		if got := organizationPath(tc.rest); got != tc.want {
+			t.Fatalf("organizationPath(%q) = %q, want %q", tc.rest, got, tc.want)
+		}
+	}
+}
+
+func TestAppHomePath(t *testing.T) {
+	if appHomePath != "/my" {
+		t.Fatalf("appHomePath = %q", appHomePath)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd server && go test ./cmd/server -run 'TestStreamPath|TestStreamInstancePath|TestOrganizationPath|TestAppHomePath' -count=1`
+
+Expected: FAIL (undefined: `streamPath` / `organizationPath` / `appHomePath`)
+
+- [ ] **Step 3: Implement helpers**
+
+Create `server/cmd/server/paths.go`:
+
+```go
+package main
+
+import "strings"
+
+const appHomePath = "/my"
+
+func streamPath(key string) string {
+	return "/my/streams/" + strings.TrimSpace(key)
+}
+
+func streamInstancePath(key, instanceID string) string {
+	return streamPath(key) + "/instance/" + strings.TrimSpace(instanceID)
+}
+
+// organizationPath joins /my/organization with rest.
+// rest may be "profile", "/roles", or "formata-builder?stream=x".
+func organizationPath(rest string) string {
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		return "/my/organization"
+	}
+	rest = strings.TrimPrefix(rest, "/")
+	return "/my/organization/" + rest
+}
+```
+
+In `main.go`, replace the body of `workflowPath` temporarily:
+
+```go
+func workflowPath(key string) string {
+	return streamPath(key)
+}
+```
+
+(Delete `workflowPath` entirely in Task 3 once all call sites use `streamPath` / `streamInstancePath`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd server && go test ./cmd/server -run 'TestStreamPath|TestStreamInstancePath|TestOrganizationPath|TestAppHomePath' -count=1`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/cmd/server/paths.go server/cmd/server/paths_test.go server/cmd/server/main.go
+git commit -m "$(cat <<'EOF'
+feat(routes): add /my path helpers
+
+Centralize stream, instance, and organization URL construction for the
+upcoming remount under /my.
+EOF
+)"
+```
+
+---
+
+### Task 2: Public `/` and stream picker at `/my`
+
+**Files:**
+- Create: `server/templates/pages/public_home.html`
+- Modify: `server/templates/pages/home.html` (comment only: used on `/my`)
+- Modify: `server/cmd/server/main.go` — `handlePublicHome`, retarget `handleHome` to `/my`, `newMux`, `redirectHomeWithMessage`, login/signup defaults
+- Test: `server/cmd/server/home_handler_test.go`, `server/cmd/server/auth_session_handler_test.go`
+
+**Interfaces:**
+- Consumes: `appHomePath` from Task 1
+- Produces: `func (s *Server) handlePublicHome(w http.ResponseWriter, r *http.Request)`; `handleHome` serves `/my` and `/my/` only
+
+- [ ] **Step 1: Write failing tests for public home + `/my` picker auth**
+
+In `home_handler_test.go` (or a new `public_home_handler_test.go`), add:
+
+```go
+func TestHandlePublicHomeIsBlankAndPublic(t *testing.T) {
+	server := newTestServer(t) // use the same helper pattern as existing home tests
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	server.handlePublicHome(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	// Must not require login redirect
+	if loc := rec.Header().Get("Location"); loc != "" {
+		t.Fatalf("unexpected redirect to %q", loc)
+	}
+}
+
+func TestHandleHomeRequiresAuthAtMy(t *testing.T) {
+	server := newTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/my", nil)
+	rec := httptest.NewRecorder()
+	server.handleHome(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want redirect", rec.Code)
+	}
+	if got := rec.Header().Get("Location"); !strings.HasPrefix(got, "/login?next=") {
+		t.Fatalf("location = %q", got)
+	}
+}
+```
+
+Adapt `newTestServer` to whatever helper already exists in `home_handler_test.go` (do not invent a new server bootstrap if one exists).
+
+Update existing home tests that hit `"/"` for the picker to hit `"/my"` instead, and expect login `next` to encode `/my` where applicable.
+
+Update `auth_session_handler_test.go`:
+- Unauthenticated home next: `/login?next=%2Fmy` (or whatever `handleHome` receives)
+- Logged-in login GET redirect: `/my` instead of `/`
+- `safeNextPath` / login default fallback: `/my`
+
+- [ ] **Step 2: Run targeted tests — expect FAIL**
+
+Run: `cd server && go test ./cmd/server -run 'TestHandlePublicHome|TestHandleHome|TestHandleLogin' -count=1`
+
+Expected: FAIL on new public-home / `/my` expectations
+
+- [ ] **Step 3: Implement public home + remount picker**
+
+Create `server/templates/pages/public_home.html`:
+
+```html
+{{ define "public_home_body" }}
+  <section class="stack u-max-w-7xl u-mx-auto">
+    <section class="page-header">
+      <div class="page-header-body">
+        <h1>Attesta</h1>
+      </div>
+    </section>
+  </section>
+{{ end }}
+
+{{ define "public_home.html" }}
+  {{ template "layout.html" . }}
+{{ end }}
+```
+
+Add handler (near `handleHome`):
+
+```go
+func (s *Server) handlePublicHome(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	view := struct {
+		PageBase
+	}{PageBase: s.pageBase("public_home_body", "", "")}
+	if err := s.tmpl.ExecuteTemplate(w, "public_home.html", view); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+```
+
+Change `handleHome` path guard from `r.URL.Path != "/"` to:
+
+```go
+path := strings.TrimSpace(r.URL.Path)
+if path != appHomePath && path != appHomePath+"/" {
+	http.NotFound(w, r)
+	return
+}
+```
+
+Update `redirectHomeWithMessage` target from `"/"` to `appHomePath`.
+
+In `handleLogin` (GET already-authenticated redirect and `safeNextPath` fallbacks) and signup success paths that use `"/"`, switch fallback to `appHomePath`. Keep platform-admin `next=/admin/orgs` behavior.
+
+In `newMux()`:
+
+```go
+mux.HandleFunc("/my", s.handleHome)
+mux.HandleFunc("/my/", s.handleMyRoutes) // temporary stub OK if Task 3 fills streams; for this task only register /my exact + leave /my/ for Task 3
+mux.HandleFunc("/", s.handlePublicHome)
+// remove old mux.HandleFunc("/", s.handleHome) after adding public home
+```
+
+**Important:** If registering both `/my` and `/my/`, ensure `/my/` empty path still reaches the picker (either redirect `/my/` → `/my` inside `handleMyRoutes`, or call `handleHome` when rest is empty). Prefer:
+
+```go
+func (s *Server) handleMyRoutes(w http.ResponseWriter, r *http.Request) {
+	if _, _, ok := s.requireAuthenticatedPage(w, r); !ok {
+		return
+	}
+	rest := strings.TrimPrefix(r.URL.Path, "/my")
+	rest = strings.TrimPrefix(rest, "/")
+	if rest == "" {
+		s.handleHome(w, r)
+		return
+	}
+	http.NotFound(w, r) // streams/organization filled in later tasks
+}
+```
+
+And register:
+
+```go
+mux.HandleFunc("/my", s.handleHome)
+mux.HandleFunc("/my/", s.handleMyRoutes)
+mux.HandleFunc("/", s.handlePublicHome)
+```
+
+Do **not** remove `/w/` or `/org-admin` yet (Tasks 3–4).
+
+Update `home.html` file comment to say used on `/my`.
+
+- [ ] **Step 4: Run targeted tests — expect PASS**
+
+Run: `cd server && go test ./cmd/server -run 'TestHandlePublicHome|TestHandleHome|TestHandleLogin|TestHandleSignup' -count=1`
+
+Expected: PASS for updated auth/home cases
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/templates/pages/public_home.html server/templates/pages/home.html server/cmd/server/main.go server/cmd/server/home_handler_test.go server/cmd/server/auth_session_handler_test.go
+git commit -m "$(cat <<'EOF'
+feat(routes): public / and stream picker at /my
+
+Serve a blank public homepage at / and move the authenticated stream
+picker to /my with login defaults pointing at app home.
+EOF
+)"
+```
+
+---
+
+### Task 3: Remount stream + instance routes under `/my/streams`
+
+**Files:**
+- Modify: `server/cmd/server/main.go` — `handleMyRoutes` / `handleWorkflowRoutes` → stream router; `handleProcessRoutes` strip `/instance/`; `newMux` drop `/w/`; all `workflowPath` / `/w/` / `/process/` URL construction
+- Modify: `server/cmd/server/stream_instance_detail.go`, `substep_views_builder.go`, any other builders emitting `/w/`
+- Test: `process_routes_test.go`, `workflow_coverage_test.go`, `store_test.go`, `stream_delete_handler_test.go`, `home_template_preview_test.go`, `home_handler_test.go` (DetailHref / WorkflowPath)
+
+**Interfaces:**
+- Consumes: `streamPath`, `streamInstancePath`, `appHomePath`
+- Produces: Stream router at `/my/streams/:id/...`; instance segment `instance`; `/w/` → 404
+
+- [ ] **Step 1: Update failing route tests first**
+
+Rewrite assertions from `/w/workflow/...` to `/my/streams/workflow/...` and `/process/` to `/instance/`.
+
+Examples of required mappings in tests:
+
+| Old | New |
+|-----|-----|
+| `/w/workflow/` | `/my/streams/workflow` or `/my/streams/workflow/` |
+| `/w/workflow/process/start` | `/my/streams/workflow/instance/start` |
+| `/w/workflow/process/{id}` | `/my/streams/workflow/instance/{id}` |
+| `/w/workflow/events` | `/my/streams/workflow/events` |
+| `/w/workflow/delete` | `/my/streams/workflow/delete` |
+| `/w/` missing key | still 404 (via `/my/streams/` with empty id) |
+
+In `workflow_coverage_test.go`, keep `/dashboard` 404; change `/w/...` cases to `/my/streams/...` equivalents; add an explicit case that `GET /w/workflow/` returns 404 after remount.
+
+- [ ] **Step 2: Run route tests — expect FAIL**
+
+Run: `cd server && go test ./cmd/server -run 'TestHandleWorkflow|TestProcessRoutes|TestWorkflowCoverage|TestStreamDelete' -count=1`
+
+Expected: FAIL until handlers remounted
+
+- [ ] **Step 3: Implement stream/instance router**
+
+Expand `handleMyRoutes`:
+
+```go
+func (s *Server) handleMyRoutes(w http.ResponseWriter, r *http.Request) {
+	if _, _, ok := s.requireAuthenticatedPage(w, r); !ok {
+		return
+	}
+	rest := strings.Trim(strings.TrimPrefix(r.URL.Path, "/my"), "/")
+	switch {
+	case rest == "":
+		s.handleHome(w, cloneRequestWithPath(r, appHomePath))
+		return
+	case rest == "streams" || strings.HasPrefix(rest, "streams/"):
+		s.handleStreamRoutes(w, cloneRequestWithPath(r, "/"+rest))
+		return
+	default:
+		http.NotFound(w, r)
+	}
+}
+```
+
+Rename/adapt `handleWorkflowRoutes` → `handleStreamRoutes`:
+
+```go
+func (s *Server) handleStreamRoutes(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/streams/")
+	// if path was exactly "/streams" or "/streams/", 404 (missing id)
+	parts := strings.Split(path, "/")
+	if len(parts) == 0 || strings.TrimSpace(parts[0]) == "" {
+		http.NotFound(w, r)
+		return
+	}
+	workflowKey := strings.TrimSpace(parts[0])
+	cfg, err := s.workflowByKey(workflowKey)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	scopedReq := r.WithContext(context.WithValue(r.Context(), workflowContextKey{}, workflowContextValue{
+		Key: workflowKey,
+		Cfg: cfg,
+	}))
+	if len(parts) == 1 || (len(parts) == 2 && parts[1] == "") {
+		s.handleWorkflowHome(w, scopedReq)
+		return
+	}
+	tail := "/" + strings.Join(parts[1:], "/")
+	switch {
+	case tail == "/instance/start":
+		s.handleStartProcess(w, cloneRequestWithPath(scopedReq, tail))
+		return
+	case tail == "/delete":
+		s.handleDeleteWorkflow(w, cloneRequestWithPath(scopedReq, tail))
+		return
+	case strings.HasPrefix(tail, "/instance/"):
+		s.handleProcessRoutes(w, cloneRequestWithPath(scopedReq, tail))
+		return
+	case tail == "/events":
+		s.handleEvents(w, cloneRequestWithPath(scopedReq, tail))
+		return
+	default:
+		http.NotFound(w, r)
+	}
+}
+```
+
+In `handleProcessRoutes`, change:
+
+```go
+path := strings.TrimPrefix(r.URL.Path, "/instance/")
+```
+
+Replace URL construction sites:
+
+```go
+// detail href
+DetailHref: streamInstancePath(key, process.ID.Hex()),
+
+// start redirect
+http.Redirect(w, r, streamInstancePath(workflowKey, id.Hex()), http.StatusSeeOther)
+
+// override SaveURL
+SaveURL: streamInstancePath(workflowKey, process.ID.Hex()) + "/substep/" + canonical.SubstepID + "/override",
+```
+
+Replace every remaining `workflowPath(...)` call with `streamPath(...)`, then delete `workflowPath`.
+
+In `newMux()`: remove `mux.HandleFunc("/w/", ...)`. `/my/` already covers streams via `handleMyRoutes`.
+
+Preserve trailing-slash acceptance for stream dashboard (existing redirect `/w/workflow` → `/w/workflow/` becomes `/my/streams/workflow` ↔ `/my/streams/workflow/` — keep the same redirect helper behavior, only with `streamPath`).
+
+- [ ] **Step 4: Run route + related tests**
+
+Run: `cd server && go test ./cmd/server -run 'TestHandleWorkflow|TestProcessRoutes|TestWorkflowCoverage|TestStreamDelete|TestHome|TestStore' -count=1`
+
+Expected: PASS for remounted paths; `/w/` 404
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/cmd/server/main.go server/cmd/server/stream_instance_detail.go server/cmd/server/substep_views_builder.go server/cmd/server/*_test.go
+git commit -m "$(cat <<'EOF'
+feat(routes): mount streams and instances under /my/streams
+
+Replace /w/:key/process/:id with /my/streams/:id/instance/:id and
+remove the legacy /w/ mount.
+EOF
+)"
+```
+
+---
+
+### Task 4: Remount organization admin under `/my/organization`
+
+**Files:**
+- Modify: `server/cmd/server/main.go` — org handler path prefixes, redirects, logo trim, `newMux`, `handleMyRoutes` org branch, EditAction formata URLs
+- Modify: `server/cmd/server/formata_builder.go` — any `/org-admin/formata-builder` strings
+- Modify: `server/templates/pages/org_admin.html` — form `action`, nav hrefs, inline JS path map
+- Modify: `server/templates/layout.html` — My Org href
+- Modify: `server/templates/components/stream_card.html` — create-stream builder href
+- Test: `org_admin_section_urls_test.go`, `admin_handler_identity_test.go`, `formata_builder_handler_test.go`, `stream_card_test.go`, `home_handler_test.go` (formata links)
+
+**Interfaces:**
+- Consumes: `organizationPath`
+- Produces: Org console at `/my/organization/...`; `/org-admin/*` → 404
+
+- [ ] **Step 1: Update failing org URL tests**
+
+Replace `/org-admin/` with `/my/organization/` in request paths and body assertions. Map:
+
+| Old | New |
+|-----|-----|
+| `/org-admin/profile` | `/my/organization/profile` |
+| `/org-admin/roles` | `/my/organization/roles` |
+| `/org-admin/members` | `/my/organization/members` |
+| `/org-admin/users` | `/my/organization/users` |
+| `/org-admin/logo/...` | `/my/organization/logo/...` |
+| `/org-admin/formata-builder` | `/my/organization/formata-builder` |
+
+Signup redirect to profile → `/my/organization/profile`.
+
+- [ ] **Step 2: Run org tests — expect FAIL**
+
+Run: `cd server && go test ./cmd/server -run 'OrgAdmin|FormataBuilder|StreamCard|HandleSignup' -count=1`
+
+Expected: FAIL on old paths
+
+- [ ] **Step 3: Implement remount**
+
+In `handleMyRoutes`, before `default`:
+
+```go
+case rest == "organization" || strings.HasPrefix(rest, "organization/"):
+	s.handleOrganizationRoutes(w, cloneRequestWithPath(r, "/"+rest))
+	return
+```
+
+Add `handleOrganizationRoutes` that switches on the suffix after `/organization`:
+
+```go
+func (s *Server) handleOrganizationRoutes(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/organization")
+	switch {
+	case path == "/profile" || path == "/profile/":
+		s.handleOrgAdminPage(w, r)
+	case path == "/roles" || path == "/roles/":
+		s.handleOrgAdminRoles(w, r)
+	case path == "/members" || path == "/members/":
+		s.handleOrgAdminPage(w, r)
+	case path == "/users" || path == "/users/":
+		s.handleOrgAdminUsers(w, r)
+	case strings.HasPrefix(path, "/logo/"):
+		s.handleOrgAdminLogo(w, cloneRequestWithPath(r, path))
+	case path == "/formata-builder" || strings.HasPrefix(path, "/formata-builder/"):
+		s.handleOrgAdminFormataBuilder(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+```
+
+Update `handleOrgAdminLogo` trim prefix from `/org-admin/logo/` to `/logo/` (because the cloned path is already under organization) **or** trim `/my/organization/logo/` if you pass the full request path — pick one approach and keep tests consistent.
+
+Replace every hardcoded redirect/string in org handlers:
+
+```go
+http.Redirect(w, r, organizationPath("profile"), http.StatusSeeOther)
+// roles, members likewise
+OrganizationLogoURL: organizationPath("logo/" + id)
+EditAction: organizationPath("formata-builder?stream=" + key)
+```
+
+In `newMux()`, **remove** all `/org-admin/...` `HandleFunc` lines (they are served via `/my/`).
+
+In `org_admin.html`, replace path strings and the inline JS map:
+
+```js
+profile: "/my/organization/profile",
+roles: "/my/organization/roles",
+members: "/my/organization/members",
+```
+
+In `layout.html`:
+
+```html
+<a href="/my/organization/profile" class="account-menu-item">
+```
+
+In `stream_card.html` create card: `href="/my/organization/formata-builder"`.
+
+- [ ] **Step 4: Run org + formata tests**
+
+Run: `cd server && go test ./cmd/server -run 'OrgAdmin|FormataBuilder|StreamCard|HandleSignup' -count=1`
+
+Expected: PASS; `GET /org-admin/profile` → 404 when hit via mux
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/cmd/server/main.go server/cmd/server/formata_builder.go server/templates/pages/org_admin.html server/templates/layout.html server/templates/components/stream_card.html server/cmd/server/*_test.go
+git commit -m "$(cat <<'EOF'
+feat(routes): move org admin under /my/organization
+
+Remount org settings and Formata builder under /my and drop the
+legacy /org-admin mount.
+EOF
+)"
+```
+
+---
+
+### Task 5: Breadcrumbs + remaining chrome URL builders
+
+**Files:**
+- Modify: `server/cmd/server/breadcrumbs.go`
+- Modify: `server/cmd/server/breadcrumbs_test.go`
+- Modify: `server/cmd/server/breadcrumbs_template_test.go`
+- Grep-fix any leftover `/w/` or `/org-admin/` in `server/templates/` and `server/cmd/server/*.go` (non-test first)
+
+**Interfaces:**
+- Consumes: `appHomePath`, `streamPath`, `streamInstancePath`, `organizationPath`
+- Produces: Breadcrumb hrefs matching the spec
+
+- [ ] **Step 1: Update breadcrumb unit tests**
+
+```go
+// root Streams → /my
+if got.Items[0].Href != appHomePath { ... }
+
+// stream current href may be empty (Current); ancestor on process page:
+// streamPath("wf-a")  // prefer without trailing slash; match generated links
+Href: streamPath("wf-a")
+
+// process:
+Href: streamInstancePath("wf-a", "abc123")
+
+// org:
+{Label: "Organization admin", Href: organizationPath("profile")}
+orgAdminSectionHref → organizationPath("roles"| "members"| "profile")
+```
+
+- [ ] **Step 2: Run breadcrumb tests — expect FAIL**
+
+Run: `cd server && go test ./cmd/server -run 'Breadcrumb' -count=1`
+
+Expected: FAIL
+
+- [ ] **Step 3: Implement breadcrumb builders**
+
+```go
+func buildStreamBreadcrumbs(workflowKey, workflowName string) BreadcrumbsView {
+	key := strings.TrimSpace(workflowKey)
+	return BreadcrumbsView{Items: []BreadcrumbItem{
+		{Label: "Streams", Href: appHomePath},
+		{Label: streamCrumbLabel(workflowName, key), Href: streamPath(key), Current: true},
+	}}
+}
+
+func buildProcessBreadcrumbs(...) BreadcrumbsView {
+	return BreadcrumbsView{Items: []BreadcrumbItem{
+		{Label: "Streams", Href: appHomePath},
+		{Label: streamCrumbLabel(workflowName, key), Href: streamPath(key)},
+		{Label: processInstanceCrumbLabel(instanceName, id), Href: streamInstancePath(key, id), Current: true},
+	}}
+}
+
+func buildOrgAdminBreadcrumbs(activePanel string) BreadcrumbsView {
+	section := strings.TrimSpace(activePanel)
+	return BreadcrumbsView{Items: []BreadcrumbItem{
+		{Label: "Streams", Href: appHomePath},
+		{Label: "Organization admin", Href: organizationPath("profile")},
+		{Label: orgAdminSectionLabel(section), Href: organizationPath(orgAdminSectionRest(section)), Current: true},
+	}}
+}
+
+func buildPlatformAdminBreadcrumbs() BreadcrumbsView {
+	return BreadcrumbsView{Items: []BreadcrumbItem{
+		{Label: "Streams", Href: appHomePath},
+		{Label: "Platform admin", Href: "/admin/orgs", Current: true},
+	}}
+}
+```
+
+Refactor `orgAdminSectionHref` to return the section rest (`profile` / `roles` / `members`) or call `organizationPath` directly.
+
+- [ ] **Step 4: Grep cleanup in production code/templates**
+
+Run: `rg -n '/w/|/org-admin' server/cmd/server server/templates --glob '!*_test.go'`
+
+Expected: no matches outside comments referring to historical names (fix any remaining)
+
+- [ ] **Step 5: Run breadcrumb tests — PASS + commit**
+
+```bash
+cd server && go test ./cmd/server -run 'Breadcrumb' -count=1
+git add server/cmd/server/breadcrumbs.go server/cmd/server/breadcrumbs_test.go server/cmd/server/breadcrumbs_template_test.go
+git commit -m "$(cat <<'EOF'
+fix(routes): point breadcrumbs at /my paths
+
+Root Streams and stream/instance/org trails now use the /my URL map.
+EOF
+)"
+```
+
+---
+
+### Task 6: Frontend EventSource and fetch URLs
+
+**Files:**
+- Modify: `web/src/main.js`
+
+**Interfaces:**
+- Consumes: new public path shapes (no Go helpers in JS)
+- Produces: content/SSE URLs under `/my/streams/.../instance/...`
+
+- [ ] **Step 1: Update URL templates in `web/src/main.js`**
+
+Replace:
+
+```js
+const url = `/w/${workflowKey}/process/${processId}/content${query}`;
+```
+
+with:
+
+```js
+const url = `/my/streams/${workflowKey}/instance/${processId}/content${query}`;
+```
+
+Replace:
+
+```js
+`/w/${workflowKey}/events?workflow=${workflowKey}&processId=${processId}`,
+```
+
+with:
+
+```js
+`/my/streams/${workflowKey}/events?workflow=${workflowKey}&processId=${processId}`,
+```
+
+Replace dept dashboard SSE/fetch (if those templates still exist):
+
+```js
+`/my/streams/${deptWorkflowKey}/events?workflow=${deptWorkflowKey}&role=${role}`,
+`/my/streams/${deptWorkflowKey}/backoffice/${role}/partial`,
+```
+
+(If backoffice routes were already 404 and unused, still update strings for consistency or delete the dead block — prefer update to match Go router; do not revive removed features.)
+
+- [ ] **Step 2: Verify no leftover `/w/` in web**
+
+Run: `rg -n '/w/' web/src`
+
+Expected: no matches
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/main.js
+git commit -m "$(cat <<'EOF'
+feat(web): fetch and SSE against /my/streams URLs
+
+Align process content refresh and event streams with the new route map.
+EOF
+)"
+```
+
+---
+
+### Task 7: Goa design + regenerate
+
+**Files:**
+- Modify: `server/design/design.go`
+- Generated under `server/gen/` (via `task goa:generate`)
+
+**Interfaces:**
+- Consumes: final public path map
+- Produces: OpenAPI/Goa artifacts matching `/`, `/my`, `/my/streams/...`, `/my/organization/...`
+
+- [ ] **Step 1: Update `server/design/design.go` HTTP paths**
+
+Workflow service (illustrative set — update every `/w/` method present):
+
+```go
+Method("home", func() {
+  HTTP(func() {
+    GET("/") // public blank home — keep; add separate method for app home if design tracks it
+  })
+})
+
+// Add or rename method for stream picker:
+Method("appHome", func() {
+  Result(Empty)
+  HTTP(func() {
+    GET("/my")
+    Response(StatusOK)
+  })
+})
+
+Method("workflowHome", func() {
+  HTTP(func() {
+    GET("/my/streams/{workflow_key}")
+  })
+})
+
+Method("startProcess", func() {
+  HTTP(func() {
+    POST("/my/streams/{workflow_key}/instance/start")
+  })
+})
+
+Method("deleteWorkflow", func() {
+  HTTP(func() {
+    POST("/my/streams/{workflow_key}/delete")
+  })
+})
+
+Method("readProcess", func() {
+  HTTP(func() {
+    GET("/my/streams/{workflow_key}/instance/{process_id}")
+  })
+})
+// similarly: content, downloads, files.zip, notarized.json, merkle.json,
+// complete, attachment file, events — all under /my/streams/.../instance/...
+```
+
+Org-admin service methods: replace `/org-admin` prefix with `/my/organization` (including formata-builder and logo). Keep `/admin/orgs` unchanged.
+
+Also update `GET /` description in design comments to “public homepage” if present.
+
+- [ ] **Step 2: Regenerate**
+
+Run: `task goa:generate`
+
+Expected: exits 0; `server/gen/` updates
+
+- [ ] **Step 3: Build sanity**
+
+Run: `cd server && go test ./design -count=1` and `cd server && go build -o /dev/null ./cmd/server`
+
+Expected: PASS / build OK
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/design/design.go server/gen
+git commit -m "$(cat <<'EOF'
+chore(goa): regenerate OpenAPI for /my route map
+
+Update design paths and generated artifacts to match the remounted
+authenticated surface.
+EOF
+)"
+```
+
+---
+
+### Task 8: Full test sweep + legacy 404 lock
+
+**Files:**
+- Modify: any remaining `server/cmd/server/*_test.go` still mentioning `/w/` or `/org-admin`
+- Modify: `workflow_coverage_test.go` — explicit legacy 404 cases
+
+- [ ] **Step 1: Find leftovers**
+
+Run: `rg -n '"/w/|/org-admin|/dashboard"' server/cmd/server --glob '*_test.go'`
+
+Update every remaining production-path assertion. Historical comments may mention old paths only if they do not assert request URLs.
+
+- [ ] **Step 2: Add legacy 404 tests**
+
+```go
+func TestLegacyRoutesGone(t *testing.T) {
+	server := /* mux-backed test server using newMux() */
+	cases := []string{
+		"/w/workflow/",
+		"/w/workflow/process/abc",
+		"/org-admin/profile",
+		"/dashboard",
+		"/dashboard/streams/workflow",
+	}
+	for _, path := range cases {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		server.newMux().ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound && rec.Code != http.StatusSeeOther /* login only if somehow under /my */ {
+			// Legacy paths must not be served as app pages.
+			if rec.Code != http.StatusNotFound {
+				t.Fatalf("%s status = %d, want 404", path, rec.Code)
+			}
+		}
+	}
+}
+```
+
+Use the same mux/auth bootstrap pattern as `workflow_coverage_test.go` (prefer extending that file).
+
+- [ ] **Step 3: Run full unit suite**
+
+Run: `cd server && go test $(go list ./... | grep -v /gen) -count=1`
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/cmd/server
+git commit -m "$(cat <<'EOF'
+test(routes): finish /my URL sweep and lock legacy 404s
+
+Align remaining handler tests with the new map and assert /w,
+/org-admin, and /dashboard stay gone.
+EOF
+)"
+```
+
+---
+
+### Task 9: Docs
+
+**Files:**
+- Modify: `AGENTS.md` — route tables and status notes
+- Modify: `QUICKSTART.md` — any `/w/` or `/org-admin` URLs
+- Modify: `CONTEXT.md` if it documents routes
+- Modify: `docs/css.md` only if it cites old paths in examples
+- Do **not** rewrite historical specs under `docs/superpowers/specs/2026-07-21-*` (leave as historical); the new routes spec already exists
+
+- [ ] **Step 1: Update AGENTS.md route sections**
+
+Replace documented paths:
+
+- Stream dashboard: `/my/streams/:key/`
+- Instance: `/my/streams/:key/instance/:id`
+- Org admin: `/my/organization/profile|roles|members`
+- Home: public `/`; picker `/my`
+- Remove claims that `/` is the stream picker
+- Note hard cut of `/w/` and `/org-admin/`
+
+- [ ] **Step 2: Update QUICKSTART / CONTEXT similarly**
+
+- [ ] **Step 3: Grep docs for stale paths**
+
+Run: `rg -n '/w/|/org-admin' AGENTS.md QUICKSTART.md CONTEXT.md README.md docs/css.md`
+
+Expected: only intentional historical references (if any); fix live docs
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add AGENTS.md QUICKSTART.md CONTEXT.md README.md docs/css.md
+git commit -m "$(cat <<'EOF'
+docs: document /my authenticated route map
+
+Update agent and quickstart route references after the URL rewrite.
+EOF
+)"
+```
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+|------------------|------|
+| Public blank `/` | 2 |
+| Stream picker `/my` | 2 |
+| `/my/streams/:id` dashboard | 3 |
+| `/my/streams/:id/instance/:id` (+ subpaths, start, events, delete) | 3, 6 |
+| `/my/organization/...` | 4 |
+| `/admin` unchanged | 4, 7 (left alone) |
+| Hard cut `/w`, `/org-admin`, `/dashboard` | 3, 4, 8 |
+| No auto-redirect `/` → `/my` when logged in | 2 |
+| Login default `/my` | 2 |
+| Breadcrumbs Streams → `/my` | 5 |
+| Frontend fetch/SSE | 6 |
+| Goa/OpenAPI | 7 |
+| Tests + docs | 8, 9 |
+| Path helpers single source of truth | 1 |
+
+## Self-review notes
+
+- No TBD placeholders in tasks
+- `organizationPath` / `streamPath` / `streamInstancePath` / `appHomePath` names are consistent across tasks
+- Goa regenerate is its own task so OpenAPI does not drift mid-remount
+- Dead `backoffice` JS paths are updated only for consistency; router may still 404 (pre-existing)

--- a/docs/superpowers/specs/2026-07-23-my-routes-design.md
+++ b/docs/superpowers/specs/2026-07-23-my-routes-design.md
@@ -1,0 +1,119 @@
+# Authenticated app under `/my` (public `/`)
+
+Date: 2026-07-23  
+Scope: Full rewrite of authenticated app URL prefixes; public blank homepage at `/`; hard cut of legacy `/w/` and `/org-admin/` mounts  
+Out of scope: Public homepage content/design; improving `/my` stream-picker UX; compatibility redirects; moving platform `/admin` under `/my`; renaming Cerbos/Appwrite/Mongo domain models
+
+## Goal
+
+Make `/` a public homepage (blank placeholder for now) and move the authenticated product surface under `/my/*`, with clearer stream/instance path segments. Platform admin stays at root `/admin`. Org settings move to `/my/organization`.
+
+## Decisions
+
+1. **Approach:** Remount handlers and rewrite URL helpers end-to-end (no path-rewrite shim, no dual-mount period).
+2. **Auth prefix:** `/my` (not `/dashboard`).
+3. **Stream picker:** `GET /my` = today’s authenticated `/` content (to be improved later).
+4. **Stream dashboard:** `GET /my/streams/:streamId` (today’s `/w/:key/`).
+5. **Instance:** `GET /my/streams/:streamId/instance/:instanceId` (today’s `/w/:key/process/:id`).
+6. **Org admin:** `/my/organization/...` (today’s `/org-admin/...`).
+7. **Platform admin:** stays at `/admin/orgs` (and related logo routes).
+8. **Hard cut:** `/w/*`, `/org-admin/*`, and `/dashboard/*` return 404. No redirects.
+9. **Logged-in visit to `/`:** stay on the public blank homepage (no auto-redirect to `/my`).
+10. **Post-login / app-home default:** `/my`.
+
+## Route map
+
+| Role | Path | Auth | Notes |
+|------|------|------|--------|
+| Public homepage | `GET /` | no | Blank placeholder; layout chrome OK |
+| Stream picker | `GET /my` | yes | Today’s `/` stream list |
+| Stream dashboard | `GET /my/streams/:streamId` | yes | Instance list for one stream |
+| Start instance | `POST /my/streams/:streamId/instance/start` | yes | Was `/process/start` |
+| Delete stream | `POST /my/streams/:streamId/delete` | yes | Same verb |
+| Instance detail | `GET /my/streams/:streamId/instance/:instanceId` | yes | Was `/process/:id` |
+| Instance subpaths | `/my/streams/:streamId/instance/:instanceId/...` | yes | `content`, `downloads`, `terminate`, `substep/...`, exports, attachment file |
+| Stream SSE | `GET /my/streams/:streamId/events` | yes | Was `/w/:key/events` |
+| Org profile | `GET /my/organization/profile` | yes | Was `/org-admin/profile` |
+| Org roles | `GET/POST /my/organization/roles` | yes | Was `/org-admin/roles` |
+| Org members | `GET /my/organization/members` | yes | Was `/org-admin/members` |
+| Org users (forms) | `GET/POST /my/organization/users` | yes | GET redirects to profile; POST keeps invite/set_roles/delete intents |
+| Formata builder | `/my/organization/formata-builder` | yes | Was `/org-admin/formata-builder` |
+| Org logo | `/my/organization/logo/...` | yes | Was `/org-admin/logo/...` |
+| Platform admin | `/admin/orgs` (+ logo) | yes | Unchanged at root |
+| Auth / public | `/login`, `/signup`, `/logout`, `/invite/`, `/reset`, `/01/…`, `/docs`, `/about`, `/api/catalog` | as today | Stay at root |
+| Legacy | `/w/*`, `/org-admin/*`, `/dashboard/*` | — | 404 |
+
+**IDs:** `:streamId` = today’s workflow key; `:instanceId` = process ObjectID hex. Persistence and domain types unchanged — path segments only.
+
+**Trailing slashes:** Preserve today’s behavior for stream picker and stream dashboard (accept `/my` and `/my/`; accept `/my/streams/:id` and `/my/streams/:id/`). Prefer generating links without a trailing slash except where existing helpers already normalize.
+
+**Verb rename:** public URL uses `instance` instead of `process` (e.g. start was `/w/:key/process/start`). Internal Go types (`Process`, handlers named `handle*Process*`) may keep existing names unless a local rename clarifies call sites; no required domain rename in this change.
+
+## Architecture
+
+### Routing (`newMux` + handlers)
+
+- `GET /` → new public blank homepage handler (no `requireAuthenticatedPage`).
+- `/my/` → auth-gated surface:
+  - `/my` and `/my/` → stream picker (today’s `handleHome`)
+  - `/my/streams/:id/...` → stream/instance router (today’s `handleWorkflowRoutes` / `handleProcessRoutes`)
+  - `/my/organization/...` → org settings (today’s `handleOrgAdmin*`)
+- Unregister `/w/` and `/org-admin/*`. Keep `/admin/*` at root.
+- Every `/my/*` handler continues to use `requireAuthenticatedPage` / `requireAuthenticatedPost` as today.
+
+### Central URL builders
+
+Rewrite helpers so templates/handlers do not hardcode old prefixes:
+
+- Stream base path: `/my/streams/{key}` (replace or adapt `workflowPath`)
+- Instance detail: `/my/streams/{key}/instance/{id}`
+- Org links: `/my/organization/profile` (and siblings)
+- Login default / `safeNextPath` fallback: `/my` (today often `/`)
+- Pagination, breadcrumbs, post-start/delete/complete redirects → new paths
+
+Prefer one helper per resource so cards, breadcrumbs, HTMX URLs, and redirects stay consistent.
+
+### Frontend
+
+Update hardcoded `/w/...` fetch and EventSource URLs in `web/src/main.js` to `/my/streams/...`.
+
+### Templates / chrome
+
+- Topbar “My Org” → `/my/organization/profile`
+- Breadcrumbs root “Streams” → `/my` (not public `/`)
+- Stream/instance crumbs use new stream and instance paths
+- Org admin page forms, nav, and inline JS path maps → `/my/organization/...`
+
+### Docs
+
+Update `AGENTS.md` (and README/QUICKSTART route mentions if present) so agents do not regenerate `/w/` or `/org-admin/` URLs.
+
+## Auth and errors
+
+- Unauthenticated access to `/my/*` → `/login?next=<request URI>` (existing pattern).
+- Login/signup default `next` fallback → `/my`.
+- Signup that today lands on `/org-admin/profile` → `/my/organization/profile`.
+- Platform-admin login `next` may still target `/admin/orgs`.
+- Cerbos resource names and role slugs (e.g. `org-admin`, `org_admin_console`) are unchanged — URL rename only.
+- Missing stream/instance → 404 as today.
+- Legacy prefixes → 404 (no redirect body).
+
+## Testing
+
+- Update handler/route/template tests that assert `/w/…`, `/org-admin/…`, or login `next=/` to the new paths.
+- Keep/extend coverage that legacy `/dashboard` is 404; assert `/w/` and `/org-admin/` 404 after remount.
+- Smoke cases:
+  - Unauthenticated `/my` → login with `next`
+  - Authenticated `GET /` → 200 blank homepage, no redirect to `/my`
+  - Instance URLs build `/my/streams/{id}/instance/{id}`
+  - Org topbar → `/my/organization/profile`
+- Frontend EventSource/content fetch paths match new stream/instance URLs.
+- No required changes to Cerbos policy files, Mongo progress-key encoding, or Appwrite identity model for this work.
+
+## Non-goals (explicit)
+
+- Designing or filling the public homepage
+- Redesigning the `/my` stream picker
+- Compatibility redirects from old URLs
+- Nesting platform admin under `/my`
+- Renaming internal process/workflow domain types solely for vocabulary alignment

--- a/server/cmd/server/admin_handler_identity_test.go
+++ b/server/cmd/server/admin_handler_identity_test.go
@@ -1893,7 +1893,7 @@ func TestHandleOrgAdminUsersCreateOrgWithIdentity(t *testing.T) {
 	form := url.Values{}
 	form.Set("intent", "create_org")
 	form.Set("name", "Fresh Org")
-	req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	rec := httptest.NewRecorder()
@@ -1906,8 +1906,8 @@ func TestHandleOrgAdminUsersCreateOrgWithIdentity(t *testing.T) {
 	if createSessionSecret != "session-1" || createName != "Fresh Org" {
 		t.Fatalf("create args = %q %q", createSessionSecret, createName)
 	}
-	if rec.Header().Get("Location") != "/org-admin/members" {
-		t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
+	if rec.Header().Get("Location") != "/my/organization/members" {
+		t.Fatalf("location = %q, want /my/organization/members", rec.Header().Get("Location"))
 	}
 }
 
@@ -1947,7 +1947,7 @@ func TestHandleOrgAdminUsersCreateOrgIdentityValidation(t *testing.T) {
 		now:         func() time.Time { return now },
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=create_org&name=Fresh+Org"))
+	req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=create_org&name=Fresh+Org"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	rec := httptest.NewRecorder()
@@ -2062,7 +2062,7 @@ func TestHandleOrgAdminUsersUpdateOrgWithIdentityLogo(t *testing.T) {
 		t.Fatalf("writer.Close error: %v", err)
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader(body.String()))
+	req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader(body.String()))
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	rec := httptest.NewRecorder()
@@ -2084,8 +2084,8 @@ func TestHandleOrgAdminUsersUpdateOrgWithIdentityLogo(t *testing.T) {
 	if deletedLogoFileID != "logo-old" {
 		t.Fatalf("deleted logo = %q, want logo-old", deletedLogoFileID)
 	}
-	if rec.Header().Get("Location") != "/org-admin/profile" {
-		t.Fatalf("location = %q, want /org-admin/profile", rec.Header().Get("Location"))
+	if rec.Header().Get("Location") != "/my/organization/profile" {
+		t.Fatalf("location = %q, want /my/organization/profile", rec.Header().Get("Location"))
 	}
 }
 
@@ -2127,7 +2127,7 @@ func TestHandleOrgAdminLogoWithIdentity(t *testing.T) {
 		now:         func() time.Time { return now },
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/org-admin/logo/logo-1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/logo/logo-1", nil)
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	rec := httptest.NewRecorder()
 
@@ -2189,7 +2189,7 @@ func TestHandleOrgAdminRolesWithIdentity(t *testing.T) {
 		now:         func() time.Time { return now },
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/org-admin/roles", strings.NewReader("name=Approver&palette=blue"))
+	req := httptest.NewRequest(http.MethodPost, "/my/organization/roles", strings.NewReader("name=Approver&palette=blue"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	rec := httptest.NewRecorder()
@@ -2241,7 +2241,7 @@ func TestHandleOrgAdminRolesSlugifiesAndTruncatesName(t *testing.T) {
 		now:         func() time.Time { return now },
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/org-admin/roles", strings.NewReader("name=QA+Reviewer!!!1234567890123456789012345678901234567890&palette=blue"))
+	req := httptest.NewRequest(http.MethodPost, "/my/organization/roles", strings.NewReader("name=QA+Reviewer!!!1234567890123456789012345678901234567890&palette=blue"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	rec := httptest.NewRecorder()
@@ -2318,7 +2318,7 @@ func TestHandleOrgAdminUsersSetRolesWithIdentity(t *testing.T) {
 	}
 
 	targetID := "user-2"
-	req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=set_roles&userId="+targetID+"&roles=approver&roles=org-admin"))
+	req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=set_roles&userId="+targetID+"&roles=approver&roles=org-admin"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	rec := httptest.NewRecorder()
@@ -2328,15 +2328,15 @@ func TestHandleOrgAdminUsersSetRolesWithIdentity(t *testing.T) {
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 	}
-	if rec.Header().Get("Location") != "/org-admin/members" {
-		t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
+	if rec.Header().Get("Location") != "/my/organization/members" {
+		t.Fatalf("location = %q, want /my/organization/members", rec.Header().Get("Location"))
 	}
 	if !hasIdentityLabel(users[1].Labels, identityOrgAdminLabel) || !containsRole(decodeIdentityRoleLabels(users[1].Labels), "approver") {
 		t.Fatalf("updated user labels = %#v", users[1].Labels)
 	}
 
 	selfID := "user-1"
-	selfReq := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=set_roles&userId="+selfID+"&roles=approver"))
+	selfReq := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=set_roles&userId="+selfID+"&roles=approver"))
 	selfReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	selfReq.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	selfRec := httptest.NewRecorder()
@@ -2409,7 +2409,7 @@ func TestHandleOrgAdminUsersSetRolesHidesPlatformAdmin(t *testing.T) {
 		now:         func() time.Time { return now },
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=set_roles&userId=user-2&roles=approver"))
+	req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=set_roles&userId=user-2&roles=approver"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	rec := httptest.NewRecorder()
@@ -2482,7 +2482,7 @@ func TestHandleOrgAdminUsersInviteWithIdentity(t *testing.T) {
 		now:         func() time.Time { return now },
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=invite&email=new%40example.com&roles=approver&roles=org-admin"))
+	req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=invite&email=new%40example.com&roles=approver&roles=org-admin"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	rec := httptest.NewRecorder()
@@ -2492,8 +2492,8 @@ func TestHandleOrgAdminUsersInviteWithIdentity(t *testing.T) {
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 	}
-	if rec.Header().Get("Location") != "/org-admin/members" {
-		t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
+	if rec.Header().Get("Location") != "/my/organization/members" {
+		t.Fatalf("location = %q, want /my/organization/members", rec.Header().Get("Location"))
 	}
 	if inviteCalls != 1 || len(invitedRoles) != 1 || invitedRoles[0] != "approver" || !invitedAdmin {
 		t.Fatalf("invite call = %d roles=%#v admin=%v", inviteCalls, invitedRoles, invitedAdmin)
@@ -2536,7 +2536,7 @@ func TestHandleOrgAdminUsersInviteIdentityDuplicatePending(t *testing.T) {
 		now:         func() time.Time { return now },
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=invite&email=pending%40example.com&roles=approver"))
+	req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=invite&email=pending%40example.com&roles=approver"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	rec := httptest.NewRecorder()
@@ -2546,8 +2546,8 @@ func TestHandleOrgAdminUsersInviteIdentityDuplicatePending(t *testing.T) {
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 	}
-	if rec.Header().Get("Location") != "/org-admin/members" {
-		t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
+	if rec.Header().Get("Location") != "/my/organization/members" {
+		t.Fatalf("location = %q, want /my/organization/members", rec.Header().Get("Location"))
 	}
 	if inviteCalls != 0 {
 		t.Fatalf("invite calls = %d, want 0", inviteCalls)
@@ -2597,7 +2597,7 @@ func TestHandleOrgAdminUsersInviteIdentityExistingAndCrossOrg(t *testing.T) {
 		now:         func() time.Time { return now },
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=invite&email=member%40example.com&roles=approver"))
+	req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=invite&email=member%40example.com&roles=approver"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	rec := httptest.NewRecorder()
@@ -2605,14 +2605,14 @@ func TestHandleOrgAdminUsersInviteIdentityExistingAndCrossOrg(t *testing.T) {
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("existing member status = %d, want %d", rec.Code, http.StatusSeeOther)
 	}
-	if rec.Header().Get("Location") != "/org-admin/members" {
-		t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
+	if rec.Header().Get("Location") != "/my/organization/members" {
+		t.Fatalf("location = %q, want /my/organization/members", rec.Header().Get("Location"))
 	}
 	if len(updatedUsers["user-2"]) != 1 || updatedUsers["user-2"][0] != encodeIdentityRoleLabel("approver") {
 		t.Fatalf("updated user labels = %#v", updatedUsers)
 	}
 
-	reqOther := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=invite&email=other%40example.com&roles=approver"))
+	reqOther := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=invite&email=other%40example.com&roles=approver"))
 	reqOther.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	reqOther.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	recOther := httptest.NewRecorder()
@@ -2670,7 +2670,7 @@ func TestHandleOrgAdminUsersDeleteUserWithIdentity(t *testing.T) {
 	}
 
 	targetID := "user-2"
-	req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=delete_user&userId="+targetID))
+	req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=delete_user&userId="+targetID))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	rec := httptest.NewRecorder()
@@ -2678,8 +2678,8 @@ func TestHandleOrgAdminUsersDeleteUserWithIdentity(t *testing.T) {
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 	}
-	if rec.Header().Get("Location") != "/org-admin/members" {
-		t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
+	if rec.Header().Get("Location") != "/my/organization/members" {
+		t.Fatalf("location = %q, want /my/organization/members", rec.Header().Get("Location"))
 	}
 	if len(deletedMemberships) != 1 || deletedMemberships[0] != "membership-2" {
 		t.Fatalf("deleted memberships = %#v", deletedMemberships)
@@ -2690,11 +2690,11 @@ func TestHandleOrgAdminUsersDeleteUserWithIdentity(t *testing.T) {
 }
 
 func TestIdentityOrgAdminHelpers(t *testing.T) {
-	if got := inviteRedirectURL(httptest.NewRequest(http.MethodGet, "/org-admin/users", nil)); !strings.Contains(got, "/invite/accept") {
+	if got := inviteRedirectURL(httptest.NewRequest(http.MethodGet, "/my/organization/users", nil)); !strings.Contains(got, "/invite/accept") {
 		t.Fatalf("invite redirect = %q", got)
 	}
 	t.Setenv("APPWRITE_INVITE_REDIRECT_URL", "https://app.example/invite/accept")
-	if got := inviteRedirectURL(httptest.NewRequest(http.MethodGet, "/org-admin/users", nil)); got != "https://app.example/invite/accept" {
+	if got := inviteRedirectURL(httptest.NewRequest(http.MethodGet, "/my/organization/users", nil)); got != "https://app.example/invite/accept" {
 		t.Fatalf("configured invite redirect = %q", got)
 	}
 	if _, err := sessionSecretFromRequest(httptest.NewRequest(http.MethodGet, "/", nil)); err == nil {
@@ -2758,7 +2758,7 @@ func TestHandleOrgAdminUsersDeleteUserHidesPlatformAdmin(t *testing.T) {
 		now:         func() time.Time { return now },
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=delete_user&userId=user-2"))
+	req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=delete_user&userId=user-2"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	rec := httptest.NewRecorder()
@@ -2808,7 +2808,7 @@ func TestHandleOrgAdminRolesIdentityErrors(t *testing.T) {
 		}
 	}
 
-	reqDup := httptest.NewRequest(http.MethodPost, "/org-admin/roles", strings.NewReader("name=QA+Reviewer&palette=blue"))
+	reqDup := httptest.NewRequest(http.MethodPost, "/my/organization/roles", strings.NewReader("name=QA+Reviewer&palette=blue"))
 	reqDup.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	reqDup.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	recDup := httptest.NewRecorder()
@@ -2817,7 +2817,7 @@ func TestHandleOrgAdminRolesIdentityErrors(t *testing.T) {
 		t.Fatalf("duplicate role response = %d %q", recDup.Code, recDup.Body.String())
 	}
 
-	reqFail := httptest.NewRequest(http.MethodPost, "/org-admin/roles", strings.NewReader("name=Approver&palette=blue"))
+	reqFail := httptest.NewRequest(http.MethodPost, "/my/organization/roles", strings.NewReader("name=Approver&palette=blue"))
 	reqFail.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	reqFail.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	recFail := httptest.NewRecorder()
@@ -2857,7 +2857,7 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		}
 		server := &Server{
 			authorizer: fakeAuthorizer{}, store: NewMemoryStore(), identity: fake, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=invite&email=pending%40example.com&roles=approver"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=invite&email=pending%40example.com&roles=approver"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -2865,8 +2865,8 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		if rec.Code != http.StatusSeeOther || updated != 1 {
 			t.Fatalf("pending update response = %d updated=%d location=%q", rec.Code, updated, rec.Header().Get("Location"))
 		}
-		if rec.Header().Get("Location") != "/org-admin/members" {
-			t.Fatalf("location = %q, want /org-admin/members", rec.Header().Get("Location"))
+		if rec.Header().Get("Location") != "/my/organization/members" {
+			t.Fatalf("location = %q, want /my/organization/members", rec.Header().Get("Location"))
 		}
 	})
 
@@ -2875,7 +2875,7 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		fake.listOrganizationUsersFunc = func(ctx context.Context, orgSlug string) ([]IdentityUser, error) { return nil, nil }
 		server := &Server{
 			authorizer: fakeAuthorizer{}, store: NewMemoryStore(), identity: fake, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=set_roles&userId=missing&roles=approver"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=set_roles&userId=missing&roles=approver"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -2892,7 +2892,7 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		}
 		server := &Server{
 			authorizer: fakeAuthorizer{}, store: NewMemoryStore(), identity: fake, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=delete_user&userId=user-1"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=delete_user&userId=user-1"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -2906,7 +2906,7 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		fake := baseIdentity()
 		server := &Server{
 			authorizer: fakeAuthorizer{}, store: NewMemoryStore(), identity: fake, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=invite&email=user%40example.com&roles=missing"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=invite&email=user%40example.com&roles=missing"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -2924,7 +2924,7 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		}
 		server := &Server{
 			authorizer: fakeAuthorizer{}, store: NewMemoryStore(), identity: fake, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=invite&email=user%40example.com&roles=approver"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=invite&email=user%40example.com&roles=approver"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -2944,7 +2944,7 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		}
 		server := &Server{
 			authorizer: fakeAuthorizer{}, store: NewMemoryStore(), identity: fake, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=set_roles&userId=user-2&roles=approver&roles=org-admin"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=set_roles&userId=user-2&roles=approver&roles=org-admin"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -2964,7 +2964,7 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		}
 		server := &Server{
 			authorizer: fakeAuthorizer{}, store: NewMemoryStore(), identity: fake, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=delete_user&userId=user-2"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=delete_user&userId=user-2"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -2991,7 +2991,7 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		}
 		server := &Server{
 			authorizer: fakeAuthorizer{}, store: NewMemoryStore(), identity: fake, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=create_org&name=Fresh+Org"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=create_org&name=Fresh+Org"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -3028,7 +3028,7 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		_ = writer.Close()
 		server := &Server{
 			authorizer: fakeAuthorizer{}, store: NewMemoryStore(), identity: fake, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader(body.String()))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader(body.String()))
 		req.Header.Set("Content-Type", writer.FormDataContentType())
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -3054,7 +3054,7 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		}
 		server := &Server{
 			authorizer: fakeAuthorizer{}, store: NewMemoryStore(), identity: fake, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=update_org&name=Other+Org"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=update_org&name=Other+Org"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -3075,7 +3075,7 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		}
 		server := &Server{
 			authorizer: fakeAuthorizer{}, store: NewMemoryStore(), identity: fake, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=update_org&name=Updated+Org"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=update_org&name=Updated+Org"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -3099,7 +3099,7 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		}
 		server := &Server{
 			authorizer: fakeAuthorizer{}, store: NewMemoryStore(), identity: fake, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=delete_user&userId=user-2"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=delete_user&userId=user-2"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -3116,7 +3116,7 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		}
 		server := &Server{
 			authorizer: fakeAuthorizer{}, store: NewMemoryStore(), identity: fake, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=invite&email=user%40example.com&roles=approver"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=invite&email=user%40example.com&roles=approver"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -3136,7 +3136,7 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		}
 		server := &Server{
 			authorizer: fakeAuthorizer{}, store: NewMemoryStore(), identity: fake, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=invite&email=pending%40example.com&roles=approver"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=invite&email=pending%40example.com&roles=approver"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -3156,7 +3156,7 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		}
 		server := &Server{
 			authorizer: fakeAuthorizer{}, store: NewMemoryStore(), identity: fake, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=invite&email=member%40example.com&roles=approver"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=invite&email=member%40example.com&roles=approver"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -3177,7 +3177,7 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		}
 		server := &Server{
 			authorizer: fakeAuthorizer{}, store: NewMemoryStore(), identity: fake, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=invite&email=new%40example.com&roles=approver"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=invite&email=new%40example.com&roles=approver"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -3212,7 +3212,7 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 			log.SetPrefix(oldPrefix)
 		})
 
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=invite&email=new%40example.com&roles=approver"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=invite&email=new%40example.com&roles=approver"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -3237,7 +3237,7 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		}
 		server := &Server{
 			authorizer: fakeAuthorizer{}, store: NewMemoryStore(), identity: fake, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=set_roles&userId=user-2&roles=missing"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=set_roles&userId=user-2&roles=missing"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -3258,7 +3258,7 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		}
 		server := &Server{
 			authorizer: fakeAuthorizer{}, store: NewMemoryStore(), identity: fake, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=delete_user&userId=user-2"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=delete_user&userId=user-2"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -3275,7 +3275,7 @@ func TestHandleOrgAdminUsersIdentityBranchErrors(t *testing.T) {
 		}
 		server := &Server{
 			authorizer: fakeAuthorizer{}, store: NewMemoryStore(), identity: fake, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=update_org&name=Updated+Org"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=update_org&name=Updated+Org"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -3350,7 +3350,7 @@ func TestHandleOrgAdminLogoIdentityBranches(t *testing.T) {
 
 	t.Run("method not allowed", func(t *testing.T) {
 		server := baseServer(&fakeIdentityStore{})
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/logo/logo-1", nil)
+		req := httptest.NewRequest(http.MethodPost, "/logo/logo-1", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminLogo(rec, req)
@@ -3372,14 +3372,14 @@ func TestHandleOrgAdminLogoIdentityBranches(t *testing.T) {
 			},
 			{
 				name: "org missing",
-				path: "/org-admin/logo/logo-1",
+				path: "/logo/logo-1",
 				identity: &fakeIdentityStore{
 					getOrganizationBySlugFunc: func(ctx context.Context, slug string) (*IdentityOrg, error) { return nil, ErrIdentityNotFound },
 				},
 			},
 			{
 				name: "id mismatch",
-				path: "/org-admin/logo/logo-1",
+				path: "/logo/logo-1",
 				identity: &fakeIdentityStore{
 					getOrganizationBySlugFunc: func(ctx context.Context, slug string) (*IdentityOrg, error) {
 						org := IdentityOrg{ID: "team-1", Slug: "acme", Name: "Acme Org", LogoFileID: "other-logo"}
@@ -3389,7 +3389,7 @@ func TestHandleOrgAdminLogoIdentityBranches(t *testing.T) {
 			},
 			{
 				name: "load error",
-				path: "/org-admin/logo/logo-1",
+				path: "/logo/logo-1",
 				identity: &fakeIdentityStore{
 					getOrganizationBySlugFunc: func(ctx context.Context, slug string) (*IdentityOrg, error) {
 						org := IdentityOrg{ID: "team-1", Slug: "acme", Name: "Acme Org", LogoFileID: "logo-1"}
@@ -3425,7 +3425,7 @@ func TestHandleOrgAdminLogoIdentityBranches(t *testing.T) {
 				return IdentityFile{ID: fileID, Filename: "logo.bin", Data: []byte("BIN")}, nil
 			},
 		})
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/logo/logo-1", nil)
+		req := httptest.NewRequest(http.MethodGet, "/logo/logo-1", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminLogo(rec, req)
@@ -3480,7 +3480,7 @@ func TestHandleOrgAdminRolesIdentityAdditionalBranches(t *testing.T) {
 			&IdentityOrg{ID: "team-1", Slug: "acme", Name: "Acme Org"},
 			nil,
 		)
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/roles", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/organization/roles", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminRoles(rec, req)
@@ -3495,7 +3495,7 @@ func TestHandleOrgAdminRolesIdentityAdditionalBranches(t *testing.T) {
 			nil,
 			nil,
 		)
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/roles", strings.NewReader("name=Approver"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/roles", strings.NewReader("name=Approver"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -3511,7 +3511,7 @@ func TestHandleOrgAdminRolesIdentityAdditionalBranches(t *testing.T) {
 			&IdentityOrg{ID: "team-1", Slug: "acme", Name: "Acme Org"},
 			nil,
 		)
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/roles", strings.NewReader("palette=blue"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/roles", strings.NewReader("palette=blue"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -3525,7 +3525,7 @@ func TestHandleOrgAdminRolesIdentityAdditionalBranches(t *testing.T) {
 			nil,
 			nil,
 		)
-		req2 := httptest.NewRequest(http.MethodPost, "/org-admin/roles", strings.NewReader("name=Approver"))
+		req2 := httptest.NewRequest(http.MethodPost, "/my/organization/roles", strings.NewReader("name=Approver"))
 		req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req2.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec2 := httptest.NewRecorder()
@@ -3541,7 +3541,7 @@ func TestHandleOrgAdminRolesIdentityAdditionalBranches(t *testing.T) {
 			&IdentityOrg{ID: "team-1", Slug: "acme", Name: "Acme Org"},
 			nil,
 		)
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/roles", strings.NewReader("name=%21%21%21&palette=blue"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/roles", strings.NewReader("name=%21%21%21&palette=blue"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -3558,7 +3558,7 @@ func TestHandleOrgAdminRolesIdentityAdditionalBranches(t *testing.T) {
 			org,
 			nil,
 		)
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/roles", strings.NewReader("name=Escalations"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/roles", strings.NewReader("name=Escalations"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -3603,7 +3603,7 @@ func TestHandleOrgAdminRolesIdentityAdditionalBranches(t *testing.T) {
 			enforceAuth: true,
 			now:         func() time.Time { return now },
 		}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/roles", strings.NewReader("intent=set_role&role_slug=qa-reviewer&name=Lead+Reviewer"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/roles", strings.NewReader("intent=set_role&role_slug=qa-reviewer&name=Lead+Reviewer"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -3657,7 +3657,7 @@ func TestHandleOrgAdminRolesIdentityAdditionalBranches(t *testing.T) {
 			enforceAuth: true,
 			now:         func() time.Time { return now },
 		}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/roles", strings.NewReader("intent=delete_role&role_slug=approver"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/roles", strings.NewReader("intent=delete_role&role_slug=approver"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -3705,7 +3705,7 @@ func TestHandleOrgAdminRolesIdentityAdditionalBranches(t *testing.T) {
 			now:         func() time.Time { return now },
 		}
 
-		reqEdit := httptest.NewRequest(http.MethodPost, "/org-admin/roles", strings.NewReader("intent=set_role&role_slug=approver&name=Lead+Approver"))
+		reqEdit := httptest.NewRequest(http.MethodPost, "/my/organization/roles", strings.NewReader("intent=set_role&role_slug=approver&name=Lead+Approver"))
 		reqEdit.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		reqEdit.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		recEdit := httptest.NewRecorder()
@@ -3714,7 +3714,7 @@ func TestHandleOrgAdminRolesIdentityAdditionalBranches(t *testing.T) {
 			t.Fatalf("edit response = %d %q", recEdit.Code, recEdit.Body.String())
 		}
 
-		reqDelete := httptest.NewRequest(http.MethodPost, "/org-admin/roles", strings.NewReader("intent=delete_role&role_slug=approver"))
+		reqDelete := httptest.NewRequest(http.MethodPost, "/my/organization/roles", strings.NewReader("intent=delete_role&role_slug=approver"))
 		reqDelete.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		reqDelete.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		recDelete := httptest.NewRecorder()
@@ -3730,7 +3730,7 @@ func TestHandleOrgAdminRolesIdentityAdditionalBranches(t *testing.T) {
 			&IdentityOrg{ID: "team-1", Slug: "acme", Name: "Acme Org"},
 			nil,
 		)
-		req := httptest.NewRequest(http.MethodPut, "/org-admin/roles", nil)
+		req := httptest.NewRequest(http.MethodPut, "/my/organization/roles", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminRoles(rec, req)
@@ -3768,18 +3768,18 @@ func TestHandleOrgAdminUsersIdentityAdditionalBranches(t *testing.T) {
 
 	t.Run("get and unsupported action", func(t *testing.T) {
 		server := baseServer(IdentityUser{ID: "user-1", Email: "owner@example.com", OrgSlug: "acme", Labels: []string{identityOrgAdminLabel}, IsOrgAdmin: true, Status: "active"})
-		getReq := httptest.NewRequest(http.MethodGet, "/org-admin/users", nil)
+		getReq := httptest.NewRequest(http.MethodGet, "/my/organization/users", nil)
 		getReq.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		getRec := httptest.NewRecorder()
 		server.handleOrgAdminUsers(getRec, getReq)
 		if getRec.Code != http.StatusSeeOther {
 			t.Fatalf("get status = %d, want %d", getRec.Code, http.StatusSeeOther)
 		}
-		if getRec.Header().Get("Location") != "/org-admin/profile" {
-			t.Fatalf("get location = %q, want /org-admin/profile", getRec.Header().Get("Location"))
+		if getRec.Header().Get("Location") != "/my/organization/profile" {
+			t.Fatalf("get location = %q, want /my/organization/profile", getRec.Header().Get("Location"))
 		}
 
-		postReq := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=unsupported"))
+		postReq := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=unsupported"))
 		postReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		postReq.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		postRec := httptest.NewRecorder()
@@ -3800,7 +3800,7 @@ func TestHandleOrgAdminUsersIdentityAdditionalBranches(t *testing.T) {
 			{body: "intent=delete_user", want: "user is required"},
 		}
 		for _, tc := range tests {
-			req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader(tc.body))
+			req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader(tc.body))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 			req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 			rec := httptest.NewRecorder()
@@ -3814,7 +3814,7 @@ func TestHandleOrgAdminUsersIdentityAdditionalBranches(t *testing.T) {
 	t.Run("create org validation without org context", func(t *testing.T) {
 		server := baseServer(IdentityUser{ID: "user-1", Email: "owner@example.com", Labels: []string{identityOrgAdminLabel}, IsOrgAdmin: true, Status: "active"})
 
-		reqInvite := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=invite&email=user%40example.com"))
+		reqInvite := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=invite&email=user%40example.com"))
 		reqInvite.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		reqInvite.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		recInvite := httptest.NewRecorder()
@@ -3823,7 +3823,7 @@ func TestHandleOrgAdminUsersIdentityAdditionalBranches(t *testing.T) {
 			t.Fatalf("invite response = %d %q", recInvite.Code, recInvite.Body.String())
 		}
 
-		reqCreate := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=create_org"))
+		reqCreate := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=create_org"))
 		reqCreate.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		reqCreate.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		recCreate := httptest.NewRecorder()
@@ -3835,7 +3835,7 @@ func TestHandleOrgAdminUsersIdentityAdditionalBranches(t *testing.T) {
 
 	t.Run("create org rejected when org already exists", func(t *testing.T) {
 		server := baseServer(IdentityUser{ID: "user-1", Email: "owner@example.com", OrgSlug: "acme", Labels: []string{identityOrgAdminLabel}, IsOrgAdmin: true, Status: "active"})
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("intent=create_org&name=Fresh+Org"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("intent=create_org&name=Fresh+Org"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
@@ -3889,7 +3889,7 @@ func TestHandleOrgAdminUsersIdentityMultipartLogoValidation(t *testing.T) {
 		if err := writer.Close(); err != nil {
 			t.Fatalf("writer.Close error: %v", err)
 		}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", &body)
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", &body)
 		req.Header.Set("Content-Type", writer.FormDataContentType())
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		return req
@@ -3922,7 +3922,7 @@ func TestHandleOrgAdminUsersIdentityMultipartLogoValidation(t *testing.T) {
 	})
 
 	t.Run("invalid multipart form", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", strings.NewReader("--broken"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", strings.NewReader("--broken"))
 		req.Header.Set("Content-Type", "multipart/form-data; boundary=missing")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()

--- a/server/cmd/server/admin_handler_identity_test.go
+++ b/server/cmd/server/admin_handler_identity_test.go
@@ -3367,7 +3367,7 @@ func TestHandleOrgAdminLogoIdentityBranches(t *testing.T) {
 		}{
 			{
 				name:     "blank id",
-				path:     "/org-admin/logo/",
+				path:     "/logo/",
 				identity: &fakeIdentityStore{},
 			},
 			{

--- a/server/cmd/server/auth_helpers_test.go
+++ b/server/cmd/server/auth_helpers_test.go
@@ -285,7 +285,7 @@ func TestRequireOrgAdmin(t *testing.T) {
 	}
 
 	t.Run("unauthenticated redirects", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/users", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/organization/users", nil)
 		rec := httptest.NewRecorder()
 		if _, ok := server.requireOrgAdmin(rec, req); ok {
 			t.Fatal("expected requireOrgAdmin to fail")
@@ -296,7 +296,7 @@ func TestRequireOrgAdmin(t *testing.T) {
 	})
 
 	t.Run("non admin forbidden", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/users", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/organization/users", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-member"})
 		rec := httptest.NewRecorder()
 		if _, ok := server.requireOrgAdmin(rec, req); ok {
@@ -308,7 +308,7 @@ func TestRequireOrgAdmin(t *testing.T) {
 	})
 
 	t.Run("admin allowed", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/users", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/organization/users", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-admin"})
 		rec := httptest.NewRecorder()
 		user, ok := server.requireOrgAdmin(rec, req)

--- a/server/cmd/server/auth_invite_handler_test.go
+++ b/server/cmd/server/auth_invite_handler_test.go
@@ -38,8 +38,8 @@ func TestHandleInviteAcceptCreatesSessionCookie(t *testing.T) {
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 	}
-	if rec.Header().Get("Location") != "/" {
-		t.Fatalf("location = %q, want /", rec.Header().Get("Location"))
+	if rec.Header().Get("Location") != appHomePath {
+		t.Fatalf("location = %q, want %s", rec.Header().Get("Location"), appHomePath)
 	}
 	cookies := rec.Result().Cookies()
 	if len(cookies) == 0 || cookies[0].Name != "attesta_session" || cookies[0].Value != "invite-session" {

--- a/server/cmd/server/auth_reset_handler_test.go
+++ b/server/cmd/server/auth_reset_handler_test.go
@@ -398,7 +398,7 @@ func TestHandleResetPageHidesAdminTopbarLinks(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
 	body := rec.Body.String()
-	if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, `href="/org-admin/profile"`) {
+	if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, `href="/my/organization/profile"`) {
 		t.Fatalf("expected reset page without admin nav links, got %q", body)
 	}
 }

--- a/server/cmd/server/auth_reset_handler_test.go
+++ b/server/cmd/server/auth_reset_handler_test.go
@@ -114,8 +114,8 @@ func TestHandleInvitePasswordUpdatesCurrentPassword(t *testing.T) {
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 	}
-	if rec.Header().Get("Location") != "/" {
-		t.Fatalf("location = %q, want /", rec.Header().Get("Location"))
+	if rec.Header().Get("Location") != appHomePath {
+		t.Fatalf("location = %q, want %s", rec.Header().Get("Location"), appHomePath)
 	}
 	if updatedSecret != "invite-session" || updatedPassword != "this-is-strong-enough" {
 		t.Fatalf("updated = %q/%q", updatedSecret, updatedPassword)

--- a/server/cmd/server/auth_session_handler_test.go
+++ b/server/cmd/server/auth_session_handler_test.go
@@ -62,7 +62,7 @@ func TestHandleLoginCreatesSessionCookie(t *testing.T) {
 	form := url.Values{}
 	form.Set("email", "u1@example.com")
 	form.Set("password", "secure-password")
-	form.Set("next", "/w/workflow/")
+	form.Set("next", "/my/streams/workflow/")
 	req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
@@ -72,8 +72,8 @@ func TestHandleLoginCreatesSessionCookie(t *testing.T) {
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 	}
-	if rec.Header().Get("Location") != "/w/workflow/" {
-		t.Fatalf("location = %q, want /w/workflow/", rec.Header().Get("Location"))
+	if rec.Header().Get("Location") != "/my/streams/workflow/" {
+		t.Fatalf("location = %q, want /my/streams/workflow/", rec.Header().Get("Location"))
 	}
 	cookies := rec.Result().Cookies()
 	if len(cookies) == 0 || cookies[0].Name != "attesta_session" {

--- a/server/cmd/server/auth_session_handler_test.go
+++ b/server/cmd/server/auth_session_handler_test.go
@@ -29,7 +29,7 @@ func TestHandleHomeRedirectsToLoginWhenUnauthenticated(t *testing.T) {
 		tmpl:        testTemplates(),
 		enforceAuth: true,
 	}
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/my", nil)
 	rec := httptest.NewRecorder()
 
 	server.handleHome(rec, req)
@@ -38,8 +38,8 @@ func TestHandleHomeRedirectsToLoginWhenUnauthenticated(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 	}
 	location := rec.Header().Get("Location")
-	if location != "/login?next=%2F" {
-		t.Fatalf("location = %q, want /login?next=%%2F", location)
+	if location != "/login?next=%2Fmy" {
+		t.Fatalf("location = %q, want /login?next=%%2Fmy", location)
 	}
 }
 
@@ -284,8 +284,8 @@ func TestHandleLoginRedirectsAuthenticatedUserToHome(t *testing.T) {
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 	}
-	if rec.Header().Get("Location") != "/" {
-		t.Fatalf("location = %q, want /", rec.Header().Get("Location"))
+	if rec.Header().Get("Location") != "/my" {
+		t.Fatalf("location = %q, want /my", rec.Header().Get("Location"))
 	}
 }
 
@@ -508,8 +508,8 @@ func TestHandleSignupRedirectsAuthenticatedUser(t *testing.T) {
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 	}
-	if rec.Header().Get("Location") != "/" {
-		t.Fatalf("location = %q, want /", rec.Header().Get("Location"))
+	if rec.Header().Get("Location") != "/my" {
+		t.Fatalf("location = %q, want /my", rec.Header().Get("Location"))
 	}
 }
 
@@ -621,8 +621,8 @@ func TestHandleSignupCreatesSessionAndRedirectsByOrgMembership(t *testing.T) {
 		if rec.Code != http.StatusSeeOther {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 		}
-		if rec.Header().Get("Location") != "/" {
-			t.Fatalf("location = %q, want /", rec.Header().Get("Location"))
+		if rec.Header().Get("Location") != "/my" {
+			t.Fatalf("location = %q, want /my", rec.Header().Get("Location"))
 		}
 	})
 }

--- a/server/cmd/server/auth_session_handler_test.go
+++ b/server/cmd/server/auth_session_handler_test.go
@@ -219,7 +219,7 @@ func TestHandleLoginPageHidesAdminTopbarLinks(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
 	body := rec.Body.String()
-	if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, `href="/org-admin/profile"`) {
+	if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, `href="/my/organization/profile"`) {
 		t.Fatalf("expected login page without admin nav links, got %q", body)
 	}
 }
@@ -581,8 +581,8 @@ func TestHandleSignupCreatesSessionAndRedirectsByOrgMembership(t *testing.T) {
 		if rec.Code != http.StatusSeeOther {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 		}
-		if rec.Header().Get("Location") != "/org-admin/profile" {
-			t.Fatalf("location = %q, want /org-admin/profile", rec.Header().Get("Location"))
+		if rec.Header().Get("Location") != "/my/organization/profile" {
+			t.Fatalf("location = %q, want /my/organization/profile", rec.Header().Get("Location"))
 		}
 		if createdEmail != "new@example.com" || createdPassword != "secure-password" {
 			t.Fatalf("create account args = %q/%q", createdEmail, createdPassword)

--- a/server/cmd/server/auth_session_handler_test.go
+++ b/server/cmd/server/auth_session_handler_test.go
@@ -222,6 +222,9 @@ func TestHandleLoginPageHidesAdminTopbarLinks(t *testing.T) {
 	if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, `href="/my/organization/profile"`) {
 		t.Fatalf("expected login page without admin nav links, got %q", body)
 	}
+	if strings.Contains(body, `class="btn btn-ghost btn-lg nav-action"`) {
+		t.Fatalf("expected login page without Login topbar link, got %q", body)
+	}
 }
 
 func TestHandleLoginPageShowsSignupWhenEnabled(t *testing.T) {

--- a/server/cmd/server/breadcrumbs.go
+++ b/server/cmd/server/breadcrumbs.go
@@ -24,7 +24,7 @@ func buildOrgAdminBreadcrumbs(activePanel string) BreadcrumbsView {
 	section := strings.TrimSpace(activePanel)
 	return BreadcrumbsView{Items: []BreadcrumbItem{
 		{Label: "Streams", Href: "/"},
-		{Label: "Organization admin", Href: "/org-admin/profile"},
+		{Label: "Organization admin", Href: organizationPath("profile")},
 		{Label: orgAdminSectionLabel(section), Href: orgAdminSectionHref(section), Current: true},
 	}}
 }
@@ -64,10 +64,10 @@ func orgAdminSectionLabel(activePanel string) string {
 func orgAdminSectionHref(activePanel string) string {
 	switch strings.TrimSpace(activePanel) {
 	case "roles":
-		return "/org-admin/roles"
+		return organizationPath("roles")
 	case "members":
-		return "/org-admin/members"
+		return organizationPath("members")
 	default:
-		return "/org-admin/profile"
+		return organizationPath("profile")
 	}
 }

--- a/server/cmd/server/breadcrumbs.go
+++ b/server/cmd/server/breadcrumbs.go
@@ -5,8 +5,8 @@ import "strings"
 func buildStreamBreadcrumbs(workflowKey, workflowName string) BreadcrumbsView {
 	key := strings.TrimSpace(workflowKey)
 	return BreadcrumbsView{Items: []BreadcrumbItem{
-		{Label: "Streams", Href: "/"},
-		{Label: streamCrumbLabel(workflowName, key), Href: "/w/" + key + "/", Current: true},
+		{Label: "Streams", Href: appHomePath},
+		{Label: streamCrumbLabel(workflowName, key), Href: streamPath(key), Current: true},
 	}}
 }
 
@@ -14,24 +14,24 @@ func buildProcessBreadcrumbs(workflowKey, workflowName, instanceName, processID 
 	key := strings.TrimSpace(workflowKey)
 	id := strings.TrimSpace(processID)
 	return BreadcrumbsView{Items: []BreadcrumbItem{
-		{Label: "Streams", Href: "/"},
-		{Label: streamCrumbLabel(workflowName, key), Href: "/w/" + key + "/"},
-		{Label: processInstanceCrumbLabel(instanceName, id), Href: "/w/" + key + "/process/" + id, Current: true},
+		{Label: "Streams", Href: appHomePath},
+		{Label: streamCrumbLabel(workflowName, key), Href: streamPath(key)},
+		{Label: processInstanceCrumbLabel(instanceName, id), Href: streamInstancePath(key, id), Current: true},
 	}}
 }
 
 func buildOrgAdminBreadcrumbs(activePanel string) BreadcrumbsView {
 	section := strings.TrimSpace(activePanel)
 	return BreadcrumbsView{Items: []BreadcrumbItem{
-		{Label: "Streams", Href: "/"},
+		{Label: "Streams", Href: appHomePath},
 		{Label: "Organization admin", Href: organizationPath("profile")},
-		{Label: orgAdminSectionLabel(section), Href: orgAdminSectionHref(section), Current: true},
+		{Label: orgAdminSectionLabel(section), Href: organizationPath(orgAdminSectionRest(section)), Current: true},
 	}}
 }
 
 func buildPlatformAdminBreadcrumbs() BreadcrumbsView {
 	return BreadcrumbsView{Items: []BreadcrumbItem{
-		{Label: "Streams", Href: "/"},
+		{Label: "Streams", Href: appHomePath},
 		{Label: "Platform admin", Href: "/admin/orgs", Current: true},
 	}}
 }
@@ -61,13 +61,17 @@ func orgAdminSectionLabel(activePanel string) string {
 	}
 }
 
-func orgAdminSectionHref(activePanel string) string {
+func orgAdminSectionRest(activePanel string) string {
 	switch strings.TrimSpace(activePanel) {
 	case "roles":
-		return organizationPath("roles")
+		return "roles"
 	case "members":
-		return organizationPath("members")
+		return "members"
 	default:
-		return organizationPath("profile")
+		return "profile"
 	}
+}
+
+func orgAdminSectionHref(activePanel string) string {
+	return organizationPath(orgAdminSectionRest(activePanel))
 }

--- a/server/cmd/server/breadcrumbs.go
+++ b/server/cmd/server/breadcrumbs.go
@@ -5,7 +5,7 @@ import "strings"
 func buildStreamBreadcrumbs(workflowKey, workflowName string) BreadcrumbsView {
 	key := strings.TrimSpace(workflowKey)
 	return BreadcrumbsView{Items: []BreadcrumbItem{
-		{Label: "Streams", Href: appHomePath},
+		{Label: "Dashboard", Href: appHomePath},
 		{Label: streamCrumbLabel(workflowName, key), Href: streamPath(key), Current: true},
 	}}
 }
@@ -14,7 +14,7 @@ func buildProcessBreadcrumbs(workflowKey, workflowName, instanceName, processID 
 	key := strings.TrimSpace(workflowKey)
 	id := strings.TrimSpace(processID)
 	return BreadcrumbsView{Items: []BreadcrumbItem{
-		{Label: "Streams", Href: appHomePath},
+		{Label: "Dashboard", Href: appHomePath},
 		{Label: streamCrumbLabel(workflowName, key), Href: streamPath(key)},
 		{Label: processInstanceCrumbLabel(instanceName, id), Href: streamInstancePath(key, id), Current: true},
 	}}
@@ -23,7 +23,7 @@ func buildProcessBreadcrumbs(workflowKey, workflowName, instanceName, processID 
 func buildOrgAdminBreadcrumbs(activePanel string) BreadcrumbsView {
 	section := strings.TrimSpace(activePanel)
 	return BreadcrumbsView{Items: []BreadcrumbItem{
-		{Label: "Streams", Href: appHomePath},
+		{Label: "Dashboard", Href: appHomePath},
 		{Label: "Organization admin", Href: organizationPath("profile")},
 		{Label: orgAdminSectionLabel(section), Href: organizationPath(orgAdminSectionRest(section)), Current: true},
 	}}
@@ -31,16 +31,16 @@ func buildOrgAdminBreadcrumbs(activePanel string) BreadcrumbsView {
 
 func buildPlatformAdminBreadcrumbs() BreadcrumbsView {
 	return BreadcrumbsView{Items: []BreadcrumbItem{
-		{Label: "Streams", Href: appHomePath},
+		{Label: "Dashboard", Href: appHomePath},
 		{Label: "Platform admin", Href: "/admin/orgs", Current: true},
 	}}
 }
 
 func streamCrumbLabel(workflowName, workflowKey string) string {
 	if name := strings.TrimSpace(workflowName); name != "" {
-		return name
+		return "Stream: " + name
 	}
-	return strings.TrimSpace(workflowKey)
+	return "Stream: " + strings.TrimSpace(workflowKey)
 }
 
 func processInstanceCrumbLabel(instanceName, processID string) string {

--- a/server/cmd/server/breadcrumbs.go
+++ b/server/cmd/server/breadcrumbs.go
@@ -25,7 +25,7 @@ func buildOrgAdminBreadcrumbs(activePanel string) BreadcrumbsView {
 	return BreadcrumbsView{Items: []BreadcrumbItem{
 		{Label: "Dashboard", Href: appHomePath},
 		{Label: "Organization admin", Href: organizationPath("profile")},
-		{Label: orgAdminSectionLabel(section), Href: organizationPath(orgAdminSectionRest(section)), Current: true},
+		{Label: orgAdminSectionLabel(section), Href: orgAdminSectionHref(section), Current: true},
 	}}
 }
 

--- a/server/cmd/server/breadcrumbs_template_test.go
+++ b/server/cmd/server/breadcrumbs_template_test.go
@@ -11,9 +11,9 @@ func TestBreadcrumbsTemplateRendersLinksAndCurrent(t *testing.T) {
 
 	var out bytes.Buffer
 	view := BreadcrumbsView{Items: []BreadcrumbItem{
-		{Label: "Streams", Href: "/"},
-		{Label: "Alpha", Href: "/w/alpha/"},
-		{Label: "Instance: Batch 1", Href: "/w/alpha/process/abc123", Current: true},
+		{Label: "Streams", Href: appHomePath},
+		{Label: "Alpha", Href: streamPath("alpha")},
+		{Label: "Instance: Batch 1", Href: streamInstancePath("alpha", "abc123"), Current: true},
 	}}
 	if err := tmpl.ExecuteTemplate(&out, "breadcrumbs", view); err != nil {
 		t.Fatalf("render breadcrumbs: %v", err)
@@ -22,11 +22,11 @@ func TestBreadcrumbsTemplateRendersLinksAndCurrent(t *testing.T) {
 	for _, want := range []string{
 		`aria-label="Breadcrumb"`,
 		`class="breadcrumbs"`,
-		`href="/"`,
+		`href="/my"`,
 		">Streams<",
-		`href="/w/alpha/"`,
+		`href="/my/streams/alpha"`,
 		">Alpha<",
-		`href="/w/alpha/process/abc123"`,
+		`href="/my/streams/alpha/instance/abc123"`,
 		`aria-current="page"`,
 		"Instance: Batch 1",
 	} {
@@ -77,7 +77,7 @@ func TestProcessPageHeaderRendersBreadcrumbs(t *testing.T) {
 		">Streams<",
 		">Alpha Stream<",
 		"Instance: Batch 1",
-		`href="/w/wf-a/process/abc123"`,
+		`href="/my/streams/wf-a/instance/abc123"`,
 		`aria-current="page"`,
 	} {
 		if !strings.Contains(body, want) {

--- a/server/cmd/server/breadcrumbs_template_test.go
+++ b/server/cmd/server/breadcrumbs_template_test.go
@@ -11,8 +11,8 @@ func TestBreadcrumbsTemplateRendersLinksAndCurrent(t *testing.T) {
 
 	var out bytes.Buffer
 	view := BreadcrumbsView{Items: []BreadcrumbItem{
-		{Label: "Streams", Href: appHomePath},
-		{Label: "Alpha", Href: streamPath("alpha")},
+		{Label: "Dashboard", Href: appHomePath},
+		{Label: "Stream: Alpha", Href: streamPath("alpha")},
 		{Label: "Instance: Batch 1", Href: streamInstancePath("alpha", "abc123"), Current: true},
 	}}
 	if err := tmpl.ExecuteTemplate(&out, "breadcrumbs", view); err != nil {
@@ -23,9 +23,9 @@ func TestBreadcrumbsTemplateRendersLinksAndCurrent(t *testing.T) {
 		`aria-label="Breadcrumb"`,
 		`class="breadcrumbs"`,
 		`href="/my"`,
-		">Streams<",
+		">Dashboard<",
 		`href="/my/streams/alpha"`,
-		">Alpha<",
+		">Stream: Alpha<",
 		`href="/my/streams/alpha/instance/abc123"`,
 		`aria-current="page"`,
 		"Instance: Batch 1",
@@ -74,8 +74,8 @@ func TestProcessPageHeaderRendersBreadcrumbs(t *testing.T) {
 	body := out.String()
 	for _, want := range []string{
 		`class="breadcrumbs"`,
-		">Streams<",
-		">Alpha Stream<",
+		">Dashboard<",
+		">Stream: Alpha Stream<",
 		"Instance: Batch 1",
 		`href="/my/streams/wf-a/instance/abc123"`,
 		`aria-current="page"`,

--- a/server/cmd/server/breadcrumbs_test.go
+++ b/server/cmd/server/breadcrumbs_test.go
@@ -9,18 +9,18 @@ func TestBuildStreamBreadcrumbs(t *testing.T) {
 	if len(got.Items) != 2 {
 		t.Fatalf("len(Items) = %d, want 2", len(got.Items))
 	}
-	if got.Items[0].Label != "Streams" || got.Items[0].Href != appHomePath {
+	if got.Items[0].Label != "Dashboard" || got.Items[0].Href != appHomePath {
 		t.Fatalf("root = %+v", got.Items[0])
 	}
-	if got.Items[1].Label != "Alpha Stream" || got.Items[1].Href != streamPath("wf-a") || !got.Items[1].Current {
+	if got.Items[1].Label != "Stream: Alpha Stream" || got.Items[1].Href != streamPath("wf-a") || !got.Items[1].Current {
 		t.Fatalf("current = %+v", got.Items[1])
 	}
 }
 
 func TestBuildStreamBreadcrumbsFallsBackToKey(t *testing.T) {
 	got := buildStreamBreadcrumbs("wf-a", "  ")
-	if got.Items[1].Label != "wf-a" {
-		t.Fatalf("label = %q, want workflow key", got.Items[1].Label)
+	if got.Items[1].Label != "Stream: wf-a" {
+		t.Fatalf("label = %q, want Stream: workflow key", got.Items[1].Label)
 	}
 }
 
@@ -29,7 +29,10 @@ func TestBuildProcessBreadcrumbsUsesInstanceName(t *testing.T) {
 	if len(got.Items) != 3 {
 		t.Fatalf("len(Items) = %d, want 3", len(got.Items))
 	}
-	if got.Items[1].Label != "Alpha Stream" || got.Items[1].Href != streamPath("wf-a") {
+	if got.Items[0].Label != "Dashboard" || got.Items[0].Href != appHomePath {
+		t.Fatalf("root = %+v", got.Items[0])
+	}
+	if got.Items[1].Label != "Stream: Alpha Stream" || got.Items[1].Href != streamPath("wf-a") {
 		t.Fatalf("stream crumb = %+v", got.Items[1])
 	}
 	if got.Items[2].Label != "Instance: Batch 1" || got.Items[2].Href != streamInstancePath("wf-a", "abc123") || !got.Items[2].Current {
@@ -49,7 +52,7 @@ func TestBuildOrgAdminBreadcrumbs(t *testing.T) {
 	if len(got.Items) != 3 {
 		t.Fatalf("len(Items) = %d, want 3", len(got.Items))
 	}
-	if got.Items[0].Label != "Streams" || got.Items[0].Href != appHomePath {
+	if got.Items[0].Label != "Dashboard" || got.Items[0].Href != appHomePath {
 		t.Fatalf("root = %+v", got.Items[0])
 	}
 	if got.Items[1].Label != "Organization admin" || got.Items[1].Href != organizationPath("profile") {
@@ -84,7 +87,7 @@ func TestBuildPlatformAdminBreadcrumbs(t *testing.T) {
 	if len(got.Items) != 2 {
 		t.Fatalf("len(Items) = %d, want 2", len(got.Items))
 	}
-	if got.Items[0].Label != "Streams" || got.Items[0].Href != appHomePath {
+	if got.Items[0].Label != "Dashboard" || got.Items[0].Href != appHomePath {
 		t.Fatalf("root = %+v", got.Items[0])
 	}
 	if got.Items[1].Label != "Platform admin" || got.Items[1].Href != "/admin/orgs" || !got.Items[1].Current {

--- a/server/cmd/server/breadcrumbs_test.go
+++ b/server/cmd/server/breadcrumbs_test.go
@@ -79,6 +79,9 @@ func TestBuildOrgAdminBreadcrumbsSections(t *testing.T) {
 		if got.Items[2].Label != want.label || got.Items[2].Href != want.href {
 			t.Fatalf("panel %q: got %+v, want label=%q href=%q", panel, got.Items[2], want.label, want.href)
 		}
+		if href := orgAdminSectionHref(panel); href != want.href {
+			t.Fatalf("orgAdminSectionHref(%q) = %q, want %q", panel, href, want.href)
+		}
 	}
 }
 

--- a/server/cmd/server/breadcrumbs_test.go
+++ b/server/cmd/server/breadcrumbs_test.go
@@ -9,10 +9,10 @@ func TestBuildStreamBreadcrumbs(t *testing.T) {
 	if len(got.Items) != 2 {
 		t.Fatalf("len(Items) = %d, want 2", len(got.Items))
 	}
-	if got.Items[0].Label != "Streams" || got.Items[0].Href != "/" {
+	if got.Items[0].Label != "Streams" || got.Items[0].Href != appHomePath {
 		t.Fatalf("root = %+v", got.Items[0])
 	}
-	if got.Items[1].Label != "Alpha Stream" || got.Items[1].Href != "/w/wf-a/" || !got.Items[1].Current {
+	if got.Items[1].Label != "Alpha Stream" || got.Items[1].Href != streamPath("wf-a") || !got.Items[1].Current {
 		t.Fatalf("current = %+v", got.Items[1])
 	}
 }
@@ -29,10 +29,10 @@ func TestBuildProcessBreadcrumbsUsesInstanceName(t *testing.T) {
 	if len(got.Items) != 3 {
 		t.Fatalf("len(Items) = %d, want 3", len(got.Items))
 	}
-	if got.Items[1].Label != "Alpha Stream" || got.Items[1].Href != "/w/wf-a/" {
+	if got.Items[1].Label != "Alpha Stream" || got.Items[1].Href != streamPath("wf-a") {
 		t.Fatalf("stream crumb = %+v", got.Items[1])
 	}
-	if got.Items[2].Label != "Instance: Batch 1" || got.Items[2].Href != "/w/wf-a/process/abc123" || !got.Items[2].Current {
+	if got.Items[2].Label != "Instance: Batch 1" || got.Items[2].Href != streamInstancePath("wf-a", "abc123") || !got.Items[2].Current {
 		t.Fatalf("instance crumb = %+v", got.Items[2])
 	}
 }
@@ -49,10 +49,13 @@ func TestBuildOrgAdminBreadcrumbs(t *testing.T) {
 	if len(got.Items) != 3 {
 		t.Fatalf("len(Items) = %d, want 3", len(got.Items))
 	}
-	if got.Items[1].Label != "Organization admin" || got.Items[1].Href != "/my/organization/profile" {
+	if got.Items[0].Label != "Streams" || got.Items[0].Href != appHomePath {
+		t.Fatalf("root = %+v", got.Items[0])
+	}
+	if got.Items[1].Label != "Organization admin" || got.Items[1].Href != organizationPath("profile") {
 		t.Fatalf("middle = %+v", got.Items[1])
 	}
-	if got.Items[2].Label != "Members" || got.Items[2].Href != "/my/organization/members" || !got.Items[2].Current {
+	if got.Items[2].Label != "Members" || got.Items[2].Href != organizationPath("members") || !got.Items[2].Current {
 		t.Fatalf("section = %+v", got.Items[2])
 	}
 }
@@ -80,6 +83,9 @@ func TestBuildPlatformAdminBreadcrumbs(t *testing.T) {
 	got := buildPlatformAdminBreadcrumbs()
 	if len(got.Items) != 2 {
 		t.Fatalf("len(Items) = %d, want 2", len(got.Items))
+	}
+	if got.Items[0].Label != "Streams" || got.Items[0].Href != appHomePath {
+		t.Fatalf("root = %+v", got.Items[0])
 	}
 	if got.Items[1].Label != "Platform admin" || got.Items[1].Href != "/admin/orgs" || !got.Items[1].Current {
 		t.Fatalf("current = %+v", got.Items[1])

--- a/server/cmd/server/breadcrumbs_test.go
+++ b/server/cmd/server/breadcrumbs_test.go
@@ -49,10 +49,10 @@ func TestBuildOrgAdminBreadcrumbs(t *testing.T) {
 	if len(got.Items) != 3 {
 		t.Fatalf("len(Items) = %d, want 3", len(got.Items))
 	}
-	if got.Items[1].Label != "Organization admin" || got.Items[1].Href != "/org-admin/profile" {
+	if got.Items[1].Label != "Organization admin" || got.Items[1].Href != "/my/organization/profile" {
 		t.Fatalf("middle = %+v", got.Items[1])
 	}
-	if got.Items[2].Label != "Members" || got.Items[2].Href != "/org-admin/members" || !got.Items[2].Current {
+	if got.Items[2].Label != "Members" || got.Items[2].Href != "/my/organization/members" || !got.Items[2].Current {
 		t.Fatalf("section = %+v", got.Items[2])
 	}
 }
@@ -62,11 +62,11 @@ func TestBuildOrgAdminBreadcrumbsSections(t *testing.T) {
 		label string
 		href  string
 	}{
-		"profile": {label: "Profile", href: "/org-admin/profile"},
-		"roles":   {label: "Roles", href: "/org-admin/roles"},
-		"members": {label: "Members", href: "/org-admin/members"},
-		"":        {label: "Profile", href: "/org-admin/profile"},
-		"other":   {label: "Profile", href: "/org-admin/profile"},
+		"profile": {label: "Profile", href: "/my/organization/profile"},
+		"roles":   {label: "Roles", href: "/my/organization/roles"},
+		"members": {label: "Members", href: "/my/organization/members"},
+		"":        {label: "Profile", href: "/my/organization/profile"},
+		"other":   {label: "Profile", href: "/my/organization/profile"},
 	}
 	for panel, want := range cases {
 		got := buildOrgAdminBreadcrumbs(panel)

--- a/server/cmd/server/complete_role_selection_test.go
+++ b/server/cmd/server/complete_role_selection_test.go
@@ -55,7 +55,7 @@ func TestHandleCompleteSubstepUsesSelectedActiveRole(t *testing.T) {
 		configProvider: func() (RuntimeConfig, error) { return testFormataRuntimeConfig(), nil },
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/w/workflow/process/"+process.ID.Hex()+"/substep/2.1/complete", strings.NewReader("value=%7B%22status%22%3A%22ok%22%7D&activeRole=dep2"))
+	req := httptest.NewRequest(http.MethodPost, "/process/"+process.ID.Hex()+"/substep/2.1/complete", strings.NewReader("value=%7B%22status%22%3A%22ok%22%7D&activeRole=dep2"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("HX-Request", "true")
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: sessionID})
@@ -117,7 +117,7 @@ func TestHandleCompleteSubstepRejectsInvalidActiveRole(t *testing.T) {
 		},
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/w/workflow/process/"+process.ID.Hex()+"/substep/2.1/complete", strings.NewReader("value=%7B%22status%22%3A%22ok%22%7D&activeRole=dep3"))
+	req := httptest.NewRequest(http.MethodPost, "/process/"+process.ID.Hex()+"/substep/2.1/complete", strings.NewReader("value=%7B%22status%22%3A%22ok%22%7D&activeRole=dep3"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("HX-Request", "true")
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: sessionID})

--- a/server/cmd/server/dialog_markup_test.go
+++ b/server/cmd/server/dialog_markup_test.go
@@ -13,7 +13,7 @@ func TestStreamPageNewInstanceDialogMarkup(t *testing.T) {
 	view := HomeView{
 		PageBase: PageBase{
 			WorkflowKey:  "workflow",
-			WorkflowPath: "/w/workflow",
+			WorkflowPath: "/my/streams/workflow",
 			WorkflowName: "Demo workflow",
 		},
 		StatusFilter:  "all",
@@ -114,14 +114,14 @@ func TestProcessTerminateDialogMarkup(t *testing.T) {
 	view := ProcessPageView{
 		PageBase: PageBase{
 			WorkflowKey:  "workflow",
-			WorkflowPath: "/w/workflow",
+			WorkflowPath: "/my/streams/workflow",
 		},
 		ProcessID: "process-1",
 		Detail: StreamInstanceDetailView{
 			WorkflowKey:      "workflow",
 			ProcessID:        "process-1",
 			CanTerminate:     true,
-			TerminateAction:  "/w/workflow/process/process-1/terminate",
+			TerminateAction:  "/my/streams/workflow/instance/process-1/terminate",
 			TerminateSubstep: "2.1",
 		},
 	}
@@ -150,7 +150,7 @@ func TestProcessTerminateDialogMarkup(t *testing.T) {
 		"Danger zone - End stream early",
 		"Available substep",
 		"2.1",
-		`action="/w/workflow/process/process-1/terminate"`,
+		`action="/my/streams/workflow/instance/process-1/terminate"`,
 	} {
 		if !strings.Contains(dialog, want) {
 			t.Fatalf("expected %q in terminate-process dialog markup, got:\n%s", want, dialog)
@@ -175,7 +175,7 @@ func TestStreamPreviewDialogPageScopedMarkup(t *testing.T) {
 	view := HomeView{
 		PageBase: PageBase{
 			WorkflowKey:  "workflow",
-			WorkflowPath: "/w/workflow",
+			WorkflowPath: "/my/streams/workflow",
 			WorkflowName: "Demo workflow",
 		},
 		StatusFilter:  "all",

--- a/server/cmd/server/download_handler_test.go
+++ b/server/cmd/server/download_handler_test.go
@@ -45,7 +45,7 @@ func TestHandleDownloadProcessAttachmentAllowsAnonymousAccess(t *testing.T) {
 		},
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/process/"+processID.Hex()+"/attachment/"+attachment.ID.Hex()+"/file", nil)
+	req := httptest.NewRequest(http.MethodGet, "/instance/"+processID.Hex()+"/attachment/"+attachment.ID.Hex()+"/file", nil)
 	rr := httptest.NewRecorder()
 	server.handleProcessRoutes(rr, req)
 
@@ -96,7 +96,7 @@ func TestHandleDownloadProcessAttachmentReturns404ForProcessMismatch(t *testing.
 		},
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/process/"+processID.Hex()+"/attachment/"+attachment.ID.Hex()+"/file", nil)
+	req := httptest.NewRequest(http.MethodGet, "/instance/"+processID.Hex()+"/attachment/"+attachment.ID.Hex()+"/file", nil)
 	rr := httptest.NewRecorder()
 	server.handleProcessRoutes(rr, req)
 
@@ -138,7 +138,7 @@ func TestHandleDownloadProcessAttachmentSupportsInlinePreview(t *testing.T) {
 		},
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/process/"+processID.Hex()+"/attachment/"+attachment.ID.Hex()+"/file?inline=1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/instance/"+processID.Hex()+"/attachment/"+attachment.ID.Hex()+"/file?inline=1", nil)
 	rr := httptest.NewRecorder()
 	server.handleProcessRoutes(rr, req)
 

--- a/server/cmd/server/dpp_helpers_test.go
+++ b/server/cmd/server/dpp_helpers_test.go
@@ -450,8 +450,8 @@ func TestPublicDPPTraceabilityAttachmentURLs(t *testing.T) {
 				{
 					Body: &SubstepBodyView{
 						Attachments: []SubstepAttachmentView{
-							{AttachmentID: "file 1", URL: "/w/workflow/process/p1/attachment/file%201/file", PreviewKind: "document"},
-							{Filename: "legacy.pdf", URL: "/w/workflow/process/p1/attachment/legacy/file"},
+							{AttachmentID: "file 1", URL: "/my/streams/workflow/instance/p1/attachment/file%201/file", PreviewKind: "document"},
+							{Filename: "legacy.pdf", URL: "/my/streams/workflow/instance/p1/attachment/legacy/file"},
 						},
 					},
 				},
@@ -467,7 +467,7 @@ func TestPublicDPPTraceabilityAttachmentURLs(t *testing.T) {
 	if attachment.PreviewURL != attachment.URL+"?inline=1#page=1&toolbar=0&navpanes=0&view=FitH" {
 		t.Fatalf("preview URL = %q", attachment.PreviewURL)
 	}
-	if got := mapped[0].Substeps[0].Body.Attachments[1].URL; got != "/w/workflow/process/p1/attachment/legacy/file" {
+	if got := mapped[0].Substeps[0].Body.Attachments[1].URL; got != "/my/streams/workflow/instance/p1/attachment/legacy/file" {
 		t.Fatalf("attachment without ID URL changed to %q", got)
 	}
 
@@ -477,14 +477,14 @@ func TestPublicDPPTraceabilityAttachmentURLs(t *testing.T) {
 				{
 					Body: &SubstepBodyView{
 						Attachments: []SubstepAttachmentView{
-							{AttachmentID: "file 1", URL: "/w/workflow/process/p1/attachment/file%201/file", PreviewKind: "document"},
+							{AttachmentID: "file 1", URL: "/my/streams/workflow/instance/p1/attachment/file%201/file", PreviewKind: "document"},
 						},
 					},
 				},
 			},
 		},
 	}, " ")
-	if unchanged[0].Substeps[0].Body.Attachments[0].URL != "/w/workflow/process/p1/attachment/file%201/file" {
+	if unchanged[0].Substeps[0].Body.Attachments[0].URL != "/my/streams/workflow/instance/p1/attachment/file%201/file" {
 		t.Fatalf("blank digital link changed URL to %q", unchanged[0].Substeps[0].Body.Attachments[0].URL)
 	}
 }

--- a/server/cmd/server/formata_builder.go
+++ b/server/cmd/server/formata_builder.go
@@ -480,6 +480,7 @@ func (s *Server) serveEmbeddedFormataBuilder(w http.ResponseWriter, r *http.Requ
 	}
 	if shouldRewriteFormataAssetContent(cleaned, contentType) {
 		data = bytes.ReplaceAll(data, []byte("/formata-arch/"), []byte(mountPath+"/"))
+		data = bytes.ReplaceAll(data, []byte("/org-admin/formata-builder"), []byte(mountPath))
 		if injectOverrides && (strings.HasPrefix(strings.ToLower(strings.TrimSpace(contentType)), "text/html") || strings.EqualFold(path.Ext(cleaned), ".html")) {
 			data = injectFormataBuilderOverrides(data)
 		}

--- a/server/cmd/server/formata_builder.go
+++ b/server/cmd/server/formata_builder.go
@@ -249,8 +249,9 @@ func formataBuilderStreamMaxBytes() int64 {
 
 func (s *Server) handleOrgAdminFormataBuilder(w http.ResponseWriter, r *http.Request) {
 	pathValue := strings.TrimSpace(r.URL.Path)
-	isRootPath := pathValue == "/org-admin/formata-builder" || pathValue == "/org-admin/formata-builder/"
-	streamPath, isStreamPath := strings.CutPrefix(pathValue, "/org-admin/formata-builder/stream/")
+	builderPath := organizationPath("formata-builder")
+	isRootPath := pathValue == builderPath || pathValue == builderPath+"/"
+	streamPath, isStreamPath := strings.CutPrefix(pathValue, builderPath+"/stream/")
 
 	switch r.Method {
 	case http.MethodGet:
@@ -271,7 +272,7 @@ func (s *Server) handleOrgAdminFormataBuilder(w http.ResponseWriter, r *http.Req
 			s.handleOrgAdminFormataBuilderStream(w, r, strings.TrimSpace(streamPath), user)
 			return
 		}
-		s.serveEmbeddedFormataBuilder(w, r, "/org-admin/formata-builder", isRootPath, true)
+		s.serveEmbeddedFormataBuilder(w, r, builderPath, isRootPath, true)
 		return
 	case http.MethodPost:
 		if !isRootPath {

--- a/server/cmd/server/formata_builder_handler_test.go
+++ b/server/cmd/server/formata_builder_handler_test.go
@@ -41,7 +41,7 @@ func TestHandleOrgAdminFormataBuilderGet(t *testing.T) {
 	}
 
 	t.Run("unauthenticated redirects to login", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/formata-builder", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/organization/formata-builder", nil)
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
 		if rec.Code != http.StatusSeeOther {
@@ -50,7 +50,7 @@ func TestHandleOrgAdminFormataBuilderGet(t *testing.T) {
 	})
 
 	t.Run("org admin can load builder", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/formata-builder", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/organization/formata-builder", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -61,7 +61,7 @@ func TestHandleOrgAdminFormataBuilderGet(t *testing.T) {
 		if !strings.Contains(strings.ToLower(body), "<!doctype html>") {
 			t.Fatalf("expected html response body, got %q", body)
 		}
-		if !strings.Contains(body, "/org-admin/formata-builder/assets/") {
+		if !strings.Contains(body, "/my/organization/formata-builder/assets/") {
 			t.Fatalf("expected rewritten asset prefix in html, got %q", body)
 		}
 		if !strings.Contains(body, "data-attesta-formata-builder-overrides") {
@@ -73,7 +73,7 @@ func TestHandleOrgAdminFormataBuilderGet(t *testing.T) {
 	})
 
 	t.Run("org admin can load nested route fallback", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/formata-builder/editor/home", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/organization/formata-builder/editor/home", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -84,7 +84,7 @@ func TestHandleOrgAdminFormataBuilderGet(t *testing.T) {
 		if !strings.Contains(strings.ToLower(body), "<!doctype html>") {
 			t.Fatalf("expected html fallback body, got %q", body)
 		}
-		if !strings.Contains(body, "/org-admin/formata-builder/assets/") {
+		if !strings.Contains(body, "/my/organization/formata-builder/assets/") {
 			t.Fatalf("expected rewritten asset prefix in fallback html, got %q", body)
 		}
 		if !strings.Contains(body, "data-attesta-formata-builder-overrides") {
@@ -93,7 +93,7 @@ func TestHandleOrgAdminFormataBuilderGet(t *testing.T) {
 	})
 
 	t.Run("missing static asset returns not found", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/formata-builder/assets/app.js", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/organization/formata-builder/assets/app.js", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -103,7 +103,7 @@ func TestHandleOrgAdminFormataBuilderGet(t *testing.T) {
 	})
 
 	t.Run("public icon asset is served", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/formata-builder/vite.svg", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/organization/formata-builder/vite.svg", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -116,14 +116,14 @@ func TestHandleOrgAdminFormataBuilderGet(t *testing.T) {
 	})
 
 	t.Run("js assets are rewritten from legacy absolute prefix", func(t *testing.T) {
-		indexReq := httptest.NewRequest(http.MethodGet, "/org-admin/formata-builder", nil)
+		indexReq := httptest.NewRequest(http.MethodGet, "/my/organization/formata-builder", nil)
 		indexReq.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		indexRec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(indexRec, indexReq)
 		if indexRec.Code != http.StatusOK {
 			t.Fatalf("index status = %d, want %d", indexRec.Code, http.StatusOK)
 		}
-		jsPath := findFirstBuilderAssetPath(t, indexRec.Body.String(), `src="(/org-admin/formata-builder/assets/[^"]+\.js)"`)
+		jsPath := findFirstBuilderAssetPath(t, indexRec.Body.String(), `src="(/my/organization/formata-builder/assets/[^"]+\.js)"`)
 
 		req := httptest.NewRequest(http.MethodGet, jsPath, nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
@@ -136,7 +136,7 @@ func TestHandleOrgAdminFormataBuilderGet(t *testing.T) {
 		if strings.Contains(body, "/formata-arch/") {
 			t.Fatalf("expected rewritten js body, still contains legacy prefix")
 		}
-		if !strings.Contains(body, "/org-admin/formata-builder/") {
+		if !strings.Contains(body, "/my/organization/formata-builder/") {
 			t.Fatalf("expected rewritten js body to contain org-admin prefix")
 		}
 		if !strings.Contains(rec.Header().Get("Content-Type"), "javascript") {
@@ -145,14 +145,14 @@ func TestHandleOrgAdminFormataBuilderGet(t *testing.T) {
 	})
 
 	t.Run("css assets are served with stylesheet content type", func(t *testing.T) {
-		indexReq := httptest.NewRequest(http.MethodGet, "/org-admin/formata-builder", nil)
+		indexReq := httptest.NewRequest(http.MethodGet, "/my/organization/formata-builder", nil)
 		indexReq.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		indexRec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(indexRec, indexReq)
 		if indexRec.Code != http.StatusOK {
 			t.Fatalf("index status = %d, want %d", indexRec.Code, http.StatusOK)
 		}
-		cssPath := findFirstBuilderAssetPath(t, indexRec.Body.String(), `href="(/org-admin/formata-builder/assets/[^"]+\.css)"`)
+		cssPath := findFirstBuilderAssetPath(t, indexRec.Body.String(), `href="(/my/organization/formata-builder/assets/[^"]+\.css)"`)
 
 		req := httptest.NewRequest(http.MethodGet, cssPath, nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
@@ -167,7 +167,7 @@ func TestHandleOrgAdminFormataBuilderGet(t *testing.T) {
 	})
 
 	t.Run("method not allowed", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPut, "/org-admin/formata-builder", nil)
+		req := httptest.NewRequest(http.MethodPut, "/my/organization/formata-builder", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -187,7 +187,7 @@ func TestHandleOrgAdminFormataBuilderGet(t *testing.T) {
 			t.Fatalf("SaveFormataBuilderStream error: %v", err)
 		}
 
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/formata-builder/stream/"+saved.ID.Hex(), nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/organization/formata-builder/stream/"+saved.ID.Hex(), nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -233,7 +233,7 @@ func TestHandleOrgAdminFormataBuilderGet(t *testing.T) {
 			Progress:    map[string]ProcessStep{},
 		})
 
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/formata-builder/stream/"+saved.ID.Hex(), nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/organization/formata-builder/stream/"+saved.ID.Hex(), nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -272,7 +272,7 @@ func TestHandleOrgAdminFormataBuilderGet(t *testing.T) {
 			Progress:    map[string]ProcessStep{"1_1": {State: "done"}},
 		})
 
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/formata-builder/stream/"+saved.ID.Hex(), nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/organization/formata-builder/stream/"+saved.ID.Hex(), nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -294,7 +294,7 @@ func TestHandleOrgAdminFormataBuilderGet(t *testing.T) {
 	})
 
 	t.Run("stream json rejects invalid id", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/formata-builder/stream/bad-id", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/organization/formata-builder/stream/bad-id", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -304,7 +304,7 @@ func TestHandleOrgAdminFormataBuilderGet(t *testing.T) {
 	})
 
 	t.Run("stream json returns not found for unknown stream", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/formata-builder/stream/"+primitive.NewObjectID().Hex(), nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/organization/formata-builder/stream/"+primitive.NewObjectID().Hex(), nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -324,7 +324,7 @@ func TestHandleOrgAdminFormataBuilderGet(t *testing.T) {
 			t.Fatalf("SaveFormataBuilderStream error: %v", err)
 		}
 
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/formata-builder/stream/"+saved.ID.Hex(), nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/organization/formata-builder/stream/"+saved.ID.Hex(), nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -341,7 +341,7 @@ func TestHandleOrgAdminFormataBuilderGet(t *testing.T) {
 			now:         time.Now,
 		}
 
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/formata-builder/stream/"+primitive.NewObjectID().Hex(), nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/organization/formata-builder/stream/"+primitive.NewObjectID().Hex(), nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		serverWithoutStore.handleOrgAdminFormataBuilder(rec, req)
@@ -389,7 +389,7 @@ func TestHandleEmbeddedFormataArchAuthenticatedUser(t *testing.T) {
 		if !strings.Contains(body, "/formata-arch/assets/") {
 			t.Fatalf("expected same-origin formata-arch asset prefix, got %q", body)
 		}
-		if strings.Contains(body, "/org-admin/formata-builder/assets/") {
+		if strings.Contains(body, "/my/organization/formata-builder/assets/") {
 			t.Fatalf("did not expect org-admin asset prefix, got %q", body)
 		}
 		if !strings.Contains(body, "data-attesta-formata-builder-overrides") {
@@ -444,7 +444,7 @@ func TestHandleOrgAdminFormataBuilderPost(t *testing.T) {
 	}
 
 	t.Run("unauthenticated is unauthorized", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/formata-builder", strings.NewReader("stream"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/formata-builder", strings.NewReader("stream"))
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
 		if rec.Code != http.StatusUnauthorized {
@@ -453,7 +453,7 @@ func TestHandleOrgAdminFormataBuilderPost(t *testing.T) {
 	})
 
 	t.Run("forbidden for non admin role", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/formata-builder", strings.NewReader("stream"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/formata-builder", strings.NewReader("stream"))
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-plain"})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -463,7 +463,7 @@ func TestHandleOrgAdminFormataBuilderPost(t *testing.T) {
 	})
 
 	t.Run("org admin can save stream", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/formata-builder", strings.NewReader(`{"nodes":[]}`))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/formata-builder", strings.NewReader(`{"nodes":[]}`))
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -497,7 +497,7 @@ func TestHandleOrgAdminFormataBuilderPost(t *testing.T) {
 			t.Fatalf("SaveFormataBuilderStream error: %v", err)
 		}
 
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/formata-builder?stream="+saved.ID.Hex(), strings.NewReader(workflowStreamYAML("Updated stream")))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/formata-builder?stream="+saved.ID.Hex(), strings.NewReader(workflowStreamYAML("Updated stream")))
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -532,7 +532,7 @@ func TestHandleOrgAdminFormataBuilderPost(t *testing.T) {
 			Progress:    map[string]ProcessStep{},
 		})
 
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/formata-builder?stream="+saved.ID.Hex()+"&new=true", strings.NewReader(workflowStreamYAML("Cloned stream")))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/formata-builder?stream="+saved.ID.Hex()+"&new=true", strings.NewReader(workflowStreamYAML("Cloned stream")))
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -595,7 +595,7 @@ func TestHandleOrgAdminFormataBuilderPost(t *testing.T) {
 			Progress:    map[string]ProcessStep{},
 		})
 
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/formata-builder?stream="+saved.ID.Hex(), strings.NewReader(workflowStreamYAML("Should fail")))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/formata-builder?stream="+saved.ID.Hex(), strings.NewReader(workflowStreamYAML("Should fail")))
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -623,7 +623,7 @@ func TestHandleOrgAdminFormataBuilderPost(t *testing.T) {
 			t.Fatalf("SaveFormataBuilderStream error: %v", err)
 		}
 
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/formata-builder?stream="+saved.ID.Hex(), strings.NewReader(workflowStreamYAML("Should fail")))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/formata-builder?stream="+saved.ID.Hex(), strings.NewReader(workflowStreamYAML("Should fail")))
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -650,7 +650,7 @@ func TestHandleOrgAdminFormataBuilderPost(t *testing.T) {
 			Progress:    map[string]ProcessStep{},
 		})
 
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/formata-builder?stream="+saved.ID.Hex(), strings.NewReader(workflowStreamYAML("Platform updated stream")))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/formata-builder?stream="+saved.ID.Hex(), strings.NewReader(workflowStreamYAML("Platform updated stream")))
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -675,7 +675,7 @@ func TestHandleOrgAdminFormataBuilderPost(t *testing.T) {
 	})
 
 	t.Run("rejects non-root post path", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/formata-builder/assets/app.js", strings.NewReader(`{"nodes":[]}`))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/formata-builder/assets/app.js", strings.NewReader(`{"nodes":[]}`))
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -685,7 +685,7 @@ func TestHandleOrgAdminFormataBuilderPost(t *testing.T) {
 	})
 
 	t.Run("rejects empty stream body", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/formata-builder", strings.NewReader("   \n\t"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/formata-builder", strings.NewReader("   \n\t"))
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -696,7 +696,7 @@ func TestHandleOrgAdminFormataBuilderPost(t *testing.T) {
 
 	t.Run("rejects oversized stream body", func(t *testing.T) {
 		t.Setenv("FORMATA_STREAM_MAX_BYTES", "8")
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/formata-builder", strings.NewReader("0123456789"))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/formata-builder", strings.NewReader("0123456789"))
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -706,7 +706,7 @@ func TestHandleOrgAdminFormataBuilderPost(t *testing.T) {
 	})
 
 	t.Run("rejects invalid stream id", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/formata-builder?stream=bad-id", strings.NewReader(workflowStreamYAML("Invalid stream id")))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/formata-builder?stream=bad-id", strings.NewReader(workflowStreamYAML("Invalid stream id")))
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -716,7 +716,7 @@ func TestHandleOrgAdminFormataBuilderPost(t *testing.T) {
 	})
 
 	t.Run("rejects missing stream id", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/formata-builder?stream="+primitive.NewObjectID().Hex(), strings.NewReader(workflowStreamYAML("Missing stream")))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/formata-builder?stream="+primitive.NewObjectID().Hex(), strings.NewReader(workflowStreamYAML("Missing stream")))
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		server.handleOrgAdminFormataBuilder(rec, req)
@@ -733,7 +733,7 @@ func TestHandleOrgAdminFormataBuilderPost(t *testing.T) {
 			now:         time.Now,
 		}
 
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/formata-builder", strings.NewReader(workflowStreamYAML("No store")))
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/formata-builder", strings.NewReader(workflowStreamYAML("No store")))
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: orgAdminSession})
 		rec := httptest.NewRecorder()
 		serverWithoutStore.handleOrgAdminFormataBuilder(rec, req)

--- a/server/cmd/server/formata_builder_handler_test.go
+++ b/server/cmd/server/formata_builder_handler_test.go
@@ -881,3 +881,20 @@ func findFirstBuilderAssetPath(t *testing.T, body, pattern string) string {
 	}
 	return matches[1]
 }
+
+func TestInjectFormataBuilderOverridesIdempotent(t *testing.T) {
+	in := []byte(`<html><head><style data-attesta-formata-builder-overrides></style></head></html>`)
+	got := injectFormataBuilderOverrides(in)
+	if string(got) != string(in) {
+		t.Fatalf("expected unchanged when overrides already present")
+	}
+}
+
+func TestShouldRewriteFormataAssetContent(t *testing.T) {
+	if !shouldRewriteFormataAssetContent("app.js", "application/octet-stream") {
+		t.Fatal("expected true for .js extension fallback")
+	}
+	if shouldRewriteFormataAssetContent("logo.png", "image/png") {
+		t.Fatal("expected false for non-rewritable asset")
+	}
+}

--- a/server/cmd/server/formata_builder_handler_test.go
+++ b/server/cmd/server/formata_builder_handler_test.go
@@ -136,8 +136,14 @@ func TestHandleOrgAdminFormataBuilderGet(t *testing.T) {
 		if strings.Contains(body, "/formata-arch/") {
 			t.Fatalf("expected rewritten js body, still contains legacy prefix")
 		}
+		if strings.Contains(body, "/org-admin/formata-builder") {
+			t.Fatalf("expected rewritten js body, still contains legacy org-admin API prefix")
+		}
+		if !strings.Contains(body, "/my/organization/formata-builder") {
+			t.Fatalf("expected rewritten js body to contain /my/organization/formata-builder API prefix")
+		}
 		if !strings.Contains(body, "/my/organization/formata-builder/") {
-			t.Fatalf("expected rewritten js body to contain org-admin prefix")
+			t.Fatalf("expected rewritten js body to contain org-admin asset prefix")
 		}
 		if !strings.Contains(rec.Header().Get("Content-Type"), "javascript") {
 			t.Fatalf("content-type = %q, want javascript content type", rec.Header().Get("Content-Type"))

--- a/server/cmd/server/helpers_completed_values_test.go
+++ b/server/cmd/server/helpers_completed_values_test.go
@@ -150,7 +150,7 @@ func TestBuildSubstepAttachmentsAndDownloadViews(t *testing.T) {
 	if attachments[1].Key != "[3]" || attachments[1].Filename != "alpha.pdf" {
 		t.Fatalf("expected sanitized filename and key, got %#v", attachments[1])
 	}
-	if !strings.Contains(attachments[0].URL, "/w/workflow/process/"+processID.Hex()+"/attachment/") {
+	if !strings.Contains(attachments[0].URL, "/my/streams/workflow/instance/"+processID.Hex()+"/attachment/") {
 		t.Fatalf("unexpected attachment url: %q", attachments[0].URL)
 	}
 

--- a/server/cmd/server/helpers_misc_coverage_test.go
+++ b/server/cmd/server/helpers_misc_coverage_test.go
@@ -187,7 +187,7 @@ func TestOrganizationLogoAdditionalBranches(t *testing.T) {
 		authorizer: fakeAuthorizer{}}
 
 	t.Run("no multipart form", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", nil)
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", nil)
 		upload, errMsg := server.readOrganizationLogoUpload(req)
 		if upload != nil || errMsg != "" {
 			t.Fatalf("upload=%#v errMsg=%q", upload, errMsg)
@@ -209,7 +209,7 @@ func TestOrganizationLogoAdditionalBranches(t *testing.T) {
 		if err := writer.Close(); err != nil {
 			t.Fatalf("writer.Close error: %v", err)
 		}
-		req := httptest.NewRequest(http.MethodPost, "/org-admin/users", &body)
+		req := httptest.NewRequest(http.MethodPost, "/my/organization/users", &body)
 		req.Header.Set("Content-Type", writer.FormDataContentType())
 		if err := req.ParseMultipartForm(int64(body.Len())); err != nil {
 			t.Fatalf("ParseMultipartForm error: %v", err)

--- a/server/cmd/server/home_handler_test.go
+++ b/server/cmd/server/home_handler_test.go
@@ -14,6 +14,39 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
+func TestHandlePublicHomeIsBlankAndPublic(t *testing.T) {
+	server := &Server{
+		store: NewMemoryStore(),
+		tmpl:  testTemplates(),
+	}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	server.handlePublicHome(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "" {
+		t.Fatalf("unexpected redirect to %q", loc)
+	}
+}
+
+func TestHandleHomeRequiresAuthAtMy(t *testing.T) {
+	server := &Server{
+		store:       NewMemoryStore(),
+		tmpl:        testTemplates(),
+		enforceAuth: true,
+	}
+	req := httptest.NewRequest(http.MethodGet, "/my", nil)
+	rec := httptest.NewRecorder()
+	server.handleHome(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want redirect", rec.Code)
+	}
+	if got := rec.Header().Get("Location"); !strings.HasPrefix(got, "/login?next=") {
+		t.Fatalf("location = %q", got)
+	}
+}
+
 func TestHandleHomeListsProcesses(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 2, 3, 12, 0, 0, 0, time.UTC)
@@ -226,7 +259,7 @@ func TestHandleHomeRendersWorkflowPicker(t *testing.T) {
 		configDir:  tempDir,
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/my", nil)
 	rec := httptest.NewRecorder()
 	server.handleHome(rec, req)
 
@@ -376,7 +409,7 @@ func TestHandleHomePickerMarksWorkflowCardsWithMyTurn(t *testing.T) {
 		enforceAuth: true,
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/my", nil)
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: sessionID})
 	rec := httptest.NewRecorder()
 	server.handleHome(rec, req)
@@ -426,7 +459,7 @@ func TestHandleHomePickerRendersTurnIndicatorOnWorkflowCard(t *testing.T) {
 		enforceAuth: true,
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/my", nil)
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: sessionID})
 	rec := httptest.NewRecorder()
 	server.handleHome(rec, req)
@@ -455,7 +488,7 @@ func TestHandleHomePickerRendersWorkflowCardsAndScopedLinks(t *testing.T) {
 		configDir:  tempDir,
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/my", nil)
 	rec := httptest.NewRecorder()
 	server.handleHome(rec, req)
 
@@ -552,7 +585,7 @@ func TestHandleHomePickerCreateStreamCardVisibility(t *testing.T) {
 			enforceAuth: true,
 		}
 
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: sessionID})
 		rec := httptest.NewRecorder()
 		server.handleHome(rec, req)
@@ -589,7 +622,7 @@ func TestHandleHomePickerCreateStreamCardVisibility(t *testing.T) {
 			enforceAuth: true,
 		}
 
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: sessionID})
 		rec := httptest.NewRecorder()
 		server.handleHome(rec, req)
@@ -710,7 +743,7 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 			now:         func() time.Time { return now },
 		}
 
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: sessionID})
 		rec := httptest.NewRecorder()
 		server.handleHome(rec, req)
@@ -737,7 +770,7 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 		if !strings.Contains(body, `onclick="document.getElementById('delete-workflow-`+stream.ID.Hex()+`').showModal()"`) {
 			t.Fatalf("expected delete dialog trigger for creator, got %q", body)
 		}
-		if !strings.Contains(body, `action="/w/`+stream.ID.Hex()+`/delete"`) {
+		if !strings.Contains(body, `action="/my/streams/`+stream.ID.Hex()+`/delete"`) {
 			t.Fatalf("expected delete form action for creator, got %q", body)
 		}
 		if !strings.Contains(rec.Body.String(), `href="/org-admin/formata-builder?stream=`+stream.ID.Hex()+`"`) {
@@ -781,7 +814,7 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 			now:         func() time.Time { return now },
 		}
 
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: sessionID})
 		rec := httptest.NewRecorder()
 		server.handleHome(rec, req)
@@ -796,7 +829,7 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 		if strings.Contains(body, `id="delete-workflow-`+stream.ID.Hex()+`"`) {
 			t.Fatalf("did not expect delete dialog for started stream, got %q", body)
 		}
-		if strings.Contains(body, `action="/w/`+stream.ID.Hex()+`/delete"`) {
+		if strings.Contains(body, `action="/my/streams/`+stream.ID.Hex()+`/delete"`) {
 			t.Fatalf("did not expect delete button for started stream, got %q", body)
 		}
 		if !strings.Contains(body, `href="/org-admin/formata-builder?stream=`+stream.ID.Hex()+`&new=true"`) {
@@ -845,7 +878,7 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 			now:         func() time.Time { return now },
 		}
 
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
 		server.handleHome(rec, req)
@@ -875,7 +908,7 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 		if !strings.Contains(body, `onclick="document.getElementById('delete-workflow-`+stream.ID.Hex()+`').showModal()"`) {
 			t.Fatalf("expected delete dialog trigger for platform admin, got %q", body)
 		}
-		if !strings.Contains(body, `action="/w/`+stream.ID.Hex()+`/delete"`) {
+		if !strings.Contains(body, `action="/my/streams/`+stream.ID.Hex()+`/delete"`) {
 			t.Fatalf("expected delete form action for platform admin, got %q", body)
 		}
 	})
@@ -909,7 +942,7 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 			now:         func() time.Time { return now },
 		}
 
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: sessionID})
 		rec := httptest.NewRecorder()
 		server.handleHome(rec, req)
@@ -1005,7 +1038,7 @@ func TestHandleHomeRendersWorkflowPickerCountsByWorkflow(t *testing.T) {
 		store:      store,
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/my", nil)
 	rec := httptest.NewRecorder()
 	server.handleHome(rec, req)
 
@@ -1158,7 +1191,7 @@ func TestHandleHomeErrorPaths(t *testing.T) {
 			configDir:  t.TempDir(),
 		}
 
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my", nil)
 		rec := httptest.NewRecorder()
 		server.handleHome(rec, req)
 		if rec.Code != http.StatusInternalServerError {
@@ -1179,7 +1212,7 @@ func TestHandleHomeErrorPaths(t *testing.T) {
 			},
 		}
 
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my", nil)
 		rec := httptest.NewRecorder()
 		server.handleHome(rec, req)
 		if rec.Code != http.StatusInternalServerError {

--- a/server/cmd/server/home_handler_test.go
+++ b/server/cmd/server/home_handler_test.go
@@ -17,7 +17,7 @@ import (
 func TestHandlePublicHomeIsBlankAndPublic(t *testing.T) {
 	server := &Server{
 		store: NewMemoryStore(),
-		tmpl:  testTemplates(),
+		tmpl:  parseTestTemplates(t),
 	}
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
@@ -27,6 +27,60 @@ func TestHandlePublicHomeIsBlankAndPublic(t *testing.T) {
 	}
 	if loc := rec.Header().Get("Location"); loc != "" {
 		t.Fatalf("unexpected redirect to %q", loc)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `href="/login"`) {
+		t.Fatalf("expected Login link on public home, got %q", body)
+	}
+	if !strings.Contains(body, `class="btn btn-ghost btn-lg nav-action"`) {
+		t.Fatalf("expected Login styled as ghost nav button, got %q", body)
+	}
+	if strings.Contains(body, `account-menu`) {
+		t.Fatalf("expected no account menu on public home, got %q", body)
+	}
+	if strings.Contains(body, "Dashboard") {
+		t.Fatalf("expected no Dashboard link when logged out, got %q", body)
+	}
+}
+
+func TestHandlePublicHomeShowsDashboardWhenLoggedIn(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	server := &Server{
+		store: NewMemoryStore(),
+		tmpl:  parseTestTemplates(t),
+		identity: &fakeIdentityStore{
+			getSessionFunc: func(ctx context.Context, sessionSecret string) (IdentitySession, error) {
+				if sessionSecret != "session-public-home" {
+					return IdentitySession{}, ErrIdentityUnauthorized
+				}
+				return fakeIdentitySession(sessionSecret, "user-1", now.Add(24*time.Hour)), nil
+			},
+			getCurrentUserFunc: func(ctx context.Context, sessionSecret string) (IdentityUser, error) {
+				return IdentityUser{ID: "user-1", Email: "user@example.com", Status: "active"}, nil
+			},
+		},
+		enforceAuth: true,
+		now:         func() time.Time { return now },
+	}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-public-home"})
+	rec := httptest.NewRecorder()
+	server.handlePublicHome(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `account-menu`) {
+		t.Fatalf("expected account menu when logged in, got %q", body)
+	}
+	if !strings.Contains(body, `href="/my"`) || !strings.Contains(body, "Dashboard") {
+		t.Fatalf("expected Dashboard item under account menu when logged in, got %q", body)
+	}
+	if strings.Contains(body, `class="btn btn-ghost btn-lg nav-action">Dashboard`) {
+		t.Fatalf("expected Dashboard inside menu, not topbar button, got %q", body)
+	}
+	if strings.Contains(body, `>Login</a>`) {
+		t.Fatalf("expected no Login link when logged in, got %q", body)
 	}
 }
 

--- a/server/cmd/server/home_handler_test.go
+++ b/server/cmd/server/home_handler_test.go
@@ -705,7 +705,7 @@ func TestHandleWorkflowHomeRendersValidationState(t *testing.T) {
 	if strings.Contains(body, `class="rail-layout`) || strings.Contains(body, `class="home-workflow-grid"`) {
 		t.Fatalf("did not expect stream dashboard grid when config is invalid, got %q", body)
 	}
-	if strings.Contains(body, `action="/my/streams/workflow/process/start"`) || strings.Contains(body, "New instance") {
+	if strings.Contains(body, `action="/my/streams/workflow/instance/start"`) || strings.Contains(body, "New instance") {
 		t.Fatalf("did not expect new instance controls when config is invalid, got %q", body)
 	}
 }

--- a/server/cmd/server/home_handler_test.go
+++ b/server/cmd/server/home_handler_test.go
@@ -594,7 +594,7 @@ func TestHandleHomePickerCreateStreamCardVisibility(t *testing.T) {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 		}
 		body := rec.Body.String()
-		if !strings.Contains(body, `href="/org-admin/formata-builder"`) {
+		if !strings.Contains(body, `href="/my/organization/formata-builder"`) {
 			t.Fatalf("expected create stream card for org admin, got %q", body)
 		}
 		if !strings.Contains(body, "stream-card-cta") || !strings.Contains(body, "Create new stream") {
@@ -630,7 +630,7 @@ func TestHandleHomePickerCreateStreamCardVisibility(t *testing.T) {
 		if rec.Code != http.StatusOK {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 		}
-		if strings.Contains(rec.Body.String(), `href="/org-admin/formata-builder"`) {
+		if strings.Contains(rec.Body.String(), `href="/my/organization/formata-builder"`) {
 			t.Fatalf("did not expect create stream card for non org admin, got %q", rec.Body.String())
 		}
 	})
@@ -755,10 +755,10 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 		if !strings.Contains(body, `class="btn btn-ghost btn-icon stream-card-menu-trigger"`) {
 			t.Fatalf("expected workflow actions menu trigger for creator, got %q", body)
 		}
-		if !strings.Contains(body, `href="/org-admin/formata-builder?stream=`+stream.ID.Hex()+`&new=true"`) {
+		if !strings.Contains(body, `href="/my/organization/formata-builder?stream=`+stream.ID.Hex()+`&new=true"`) {
 			t.Fatalf("expected clone action for creator, got %q", body)
 		}
-		if !strings.Contains(body, `href="/org-admin/formata-builder?stream=`+stream.ID.Hex()+`"`) {
+		if !strings.Contains(body, `href="/my/organization/formata-builder?stream=`+stream.ID.Hex()+`"`) {
 			t.Fatalf("expected edit action for creator, got %q", body)
 		}
 		if strings.Contains(body, `id="edit-workflow-`+stream.ID.Hex()+`"`) {
@@ -773,7 +773,7 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 		if !strings.Contains(body, `action="/my/streams/`+stream.ID.Hex()+`/delete"`) {
 			t.Fatalf("expected delete form action for creator, got %q", body)
 		}
-		if !strings.Contains(rec.Body.String(), `href="/org-admin/formata-builder?stream=`+stream.ID.Hex()+`"`) {
+		if !strings.Contains(rec.Body.String(), `href="/my/organization/formata-builder?stream=`+stream.ID.Hex()+`"`) {
 			t.Fatalf("expected edit button for creator, got %q", rec.Body.String())
 		}
 	})
@@ -832,10 +832,10 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 		if strings.Contains(body, `action="/my/streams/`+stream.ID.Hex()+`/delete"`) {
 			t.Fatalf("did not expect delete button for started stream, got %q", body)
 		}
-		if !strings.Contains(body, `href="/org-admin/formata-builder?stream=`+stream.ID.Hex()+`&new=true"`) {
+		if !strings.Contains(body, `href="/my/organization/formata-builder?stream=`+stream.ID.Hex()+`&new=true"`) {
 			t.Fatalf("expected clone action for started stream, got %q", body)
 		}
-		if strings.Contains(body, `href="/org-admin/formata-builder?stream=`+stream.ID.Hex()+`"`) {
+		if strings.Contains(body, `href="/my/organization/formata-builder?stream=`+stream.ID.Hex()+`"`) {
 			t.Fatalf("did not expect direct edit action for started stream, got %q", body)
 		}
 		if !strings.Contains(body, `class="stream-card-menu-item stream-card-menu-item-disabled"`) {
@@ -890,7 +890,7 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 		if !strings.Contains(body, `class="btn btn-ghost btn-icon stream-card-menu-trigger"`) {
 			t.Fatalf("expected workflow actions menu trigger for platform admin, got %q", body)
 		}
-		if !strings.Contains(body, `href="/org-admin/formata-builder?stream=`+stream.ID.Hex()+`&new=true"`) {
+		if !strings.Contains(body, `href="/my/organization/formata-builder?stream=`+stream.ID.Hex()+`&new=true"`) {
 			t.Fatalf("expected clone action for platform admin, got %q", body)
 		}
 		if !strings.Contains(body, `id="edit-workflow-`+stream.ID.Hex()+`"`) {
@@ -899,7 +899,7 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 		if !strings.Contains(body, `onclick="document.getElementById('edit-workflow-`+stream.ID.Hex()+`').showModal()"`) {
 			t.Fatalf("expected edit warning dialog trigger for platform admin, got %q", body)
 		}
-		if !strings.Contains(body, `href="/org-admin/formata-builder?stream=`+stream.ID.Hex()+`"`) {
+		if !strings.Contains(body, `href="/my/organization/formata-builder?stream=`+stream.ID.Hex()+`"`) {
 			t.Fatalf("expected edit dialog continue action for platform admin, got %q", body)
 		}
 		if !strings.Contains(body, `id="delete-workflow-`+stream.ID.Hex()+`"`) {
@@ -954,10 +954,10 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 		if strings.Contains(body, `stream-card-menu-trigger`) {
 			t.Fatalf("did not expect workflow actions menu trigger without builder access, got %q", body)
 		}
-		if strings.Contains(body, `href="/org-admin/formata-builder?stream=`+stream.ID.Hex()+`&new=true"`) {
+		if strings.Contains(body, `href="/my/organization/formata-builder?stream=`+stream.ID.Hex()+`&new=true"`) {
 			t.Fatalf("did not expect clone action without builder access, got %q", body)
 		}
-		if strings.Contains(body, `href="/org-admin/formata-builder?stream=`+stream.ID.Hex()+`"`) {
+		if strings.Contains(body, `href="/my/organization/formata-builder?stream=`+stream.ID.Hex()+`"`) {
 			t.Fatalf("did not expect edit action without builder access, got %q", body)
 		}
 		if strings.Contains(body, `stream-card-menu-item-danger stream-card-menu-item-disabled`) {

--- a/server/cmd/server/home_handler_test.go
+++ b/server/cmd/server/home_handler_test.go
@@ -100,7 +100,7 @@ func TestHandleHomeListsProcesses(t *testing.T) {
 		},
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/w/workflow/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/my/streams/workflow/", nil)
 	cfg := testRuntimeConfig()
 	cfg.Workflow.Description = "Demo workflow description"
 	req = req.WithContext(context.WithValue(req.Context(), workflowContextKey{}, workflowContextValue{
@@ -173,7 +173,7 @@ func TestHandleHomeFiltersProcessesByStatus(t *testing.T) {
 		},
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/w/workflow/?filter=done", nil)
+	req := httptest.NewRequest(http.MethodGet, "/my/streams/workflow/?filter=done", nil)
 	req = req.WithContext(context.WithValue(req.Context(), workflowContextKey{}, workflowContextValue{
 		Key: "workflow",
 		Cfg: testRuntimeConfig(),
@@ -227,7 +227,7 @@ func TestHandleHomePaginatesProcesses(t *testing.T) {
 		},
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/w/workflow/?page=2", nil)
+	req := httptest.NewRequest(http.MethodGet, "/my/streams/workflow/?page=2", nil)
 	req = req.WithContext(context.WithValue(req.Context(), workflowContextKey{}, workflowContextValue{
 		Key: "workflow",
 		Cfg: testRuntimeConfig(),
@@ -504,10 +504,10 @@ func TestHandleHomePickerRendersWorkflowCardsAndScopedLinks(t *testing.T) {
 	if !strings.Contains(body, `class="workflow-grid"`) || !strings.Contains(body, `class="stream-card"`) {
 		t.Fatalf("expected workflow card grid markup, got %q", body)
 	}
-	if !strings.Contains(body, `href="/w/workflow/"`) {
+	if !strings.Contains(body, `href="/my/streams/workflow/"`) {
 		t.Fatalf("expected scoped workflow href for workflow key, got %q", body)
 	}
-	if !strings.Contains(body, `href="/w/secondary/"`) {
+	if !strings.Contains(body, `href="/my/streams/secondary/"`) {
 		t.Fatalf("expected scoped workflow href for secondary key, got %q", body)
 	}
 	if !strings.Contains(body, "Main workflow description") {
@@ -542,7 +542,7 @@ func TestHandleWorkflowHomeMarksProcessesWithMyTurn(t *testing.T) {
 		},
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/w/workflow/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/my/streams/workflow/", nil)
 	req = req.WithContext(context.WithValue(req.Context(), workflowContextKey{}, workflowContextValue{
 		Key: "workflow",
 		Cfg: testRuntimeConfig(),
@@ -680,7 +680,7 @@ func TestHandleWorkflowHomeRendersValidationState(t *testing.T) {
 		enforceAuth: true,
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/w/workflow/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/my/streams/workflow/", nil)
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	req = req.WithContext(context.WithValue(req.Context(), workflowContextKey{}, workflowContextValue{
 		Key: "workflow",
@@ -705,7 +705,7 @@ func TestHandleWorkflowHomeRendersValidationState(t *testing.T) {
 	if strings.Contains(body, `class="rail-layout`) || strings.Contains(body, `class="home-workflow-grid"`) {
 		t.Fatalf("did not expect stream dashboard grid when config is invalid, got %q", body)
 	}
-	if strings.Contains(body, `action="/w/workflow/process/start"`) || strings.Contains(body, "New instance") {
+	if strings.Contains(body, `action="/my/streams/workflow/process/start"`) || strings.Contains(body, "New instance") {
 		t.Fatalf("did not expect new instance controls when config is invalid, got %q", body)
 	}
 }
@@ -1097,8 +1097,8 @@ func TestHomeProcessStatusCopy(t *testing.T) {
 }
 
 func TestHomePaginationURLUsesGlobalSortAndPage(t *testing.T) {
-	got := homePaginationURL("/w/workflow", "active", "status", 3)
-	want := "/w/workflow/?filter=active&page=3&sort=status"
+	got := homePaginationURL("/my/streams/workflow", "active", "status", 3)
+	want := "/my/streams/workflow/?filter=active&page=3&sort=status"
 	if got != want {
 		t.Fatalf("pagination url = %q, want %q", got, want)
 	}
@@ -1109,14 +1109,14 @@ func TestHomePaginationURLUsesGlobalSortAndPage(t *testing.T) {
 		t.Fatalf("did not expect per-status sort/page params, got %q", got)
 	}
 
-	allURL := homePaginationURL("/w/workflow", "all", "time_desc", 1)
-	if allURL != "/w/workflow/" {
+	allURL := homePaginationURL("/my/streams/workflow", "all", "time_desc", 1)
+	if allURL != "/my/streams/workflow/" {
 		t.Fatalf("defaults should omit query params, got %q", allURL)
 	}
 }
 
 func TestBuildHomeProcessGroupsUsesGlobalSortAndFilterFields(t *testing.T) {
-	groups := buildHomeProcessGroups("/w/workflow", []StreamInstanceCard{
+	groups := buildHomeProcessGroups("/my/streams/workflow", []StreamInstanceCard{
 		{ID: "1", Status: "active"},
 		{ID: "2", Status: "done"},
 	}, "progress_desc", 1)
@@ -1231,7 +1231,7 @@ func TestHandleWorkflowHomeErrorPaths(t *testing.T) {
 			},
 		}
 
-		req := httptest.NewRequest(http.MethodGet, "/w/workflow/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/streams/workflow/", nil)
 		rec := httptest.NewRecorder()
 		server.handleWorkflowHome(rec, req)
 		if rec.Code != http.StatusInternalServerError {
@@ -1248,7 +1248,7 @@ func TestHandleWorkflowHomeErrorPaths(t *testing.T) {
 				return testRuntimeConfig(), nil
 			},
 		}
-		req := httptest.NewRequest(http.MethodGet, "/w/workflow/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/streams/workflow/", nil)
 		req = req.WithContext(context.WithValue(req.Context(), workflowContextKey{}, workflowContextValue{
 			Key: "workflow",
 			Cfg: testRuntimeConfig(),
@@ -1287,7 +1287,7 @@ func TestHandleWorkflowHomeUsesHumanReadableProcessDates(t *testing.T) {
 		},
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/w/workflow/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/my/streams/workflow/", nil)
 	req = req.WithContext(context.WithValue(req.Context(), workflowContextKey{}, workflowContextValue{
 		Key: "workflow",
 		Cfg: testRuntimeConfig(),
@@ -1367,7 +1367,7 @@ func TestHandleWorkflowHomeHTMXReturnsPartial(t *testing.T) {
 		},
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/w/workflow/", nil)
+	req := httptest.NewRequest(http.MethodGet, "/my/streams/workflow/", nil)
 	req.Header.Set("HX-Request", "true")
 	req = req.WithContext(context.WithValue(req.Context(), workflowContextKey{}, workflowContextValue{
 		Key: "workflow",
@@ -1437,7 +1437,7 @@ func TestHandleWorkflowHomeHTMXFiltersAndPaginates(t *testing.T) {
 	}
 
 	t.Run("filter", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/w/workflow/?filter=done", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/streams/workflow/?filter=done", nil)
 		req.Header.Set("HX-Request", "true")
 		req = req.WithContext(context.WithValue(req.Context(), workflowContextKey{}, workflowContextValue{
 			Key: "workflow",
@@ -1486,7 +1486,7 @@ func TestHandleWorkflowHomeHTMXFiltersAndPaginates(t *testing.T) {
 			},
 		}
 
-		req := httptest.NewRequest(http.MethodGet, "/w/workflow/?page=2", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/streams/workflow/?page=2", nil)
 		req.Header.Set("HX-Request", "true")
 		req = req.WithContext(context.WithValue(req.Context(), workflowContextKey{}, workflowContextValue{
 			Key: "workflow",
@@ -1535,7 +1535,7 @@ func TestBuildHomeFilterOptionsIncludesAllStatuses(t *testing.T) {
 }
 
 func TestBuildHomeActiveProcessGroupBuildsSingleStatus(t *testing.T) {
-	group := buildHomeActiveProcessGroup("/w/workflow", []StreamInstanceCard{
+	group := buildHomeActiveProcessGroup("/my/streams/workflow", []StreamInstanceCard{
 		{ID: "1", Status: "active"},
 		{ID: "2", Status: "done"},
 	}, "done", "time_desc", 1)

--- a/server/cmd/server/home_template_preview_test.go
+++ b/server/cmd/server/home_template_preview_test.go
@@ -17,7 +17,7 @@ func testHomeActiveProcessGroups(items []StreamInstanceCard, statusFilter, sortK
 	if statusFilter == "" {
 		statusFilter = "all"
 	}
-	return []ProcessStatusGroup{buildHomeActiveProcessGroup("/w/workflow", items, statusFilter, sortKey, page)}
+	return []ProcessStatusGroup{buildHomeActiveProcessGroup("/my/streams/workflow", items, statusFilter, sortKey, page)}
 }
 
 func testHomeActiveGroup(statusFilter string, items ...StreamInstanceCard) []ProcessStatusGroup {
@@ -27,11 +27,11 @@ func testHomeActiveGroup(statusFilter string, items ...StreamInstanceCard) []Pro
 func TestHomeTemplateRendersSidebarAndReadOnlyPreview(t *testing.T) {
 	tmpl := parseTestTemplates(t)
 
-	process := StreamInstanceCard{ID: "process-1", Name: "Pilot batch", Status: "active", DetailHref: "/w/workflow/process/process-1", Percent: 25, DoneSubsteps: 1, TotalSubsteps: 4, CreatedAt: "1 Mar 2026 at 10:00 UTC"}
+	process := StreamInstanceCard{ID: "process-1", Name: "Pilot batch", Status: "active", DetailHref: "/my/streams/workflow/instance/process-1", Percent: 25, DoneSubsteps: 1, TotalSubsteps: 4, CreatedAt: "1 Mar 2026 at 10:00 UTC"}
 	view := HomeView{
 		PageBase: PageBase{
 			WorkflowKey:  "workflow",
-			WorkflowPath: "/w/workflow",
+			WorkflowPath: "/my/streams/workflow",
 			WorkflowName: "Demo workflow",
 		},
 		WorkflowDescription: "Previewable workflow",
@@ -143,7 +143,7 @@ func TestHomeTemplateRendersEmptyStatusSections(t *testing.T) {
 	view := HomeView{
 		PageBase: PageBase{
 			WorkflowKey:  "workflow",
-			WorkflowPath: "/w/workflow",
+			WorkflowPath: "/my/streams/workflow",
 			WorkflowName: "Demo workflow",
 		},
 		WorkflowDescription: "Previewable workflow",
@@ -181,7 +181,7 @@ func TestHomeTemplateRendersStatusPagination(t *testing.T) {
 	view := HomeView{
 		PageBase: PageBase{
 			WorkflowKey:  "workflow",
-			WorkflowPath: "/w/workflow",
+			WorkflowPath: "/my/streams/workflow",
 			WorkflowName: "Demo workflow",
 		},
 		Sort:          "status",
@@ -203,12 +203,12 @@ func TestHomeTemplateRendersStatusPagination(t *testing.T) {
 				CurrentPage:         2,
 				TotalPages:          3,
 				PageNumbers:         []int{1, 2, 3},
-				PageLinks:           []PaginationLink{{Page: 1, URL: "/w/workflow/?filter=active&sort=status"}, {Page: 2, URL: "/w/workflow/?filter=active&page=2&sort=status", IsCurrent: true}, {Page: 3, URL: "/w/workflow/?filter=active&page=3&sort=status"}},
+				PageLinks:           []PaginationLink{{Page: 1, URL: "/my/streams/workflow/?filter=active&sort=status"}, {Page: 2, URL: "/my/streams/workflow/?filter=active&page=2&sort=status", IsCurrent: true}, {Page: 3, URL: "/my/streams/workflow/?filter=active&page=3&sort=status"}},
 				HasPreviousPage:     true,
 				HasNextPage:         true,
-				PreviousURL:         "/w/workflow/?filter=active&sort=status",
-				NextURL:             "/w/workflow/?filter=active&page=3&sort=status",
-				Processes:           []StreamInstanceCard{{ID: "process-13", Status: "active", DetailHref: "/w/workflow/process/process-13", Percent: 25, DoneSubsteps: 1, TotalSubsteps: 4, CreatedAt: "1 Mar 2026 at 10:00 UTC"}},
+				PreviousURL:         "/my/streams/workflow/?filter=active&sort=status",
+				NextURL:             "/my/streams/workflow/?filter=active&page=3&sort=status",
+				Processes:           []StreamInstanceCard{{ID: "process-13", Status: "active", DetailHref: "/my/streams/workflow/instance/process-13", Percent: 25, DoneSubsteps: 1, TotalSubsteps: 4, CreatedAt: "1 Mar 2026 at 10:00 UTC"}},
 			},
 		},
 	}
@@ -223,10 +223,10 @@ func TestHomeTemplateRendersStatusPagination(t *testing.T) {
 	if !strings.Contains(compactBody, `Active stream instances pagination`) {
 		t.Fatalf("expected active stream instances pagination nav, got: %s", body)
 	}
-	if !strings.Contains(compactBody, `/w/workflow/?filter=active&amp;page=3&amp;sort=status`) {
+	if !strings.Contains(compactBody, `/my/streams/workflow/?filter=active&amp;page=3&amp;sort=status`) {
 		t.Fatalf("expected pagination to preserve filter, sort and page, got: %s", body)
 	}
-	if !strings.Contains(compactBody, `hx-get="/w/workflow/?filter=active&amp;page=3&amp;sort=status"`) {
+	if !strings.Contains(compactBody, `hx-get="/my/streams/workflow/?filter=active&amp;page=3&amp;sort=status"`) {
 		t.Fatalf("expected pagination hx-get, got: %s", body)
 	}
 	if !strings.Contains(compactBody, `name="sort"`) {
@@ -270,7 +270,7 @@ func TestHomeTemplateHighlightsProcessWhenItIsUsersTurn(t *testing.T) {
 	item := StreamInstanceCard{
 		ID:            "process-1",
 		Status:        "available",
-		DetailHref:    "/w/workflow/process/process-1",
+		DetailHref:    "/my/streams/workflow/instance/process-1",
 		Percent:       25,
 		DoneSubsteps:  1,
 		TotalSubsteps: 4,
@@ -279,7 +279,7 @@ func TestHomeTemplateHighlightsProcessWhenItIsUsersTurn(t *testing.T) {
 	view := HomeView{
 		PageBase: PageBase{
 			WorkflowKey:  "workflow",
-			WorkflowPath: "/w/workflow",
+			WorkflowPath: "/my/streams/workflow",
 			WorkflowName: "Demo workflow",
 		},
 		Sort:          "time_desc",

--- a/server/cmd/server/layout_fonts_test.go
+++ b/server/cmd/server/layout_fonts_test.go
@@ -32,3 +32,24 @@ func TestLayoutLoadsGoogleFontsWithSwap(t *testing.T) {
 		t.Fatalf("expected Source Code Pro to be removed from layout fonts, got:\n%s", body)
 	}
 }
+
+func TestLayoutShowsAccountMenuWhenLoggedIn(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+	var rendered bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&rendered, "layout.html", PageBase{ShowLogout: true}); err != nil {
+		t.Fatalf("ExecuteTemplate() error = %v", err)
+	}
+	body := rendered.String()
+	if !strings.Contains(body, `account-menu`) {
+		t.Fatalf("expected account menu when logged in, got:\n%s", body)
+	}
+	if !strings.Contains(body, `href="/my"`) || !strings.Contains(body, "Dashboard") {
+		t.Fatalf("expected Dashboard under account menu when logged in, got:\n%s", body)
+	}
+	if strings.Contains(body, `class="btn btn-ghost btn-lg nav-action">Dashboard`) {
+		t.Fatalf("expected Dashboard inside menu, not topbar button, got:\n%s", body)
+	}
+	if strings.Contains(body, `>Login</a>`) {
+		t.Fatalf("expected no Login link when logged in, got:\n%s", body)
+	}
+}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -1293,10 +1293,6 @@ func (s *Server) logAndRenderOrgAdminError(w http.ResponseWriter, r *http.Reques
 	s.renderOrgAdminWithErrors(w, r, user, orgSlug, inviteLink, errs)
 }
 
-func workflowPath(key string) string {
-	return streamPath(key)
-}
-
 func (s *Server) pageBase(body, workflowKey, workflowName string) PageBase {
 	base := PageBase{
 		Body:          body,
@@ -1305,7 +1301,7 @@ func (s *Server) pageBase(body, workflowKey, workflowName string) PageBase {
 		WorkflowName:  strings.TrimSpace(workflowName),
 	}
 	if base.WorkflowKey != "" {
-		base.WorkflowPath = workflowPath(base.WorkflowKey)
+		base.WorkflowPath = streamPath(base.WorkflowKey)
 	}
 	return base
 }
@@ -1522,7 +1518,7 @@ func (s *Server) workflowOptions(ctx context.Context, user *AccountUser) ([]Stre
 			Description:  strings.TrimSpace(cfg.Workflow.Description),
 			Counts:       WorkflowProcessCounts{},
 			EditAction:   "/org-admin/formata-builder?stream=" + key,
-			DeleteAction: workflowPath(key) + "/delete",
+			DeleteAction: streamPath(key) + "/delete",
 		}
 		if s.store == nil {
 			options = append(options, option)
@@ -2019,7 +2015,7 @@ func redirectHomeWithMessage(w http.ResponseWriter, r *http.Request, key, messag
 }
 
 func redirectWorkflowHomeWithMessage(w http.ResponseWriter, r *http.Request, workflowKey, message string) {
-	target := workflowPath(workflowKey) + "/"
+	target := streamPath(workflowKey) + "/"
 	trimmedMessage := strings.TrimSpace(message)
 	if trimmedMessage != "" {
 		target += "?" + url.Values{"error": []string{trimmedMessage}}.Encode()
@@ -2077,13 +2073,17 @@ func (s *Server) handleMyRoutes(w http.ResponseWriter, r *http.Request) {
 	if _, _, ok := s.requireAuthenticatedPage(w, r); !ok {
 		return
 	}
-	rest := strings.TrimPrefix(r.URL.Path, "/my")
-	rest = strings.TrimPrefix(rest, "/")
-	if rest == "" {
-		s.handleHome(w, r)
+	rest := strings.Trim(strings.TrimPrefix(r.URL.Path, "/my"), "/")
+	switch {
+	case rest == "":
+		s.handleHome(w, cloneRequestWithPath(r, appHomePath))
 		return
+	case rest == "streams" || strings.HasPrefix(rest, "streams/"):
+		s.handleStreamRoutes(w, cloneRequestWithPath(r, "/"+rest))
+		return
+	default:
+		http.NotFound(w, r)
 	}
-	http.NotFound(w, r)
 }
 
 func (s *Server) handleAbout(w http.ResponseWriter, r *http.Request) {
@@ -2242,7 +2242,6 @@ func (s *Server) newMux() *http.ServeMux {
 	mux.HandleFunc("/formata-arch", s.handleEmbeddedFormataArch)
 	mux.HandleFunc("/formata-arch/", s.handleEmbeddedFormataArch)
 	mux.HandleFunc("/organization/logo/", s.handleOrganizationLogo)
-	mux.HandleFunc("/w/", s.handleWorkflowRoutes)
 	mux.HandleFunc("/my", s.handleHome)
 	mux.HandleFunc("/my/", s.handleMyRoutes)
 	mux.HandleFunc("/", s.handlePublicHome)
@@ -4672,11 +4671,8 @@ func cloneRequestWithSelectedSubstep(r *http.Request, substepID string) *http.Re
 	return clone
 }
 
-func (s *Server) handleWorkflowRoutes(w http.ResponseWriter, r *http.Request) {
-	if _, _, ok := s.requireAuthenticatedPage(w, r); !ok {
-		return
-	}
-	path := strings.TrimPrefix(r.URL.Path, "/w/")
+func (s *Server) handleStreamRoutes(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/streams/")
 	parts := strings.Split(path, "/")
 	if len(parts) == 0 || strings.TrimSpace(parts[0]) == "" {
 		http.NotFound(w, r)
@@ -4696,19 +4692,19 @@ func (s *Server) handleWorkflowRoutes(w http.ResponseWriter, r *http.Request) {
 		s.handleWorkflowHome(w, scopedReq)
 		return
 	}
-	rest := "/" + strings.Join(parts[1:], "/")
+	tail := "/" + strings.Join(parts[1:], "/")
 	switch {
-	case rest == "/process/start":
-		s.handleStartProcess(w, cloneRequestWithPath(scopedReq, rest))
+	case tail == "/instance/start":
+		s.handleStartProcess(w, cloneRequestWithPath(scopedReq, tail))
 		return
-	case rest == "/delete":
-		s.handleDeleteWorkflow(w, cloneRequestWithPath(scopedReq, rest))
+	case tail == "/delete":
+		s.handleDeleteWorkflow(w, cloneRequestWithPath(scopedReq, tail))
 		return
-	case strings.HasPrefix(rest, "/process/"):
-		s.handleProcessRoutes(w, cloneRequestWithPath(scopedReq, rest))
+	case strings.HasPrefix(tail, "/instance/"):
+		s.handleProcessRoutes(w, cloneRequestWithPath(scopedReq, tail))
 		return
-	case rest == "/events":
-		s.handleEvents(w, cloneRequestWithPath(scopedReq, rest))
+	case tail == "/events":
+		s.handleEvents(w, cloneRequestWithPath(scopedReq, tail))
 		return
 	default:
 		http.NotFound(w, r)
@@ -4818,7 +4814,7 @@ func (s *Server) buildWorkflowHomeView(ctx context.Context, r *http.Request, use
 
 	totalSubsteps := countWorkflowSubsteps(cfg.Workflow)
 	var processes []StreamInstanceCard
-	path := workflowPath(workflowKey)
+	path := streamPath(workflowKey)
 	for _, process := range processesRaw {
 		process.Progress = normalizeProgressKeys(process.Progress)
 		status := deriveProcessStatus(cfg.Workflow, &process)
@@ -4832,7 +4828,7 @@ func (s *Server) buildWorkflowHomeView(ctx context.Context, r *http.Request, use
 			Name:               strings.TrimSpace(process.Name),
 			Status:             status,
 			StatusLabel:        processStatusLabel(status),
-			DetailHref:         path + "/process/" + process.ID.Hex(),
+			DetailHref:         streamInstancePath(workflowKey, process.ID.Hex()),
 			CreatedAt:          humanReadableTraceabilityTime(process.CreatedAt),
 			CreatedAtISO:       rfc3339UTC(process.CreatedAt),
 			CreatedAtTime:      process.CreatedAt,
@@ -4949,7 +4945,7 @@ func (s *Server) handleStartProcess(w http.ResponseWriter, r *http.Request) {
 	for _, role := range s.roles(cfg) {
 		s.sse.Broadcast("role:"+workflowKey+":"+role, "role-updated")
 	}
-	http.Redirect(w, r, fmt.Sprintf("%s/process/%s", workflowPath(workflowKey), id.Hex()), http.StatusSeeOther)
+	http.Redirect(w, r, streamInstancePath(workflowKey, id.Hex()), http.StatusSeeOther)
 }
 
 const maxProcessNameRunes = 80
@@ -4996,7 +4992,7 @@ func (s *Server) processBelongsToWorkflow(process *Process, workflowKey string) 
 }
 
 func (s *Server) handleProcessRoutes(w http.ResponseWriter, r *http.Request) {
-	path := strings.TrimPrefix(r.URL.Path, "/process/")
+	path := strings.TrimPrefix(r.URL.Path, "/instance/")
 	parts := strings.Split(path, "/")
 	if len(parts) == 0 || parts[0] == "" {
 		http.NotFound(w, r)
@@ -5680,7 +5676,7 @@ func (s *Server) handleGetSubstepOverride(w http.ResponseWriter, r *http.Request
 		UISchema:       marshalJSONCompact(effective.UISchema),
 		Reason:         strings.TrimSpace(override.Reason),
 		FormataArchURL: strings.TrimRight(strings.TrimSpace(s.formataArchURL), "/"),
-		SaveURL:        fmt.Sprintf("/w/%s/process/%s/substep/%s/override", workflowKey, process.ID.Hex(), canonical.SubstepID),
+		SaveURL:        streamInstancePath(workflowKey, process.ID.Hex()) + "/substep/" + canonical.SubstepID + "/override",
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := s.tmpl.ExecuteTemplate(w, "substep_override_editor.html", view); err != nil {
@@ -6823,7 +6819,7 @@ func buildProcessDownloadAttachments(workflowKey string, process *Process, files
 		views = append(views, ProcessDownloadAttachment{
 			SubstepID: file.SubstepID,
 			Filename:  sanitizeAttachmentFilename(file.Filename),
-			URL:       fmt.Sprintf("%s/process/%s/attachment/%s/file", workflowPath(workflowKey), process.ID.Hex(), file.AttachmentID),
+			URL:       fmt.Sprintf("%s/attachment/%s/file", streamInstancePath(workflowKey, process.ID.Hex()), file.AttachmentID),
 		})
 	}
 	return views
@@ -7263,7 +7259,7 @@ func buildSubstepAttachments(workflowKey string, process *Process, data map[stri
 			continue
 		}
 		seen[id] = struct{}{}
-		downloadURL := fmt.Sprintf("%s/process/%s/attachment/%s/file", workflowPath(workflowKey), process.ID.Hex(), id)
+		downloadURL := fmt.Sprintf("%s/attachment/%s/file", streamInstancePath(workflowKey, process.ID.Hex()), id)
 		previewKind := actionAttachmentPreviewKind(meta)
 		attachments = append(attachments, SubstepAttachmentView{
 			AttachmentID: id,

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -1517,7 +1517,7 @@ func (s *Server) workflowOptions(ctx context.Context, user *AccountUser) ([]Stre
 			Name:         cfg.Workflow.Name,
 			Description:  strings.TrimSpace(cfg.Workflow.Description),
 			Counts:       WorkflowProcessCounts{},
-			EditAction:   "/org-admin/formata-builder?stream=" + key,
+			EditAction:   organizationPath("formata-builder?stream=" + key),
 			DeleteAction: streamPath(key) + "/delete",
 		}
 		if s.store == nil {
@@ -2081,6 +2081,30 @@ func (s *Server) handleMyRoutes(w http.ResponseWriter, r *http.Request) {
 	case rest == "streams" || strings.HasPrefix(rest, "streams/"):
 		s.handleStreamRoutes(w, cloneRequestWithPath(r, "/"+rest))
 		return
+	case rest == "organization" || strings.HasPrefix(rest, "organization/"):
+		s.handleOrganizationRoutes(w, cloneRequestWithPath(r, "/"+rest))
+		return
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *Server) handleOrganizationRoutes(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/organization")
+	switch {
+	case path == "/profile" || path == "/profile/":
+		s.handleOrgAdminPage(w, r)
+	case path == "/roles" || path == "/roles/":
+		s.handleOrgAdminRoles(w, r)
+	case path == "/members" || path == "/members/":
+		s.handleOrgAdminPage(w, r)
+	case path == "/users" || path == "/users/":
+		s.handleOrgAdminUsers(w, r)
+	case strings.HasPrefix(path, "/logo/"):
+		s.handleOrgAdminLogo(w, cloneRequestWithPath(r, path))
+	case path == "/formata-builder" || strings.HasPrefix(path, "/formata-builder/"):
+		suffix := strings.TrimPrefix(path, "/formata-builder")
+		s.handleOrgAdminFormataBuilder(w, cloneRequestWithPath(r, organizationPath("formata-builder"+suffix)))
 	default:
 		http.NotFound(w, r)
 	}
@@ -2232,13 +2256,6 @@ func (s *Server) newMux() *http.ServeMux {
 	mux.HandleFunc("/invite/", s.handleInvite)
 	mux.HandleFunc("/reset", s.handleResetRequest)
 	mux.HandleFunc("/reset/", s.handleResetSet)
-	mux.HandleFunc("/org-admin/profile", s.handleOrgAdminPage)
-	mux.HandleFunc("/org-admin/roles", s.handleOrgAdminRoles)
-	mux.HandleFunc("/org-admin/members", s.handleOrgAdminPage)
-	mux.HandleFunc("/org-admin/logo/", s.handleOrgAdminLogo)
-	mux.HandleFunc("/org-admin/users", s.handleOrgAdminUsers)
-	mux.HandleFunc("/org-admin/formata-builder", s.handleOrgAdminFormataBuilder)
-	mux.HandleFunc("/org-admin/formata-builder/", s.handleOrgAdminFormataBuilder)
 	mux.HandleFunc("/formata-arch", s.handleEmbeddedFormataArch)
 	mux.HandleFunc("/formata-arch/", s.handleEmbeddedFormataArch)
 	mux.HandleFunc("/organization/logo/", s.handleOrganizationLogo)
@@ -2528,7 +2545,7 @@ func (s *Server) handleSignup(w http.ResponseWriter, r *http.Request) {
 		}
 		redirectTarget := appHomePath
 		if strings.TrimSpace(identityUser.OrgSlug) == "" {
-			redirectTarget = "/org-admin/profile"
+			redirectTarget = organizationPath("profile")
 		}
 		http.Redirect(w, r, redirectTarget, http.StatusSeeOther)
 		return
@@ -3668,11 +3685,11 @@ func resolveOrgAdminActivePanel(r *http.Request, errs OrgAdminErrors, inviteLink
 	}
 	if r != nil {
 		switch r.URL.Path {
-		case "/org-admin/roles":
+		case organizationPath("roles"):
 			return "roles"
-		case "/org-admin/members":
+		case organizationPath("members"):
 			return "members"
-		case "/org-admin/profile":
+		case organizationPath("profile"):
 			return "profile"
 		}
 	}
@@ -3880,7 +3897,7 @@ func (s *Server) renderOrgAdminWithErrors(w http.ResponseWriter, r *http.Request
 		Breadcrumbs:            buildOrgAdminBreadcrumbs(activePanel),
 		ActivePanel:            activePanel,
 		Organization:           org,
-		OrganizationLogoURL:    "/org-admin/logo/" + strings.TrimSpace(org.LogoAttachmentID),
+		OrganizationLogoURL:    organizationPath("logo/" + strings.TrimSpace(org.LogoAttachmentID)),
 		NeedsOrganizationSetup: false,
 		OrganizationError:      errs.Organization,
 		RoleError:              errs.Role,
@@ -3915,7 +3932,7 @@ func (s *Server) handleOrgAdminLogo(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	logoID := strings.Trim(strings.TrimPrefix(r.URL.Path, "/org-admin/logo/"), "/")
+	logoID := strings.Trim(strings.TrimPrefix(r.URL.Path, "/logo/"), "/")
 	if logoID == "" {
 		http.NotFound(w, r)
 		return
@@ -4226,7 +4243,7 @@ func (s *Server) handleOrgAdminRoles(w http.ResponseWriter, r *http.Request) {
 			s.renderOrgAdminWithErrors(w, r, user, user.OrgSlug, "", OrgAdminErrors{Role: "unsupported action"})
 			return
 		}
-		http.Redirect(w, r, "/org-admin/roles", http.StatusSeeOther)
+		http.Redirect(w, r, organizationPath("roles"), http.StatusSeeOther)
 		return
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -4243,7 +4260,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if r.Method == http.MethodGet {
-		http.Redirect(w, r, "/org-admin/profile", http.StatusSeeOther)
+		http.Redirect(w, r, organizationPath("profile"), http.StatusSeeOther)
 		return
 	}
 	if r.Method != http.MethodPost {
@@ -4322,7 +4339,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-		http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
+		http.Redirect(w, r, organizationPath("members"), http.StatusSeeOther)
 		return
 	}
 
@@ -4385,7 +4402,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 					s.logAndRenderOrgAdminError(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "failed to update user roles"}, err, "failed to update labels for invited member %s in organization %s", membership.UserID, admin.OrgSlug)
 					return
 				}
-				http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
+				http.Redirect(w, r, organizationPath("members"), http.StatusSeeOther)
 				return
 			}
 			if roleSlugsKey(append(append([]string{}, membership.RoleSlugs...), func() []string {
@@ -4394,7 +4411,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 				}
 				return nil
 			}()...)) == roleSlugsKey(selectedRoles) {
-				http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
+				http.Redirect(w, r, organizationPath("members"), http.StatusSeeOther)
 				return
 			}
 			sessionSecret, err := sessionSecretFromRequest(r)
@@ -4406,7 +4423,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 				s.logAndRenderOrgAdminError(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "failed to create invite"}, err, "failed to update membership %s in organization %s", membership.ID, admin.OrgSlug)
 				return
 			}
-			http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
+			http.Redirect(w, r, organizationPath("members"), http.StatusSeeOther)
 			return
 		}
 		existingUser, err := s.identity.GetUserByEmail(r.Context(), email)
@@ -4426,7 +4443,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 				s.logAndRenderOrgAdminError(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "failed to update user roles"}, err, "failed to update labels for existing user %s in organization %s", existingUser.ID, admin.OrgSlug)
 				return
 			}
-			http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
+			http.Redirect(w, r, organizationPath("members"), http.StatusSeeOther)
 			return
 		case err != nil && !errors.Is(err, ErrIdentityNotFound):
 			s.logAndRenderOrgAdminError(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "failed to load existing user"}, err, "failed to look up existing user %s during invite", email)
@@ -4441,7 +4458,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 			s.logAndRenderOrgAdminError(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Invite: "failed to create invite"}, err, "failed to create invite for %s in organization %s", email, admin.OrgSlug)
 			return
 		}
-		http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
+		http.Redirect(w, r, organizationPath("members"), http.StatusSeeOther)
 	case "update_org":
 		name := strings.TrimSpace(r.FormValue("name"))
 		if name == "" {
@@ -4501,7 +4518,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 				log.Printf("failed to delete previous organization logo %q: %v", previousLogoFileID, err)
 			}
 		}
-		http.Redirect(w, r, "/org-admin/profile", http.StatusSeeOther)
+		http.Redirect(w, r, organizationPath("profile"), http.StatusSeeOther)
 	case "set_roles":
 		userID := strings.TrimSpace(r.FormValue("userId"))
 		if userID == "" {
@@ -4575,7 +4592,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 			s.logAndRenderOrgAdminError(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "failed to update user roles"}, err, "failed to update labels for user %s in organization %s", target.ID, admin.OrgSlug)
 			return
 		}
-		http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
+		http.Redirect(w, r, organizationPath("members"), http.StatusSeeOther)
 	case "delete_user":
 		userID := strings.TrimSpace(r.FormValue("userId"))
 		if userID == "" {
@@ -4634,7 +4651,7 @@ func (s *Server) handleOrgAdminUsers(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-		http.Redirect(w, r, "/org-admin/members", http.StatusSeeOther)
+		http.Redirect(w, r, organizationPath("members"), http.StatusSeeOther)
 	default:
 		s.renderOrgAdminWithErrors(w, r, admin, admin.OrgSlug, "", OrgAdminErrors{Users: "unsupported action"})
 	}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -2627,7 +2627,7 @@ func (s *Server) handleInviteAccept(w http.ResponseWriter, r *http.Request) {
 	} else if err != nil {
 		logRequestError(r, err, "failed to load invited user after accepting invite")
 	}
-	http.Redirect(w, r, "/", http.StatusSeeOther)
+	http.Redirect(w, r, appHomePath, http.StatusSeeOther)
 }
 
 func (s *Server) handleInvitePassword(w http.ResponseWriter, r *http.Request) {
@@ -2687,7 +2687,7 @@ func (s *Server) handleInvitePassword(w http.ResponseWriter, r *http.Request) {
 			logAndHTTPError(w, r, http.StatusInternalServerError, "failed to update password", err, "failed to update invited user password for %s", user.Email)
 			return
 		}
-		http.Redirect(w, r, "/", http.StatusSeeOther)
+		http.Redirect(w, r, appHomePath, http.StatusSeeOther)
 		return
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -2009,7 +2009,7 @@ func homeProcessStatusRank(status string) int {
 }
 
 func redirectHomeWithMessage(w http.ResponseWriter, r *http.Request, key, message string) {
-	target := "/"
+	target := appHomePath
 	trimmedKey := strings.TrimSpace(key)
 	trimmedMessage := strings.TrimSpace(message)
 	if trimmedKey != "" && trimmedMessage != "" {
@@ -2027,8 +2027,22 @@ func redirectWorkflowHomeWithMessage(w http.ResponseWriter, r *http.Request, wor
 	http.Redirect(w, r, target, http.StatusSeeOther)
 }
 
-func (s *Server) handleHome(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handlePublicHome(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	view := struct {
+		PageBase
+	}{PageBase: s.pageBase("public_home_body", "", "")}
+	if err := s.tmpl.ExecuteTemplate(w, "public_home.html", view); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (s *Server) handleHome(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimSpace(r.URL.Path)
+	if path != appHomePath && path != appHomePath+"/" {
 		http.NotFound(w, r)
 		return
 	}
@@ -2057,6 +2071,19 @@ func (s *Server) handleHome(w http.ResponseWriter, r *http.Request) {
 	if err := s.tmpl.ExecuteTemplate(w, "home.html", view); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
+}
+
+func (s *Server) handleMyRoutes(w http.ResponseWriter, r *http.Request) {
+	if _, _, ok := s.requireAuthenticatedPage(w, r); !ok {
+		return
+	}
+	rest := strings.TrimPrefix(r.URL.Path, "/my")
+	rest = strings.TrimPrefix(rest, "/")
+	if rest == "" {
+		s.handleHome(w, r)
+		return
+	}
+	http.NotFound(w, r)
 }
 
 func (s *Server) handleAbout(w http.ResponseWriter, r *http.Request) {
@@ -2216,7 +2243,9 @@ func (s *Server) newMux() *http.ServeMux {
 	mux.HandleFunc("/formata-arch/", s.handleEmbeddedFormataArch)
 	mux.HandleFunc("/organization/logo/", s.handleOrganizationLogo)
 	mux.HandleFunc("/w/", s.handleWorkflowRoutes)
-	mux.HandleFunc("/", s.handleHome)
+	mux.HandleFunc("/my", s.handleHome)
+	mux.HandleFunc("/my/", s.handleMyRoutes)
+	mux.HandleFunc("/", s.handlePublicHome)
 	mux.HandleFunc("/events", s.handleEvents)
 	return mux
 }
@@ -2361,13 +2390,13 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		if s.enforceAuth {
 			if _, _, err := s.currentUser(r); err == nil {
-				http.Redirect(w, r, "/", http.StatusSeeOther)
+				http.Redirect(w, r, appHomePath, http.StatusSeeOther)
 				return
 			}
 		}
 		view := LoginView{
 			PageBase:     s.pageBase("login_body", "", ""),
-			Next:         safeNextPath(r, "/"),
+			Next:         safeNextPath(r, appHomePath),
 			Confirmation: loginNoticeMessage(requestNotice(r)),
 			ShowSignup:   anyoneCanCreateAccount(),
 		}
@@ -2382,7 +2411,7 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		}
 		email := strings.ToLower(strings.TrimSpace(r.FormValue("email")))
 		password := strings.TrimSpace(r.FormValue("password"))
-		next := safeNextPath(r, "/")
+		next := safeNextPath(r, appHomePath)
 
 		if adminEmail, adminPassword, ok := platformAdminCredentials(); ok && strings.EqualFold(email, adminEmail) {
 			if subtle.ConstantTimeCompare([]byte(password), []byte(adminPassword)) != 1 {
@@ -2451,7 +2480,7 @@ func (s *Server) handleSignup(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		if s.enforceAuth {
 			if _, _, err := s.currentUser(r); err == nil {
-				http.Redirect(w, r, "/", http.StatusSeeOther)
+				http.Redirect(w, r, appHomePath, http.StatusSeeOther)
 				return
 			}
 		}
@@ -2498,7 +2527,7 @@ func (s *Server) handleSignup(w http.ResponseWriter, r *http.Request) {
 			logAndHTTPError(w, r, http.StatusInternalServerError, "signup failed", err, "failed to load signed up user %s", email)
 			return
 		}
-		redirectTarget := "/"
+		redirectTarget := appHomePath
 		if strings.TrimSpace(identityUser.OrgSlug) == "" {
 			redirectTarget = "/org-admin/profile"
 		}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -1294,7 +1294,7 @@ func (s *Server) logAndRenderOrgAdminError(w http.ResponseWriter, r *http.Reques
 }
 
 func workflowPath(key string) string {
-	return "/w/" + strings.TrimSpace(key)
+	return streamPath(key)
 }
 
 func (s *Server) pageBase(body, workflowKey, workflowName string) PageBase {

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -2028,9 +2028,13 @@ func (s *Server) handlePublicHome(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	base := s.pageBase("public_home_body", "", "")
+	if user, _, err := s.currentUser(r); err == nil {
+		base = s.pageBaseForUser(user, "public_home_body", "", "")
+	}
 	view := struct {
 		PageBase
-	}{PageBase: s.pageBase("public_home_body", "", "")}
+	}{PageBase: base}
 	if err := s.tmpl.ExecuteTemplate(w, "public_home.html", view); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/server/cmd/server/org_admin_section_urls_test.go
+++ b/server/cmd/server/org_admin_section_urls_test.go
@@ -58,7 +58,7 @@ func TestOrgAdminSectionURLHandlers(t *testing.T) {
 	server := orgAdminSectionURLTestServer(t, now)
 
 	t.Run("GET legacy users redirects to profile", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/users", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/organization/users", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
 
@@ -67,13 +67,13 @@ func TestOrgAdminSectionURLHandlers(t *testing.T) {
 		if rec.Code != http.StatusSeeOther {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 		}
-		if loc := rec.Header().Get("Location"); loc != "/org-admin/profile" {
-			t.Fatalf("location = %q, want /org-admin/profile", loc)
+		if loc := rec.Header().Get("Location"); loc != "/my/organization/profile" {
+			t.Fatalf("location = %q, want /my/organization/profile", loc)
 		}
 	})
 
 	t.Run("GET profile renders active profile panel", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/profile", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/organization/profile", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
 
@@ -87,7 +87,7 @@ func TestOrgAdminSectionURLHandlers(t *testing.T) {
 	})
 
 	t.Run("GET members renders active members panel", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/members", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/organization/members", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
 
@@ -101,7 +101,7 @@ func TestOrgAdminSectionURLHandlers(t *testing.T) {
 	})
 
 	t.Run("GET roles renders active roles panel", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/org-admin/roles", nil)
+		req := httptest.NewRequest(http.MethodGet, "/my/organization/roles", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 		rec := httptest.NewRecorder()
 
@@ -120,10 +120,10 @@ func TestResolveOrgAdminActivePanelFromPath(t *testing.T) {
 		path string
 		want string
 	}{
-		{path: "/org-admin/profile", want: "profile"},
-		{path: "/org-admin/members", want: "members"},
-		{path: "/org-admin/roles", want: "roles"},
-		{path: "/org-admin/users", want: "profile"},
+		{path: "/my/organization/profile", want: "profile"},
+		{path: "/my/organization/members", want: "members"},
+		{path: "/my/organization/roles", want: "roles"},
+		{path: "/my/organization/users", want: "profile"},
 	}
 	for _, tc := range tests {
 		req := httptest.NewRequest(http.MethodGet, tc.path, nil)
@@ -139,7 +139,7 @@ func assertOrgAdminActivePanel(t *testing.T, body, panel string) {
 	if !strings.Contains(body, `class="sidebar-nav-link is-active"`) {
 		t.Fatalf("expected active sidebar nav link for %q", panel)
 	}
-	if !strings.Contains(body, `href="/org-admin/`+panel+`"`) {
+	if !strings.Contains(body, `href="/my/organization/`+panel+`"`) {
 		t.Fatalf("expected nav href for %q panel", panel)
 	}
 	if !strings.Contains(body, `data-org-admin-default-panel="`+panel+`"`) {
@@ -200,5 +200,19 @@ func TestOrgAdminActivePanelTemplateRendering(t *testing.T) {
 			}
 			assertOrgAdminActivePanel(t, out.String(), panel)
 		})
+	}
+}
+
+func TestLegacyOrgAdminRoutesReturnNotFound(t *testing.T) {
+	server := orgAdminSectionURLTestServer(t, time.Now().UTC())
+	mux := server.newMux()
+
+	req := httptest.NewRequest(http.MethodGet, "/org-admin/profile", nil)
+	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
 	}
 }

--- a/server/cmd/server/org_admin_section_urls_test.go
+++ b/server/cmd/server/org_admin_section_urls_test.go
@@ -216,3 +216,20 @@ func TestLegacyOrgAdminRoutesReturnNotFound(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
 	}
 }
+
+func TestMyOrganizationProfileRouteViaMux(t *testing.T) {
+	server := orgAdminSectionURLTestServer(t, time.Now().UTC())
+	mux := server.newMux()
+
+	req := httptest.NewRequest(http.MethodGet, "/my/organization/profile", nil)
+	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusNotFound {
+		t.Fatalf("status = %d, want route registered (not 404)", rec.Code)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}

--- a/server/cmd/server/org_admin_section_urls_test.go
+++ b/server/cmd/server/org_admin_section_urls_test.go
@@ -233,3 +233,24 @@ func TestMyOrganizationProfileRouteViaMux(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
 }
+
+func TestUnknownMyRoutesReturnNotFound(t *testing.T) {
+	server := orgAdminSectionURLTestServer(t, time.Now().UTC())
+	mux := server.newMux()
+
+	cases := []string{
+		"/my/not-a-page",
+		"/my/organization/not-a-section",
+	}
+	for _, path := range cases {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+			if rec.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+			}
+		})
+	}
+}

--- a/server/cmd/server/org_admin_template_sidebar_test.go
+++ b/server/cmd/server/org_admin_template_sidebar_test.go
@@ -14,7 +14,7 @@ func TestOrgAdminTemplateRendersSidebarPanels(t *testing.T) {
 			Name: "Acme Org",
 			Slug: "acme-org",
 		},
-		OrganizationLogoURL: "/org-admin/logo/logo-1",
+		OrganizationLogoURL: "/my/organization/logo/logo-1",
 		Roles: []Role{
 			{Slug: "qa-reviewer", Name: "QA Reviewer"},
 		},

--- a/server/cmd/server/org_logo_helpers_test.go
+++ b/server/cmd/server/org_logo_helpers_test.go
@@ -28,7 +28,7 @@ func organizationLogoRequest(t *testing.T, filename, contentType string, data []
 		t.Fatalf("writer.Close error: %v", err)
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/org-admin/users", &body)
+	req := httptest.NewRequest(http.MethodPost, "/my/organization/users", &body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	if err := req.ParseMultipartForm(int64(body.Len())); err != nil {
 		t.Fatalf("ParseMultipartForm error: %v", err)

--- a/server/cmd/server/panel_markup_test.go
+++ b/server/cmd/server/panel_markup_test.go
@@ -11,7 +11,7 @@ func TestProcessDownloadsPanelMarkup(t *testing.T) {
 
 	var out bytes.Buffer
 	view := ProcessPageView{
-		PageBase:  PageBase{WorkflowPath: "/w/demo"},
+		PageBase:  PageBase{WorkflowPath: "/my/streams/demo"},
 		ProcessID: "proc-1",
 	}
 	if err := tmpl.ExecuteTemplate(&out, "process_downloads", view); err != nil {
@@ -49,7 +49,7 @@ func TestProcessDPPPanelMarkup(t *testing.T) {
 
 	var out bytes.Buffer
 	view := ProcessPageView{
-		PageBase: PageBase{WorkflowPath: "/w/demo"},
+		PageBase: PageBase{WorkflowPath: "/my/streams/demo"},
 		DPPURL:   "https://example.com/01/01234567890123/10/LOT1/21/SN1",
 		DPPGS1:   "01/01234567890123/10/LOT1/21/SN1",
 	}
@@ -248,7 +248,7 @@ func TestStreamHomeBodyPanelMarkup(t *testing.T) {
 	view := HomeView{
 		PageBase: PageBase{
 			WorkflowKey:  "workflow",
-			WorkflowPath: "/w/workflow",
+			WorkflowPath: "/my/streams/workflow",
 			WorkflowName: "Demo workflow",
 		},
 		StatusFilter:  "all",

--- a/server/cmd/server/paths.go
+++ b/server/cmd/server/paths.go
@@ -1,0 +1,24 @@
+package main
+
+import "strings"
+
+const appHomePath = "/my"
+
+func streamPath(key string) string {
+	return "/my/streams/" + strings.TrimSpace(key)
+}
+
+func streamInstancePath(key, instanceID string) string {
+	return streamPath(key) + "/instance/" + strings.TrimSpace(instanceID)
+}
+
+// organizationPath joins /my/organization with rest.
+// rest may be "profile", "/roles", or "formata-builder?stream=x".
+func organizationPath(rest string) string {
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		return "/my/organization"
+	}
+	rest = strings.TrimPrefix(rest, "/")
+	return "/my/organization/" + rest
+}

--- a/server/cmd/server/paths_test.go
+++ b/server/cmd/server/paths_test.go
@@ -1,0 +1,38 @@
+package main
+
+import "testing"
+
+func TestStreamPath(t *testing.T) {
+	if got := streamPath("  wf-a  "); got != "/my/streams/wf-a" {
+		t.Fatalf("streamPath = %q", got)
+	}
+}
+
+func TestStreamInstancePath(t *testing.T) {
+	if got := streamInstancePath("wf-a", "abc123"); got != "/my/streams/wf-a/instance/abc123" {
+		t.Fatalf("streamInstancePath = %q", got)
+	}
+}
+
+func TestOrganizationPath(t *testing.T) {
+	cases := []struct {
+		rest string
+		want string
+	}{
+		{"", "/my/organization"},
+		{"profile", "/my/organization/profile"},
+		{"/roles", "/my/organization/roles"},
+		{"formata-builder?stream=x", "/my/organization/formata-builder?stream=x"},
+	}
+	for _, tc := range cases {
+		if got := organizationPath(tc.rest); got != tc.want {
+			t.Fatalf("organizationPath(%q) = %q, want %q", tc.rest, got, tc.want)
+		}
+	}
+}
+
+func TestAppHomePath(t *testing.T) {
+	if appHomePath != "/my" {
+		t.Fatalf("appHomePath = %q", appHomePath)
+	}
+}

--- a/server/cmd/server/process_action_selection_test.go
+++ b/server/cmd/server/process_action_selection_test.go
@@ -47,7 +47,7 @@ func TestResolveSelectedSubstepIDAndSelectAction(t *testing.T) {
 }
 
 func TestCloneRequestWithSelectedSubstepUpdatesQuery(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/process/123/content?substep=1.1&filter=active", nil)
+	req := httptest.NewRequest(http.MethodGet, "/instance/123/content?substep=1.1&filter=active", nil)
 
 	cleared := cloneRequestWithSelectedSubstep(req, "")
 	if got := cleared.URL.Query().Get("substep"); got != "" {
@@ -70,7 +70,7 @@ func TestCloneRequestWithSelectedSubstepUpdatesQuery(t *testing.T) {
 }
 
 func TestCloneRequestWithSelectedSubstepHandlesNilURL(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/process/123/content", nil)
+	req := httptest.NewRequest(http.MethodGet, "/instance/123/content", nil)
 	req.URL = nil
 	req.RequestURI = ""
 
@@ -149,7 +149,7 @@ func TestDecorateTimelineActionsMapsUnauthorizedAvailableToActive(t *testing.T) 
 
 func TestHandleProcessActionsRouteRemoved(t *testing.T) {
 	server := &Server{store: NewMemoryStore(), tmpl: testTemplates()}
-	req := httptest.NewRequest(http.MethodGet, "/process/507f1f77bcf86cd799439011/actions", nil)
+	req := httptest.NewRequest(http.MethodGet, "/instance/507f1f77bcf86cd799439011/actions", nil)
 	rec := httptest.NewRecorder()
 
 	server.handleProcessRoutes(rec, req)

--- a/server/cmd/server/process_read_handler_test.go
+++ b/server/cmd/server/process_read_handler_test.go
@@ -39,7 +39,7 @@ func TestHandleProcessContentPartialSelectsSubstepInTimeline(t *testing.T) {
 		},
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/process/"+processID.Hex()+"/content?substep=1.2", nil)
+	req := httptest.NewRequest(http.MethodGet, "/instance/"+processID.Hex()+"/content?substep=1.2", nil)
 	rec := httptest.NewRecorder()
 	server.handleProcessRoutes(rec, req)
 
@@ -68,7 +68,7 @@ func TestHandleProcessPageAndContentSuccess(t *testing.T) {
 		},
 	}
 
-	pageReq := httptest.NewRequest(http.MethodGet, "/process/"+id.Hex(), nil)
+	pageReq := httptest.NewRequest(http.MethodGet, "/instance/"+id.Hex(), nil)
 	pageRec := httptest.NewRecorder()
 	server.handleProcessRoutes(pageRec, pageReq)
 	if pageRec.Code != http.StatusOK {
@@ -81,7 +81,7 @@ func TestHandleProcessPageAndContentSuccess(t *testing.T) {
 		t.Fatalf("expected process content in page response, got %q", pageRec.Body.String())
 	}
 
-	contentReq := httptest.NewRequest(http.MethodGet, "/process/"+id.Hex()+"/content", nil)
+	contentReq := httptest.NewRequest(http.MethodGet, "/instance/"+id.Hex()+"/content", nil)
 	contentRec := httptest.NewRecorder()
 	server.handleProcessRoutes(contentRec, contentReq)
 	if contentRec.Code != http.StatusOK {
@@ -101,7 +101,7 @@ func TestHandleProcessPageNotFoundCases(t *testing.T) {
 		},
 	}
 
-	badIDReq := httptest.NewRequest(http.MethodGet, "/process/not-an-id", nil)
+	badIDReq := httptest.NewRequest(http.MethodGet, "/instance/not-an-id", nil)
 	badIDRec := httptest.NewRecorder()
 	server.handleProcessRoutes(badIDRec, badIDReq)
 	if badIDRec.Code != http.StatusNotFound {
@@ -109,7 +109,7 @@ func TestHandleProcessPageNotFoundCases(t *testing.T) {
 	}
 
 	missingID := primitive.NewObjectID().Hex()
-	missingReq := httptest.NewRequest(http.MethodGet, "/process/"+missingID, nil)
+	missingReq := httptest.NewRequest(http.MethodGet, "/instance/"+missingID, nil)
 	missingRec := httptest.NewRecorder()
 	server.handleProcessRoutes(missingRec, missingReq)
 	if missingRec.Code != http.StatusNotFound {
@@ -126,7 +126,7 @@ func TestHandleProcessContentNotFoundCases(t *testing.T) {
 		},
 	}
 
-	badIDReq := httptest.NewRequest(http.MethodGet, "/process/not-an-id/content", nil)
+	badIDReq := httptest.NewRequest(http.MethodGet, "/instance/not-an-id/content", nil)
 	badIDRec := httptest.NewRecorder()
 	server.handleProcessRoutes(badIDRec, badIDReq)
 	if badIDRec.Code != http.StatusNotFound {
@@ -134,7 +134,7 @@ func TestHandleProcessContentNotFoundCases(t *testing.T) {
 	}
 
 	missingID := primitive.NewObjectID().Hex()
-	missingReq := httptest.NewRequest(http.MethodGet, "/process/"+missingID+"/content", nil)
+	missingReq := httptest.NewRequest(http.MethodGet, "/instance/"+missingID+"/content", nil)
 	missingRec := httptest.NewRecorder()
 	server.handleProcessRoutes(missingRec, missingReq)
 	if missingRec.Code != http.StatusNotFound {
@@ -154,7 +154,7 @@ func TestHandleProcessPageTemplateErrorReturns500(t *testing.T) {
 		},
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/process/"+id.Hex(), nil)
+	req := httptest.NewRequest(http.MethodGet, "/instance/"+id.Hex(), nil)
 	rr := httptest.NewRecorder()
 	server.handleProcessRoutes(rr, req)
 
@@ -175,7 +175,7 @@ func TestHandleProcessContentTemplateErrorReturns500(t *testing.T) {
 		},
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/process/"+id.Hex()+"/content", nil)
+	req := httptest.NewRequest(http.MethodGet, "/instance/"+id.Hex()+"/content", nil)
 	rr := httptest.NewRecorder()
 	server.handleProcessRoutes(rr, req)
 
@@ -203,7 +203,7 @@ func TestHandleProcessRoutesRejectsWorkflowMismatch(t *testing.T) {
 		},
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/process/"+processID.Hex(), nil)
+	req := httptest.NewRequest(http.MethodGet, "/instance/"+processID.Hex(), nil)
 	req = req.WithContext(context.WithValue(req.Context(), workflowContextKey{}, workflowContextValue{
 		Key: "workflow",
 		Cfg: testRuntimeConfig(),
@@ -244,7 +244,7 @@ func TestHandleProcessPageIncludesDPPLinkWhenPresent(t *testing.T) {
 		},
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/process/"+processID.Hex(), nil)
+	req := httptest.NewRequest(http.MethodGet, "/instance/"+processID.Hex(), nil)
 	rr := httptest.NewRecorder()
 	server.handleProcessRoutes(rr, req)
 
@@ -287,7 +287,7 @@ func TestHandleProcessPageRendersDPPLabel(t *testing.T) {
 		},
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/process/"+processID.Hex(), nil)
+	req := httptest.NewRequest(http.MethodGet, "/instance/"+processID.Hex(), nil)
 	rr := httptest.NewRecorder()
 	server.handleProcessRoutes(rr, req)
 
@@ -329,7 +329,7 @@ func TestHandleProcessDownloadsPartialExcludesDPPSection(t *testing.T) {
 		},
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/process/"+processID.Hex()+"/downloads", nil)
+	req := httptest.NewRequest(http.MethodGet, "/instance/"+processID.Hex()+"/downloads", nil)
 	rr := httptest.NewRecorder()
 	server.handleProcessRoutes(rr, req)
 
@@ -376,7 +376,7 @@ func TestHandleProcessDownloadsPartialBackfillsDPPForDoneProcess(t *testing.T) {
 		},
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/process/"+processID.Hex()+"/downloads", nil)
+	req := httptest.NewRequest(http.MethodGet, "/instance/"+processID.Hex()+"/downloads", nil)
 	rr := httptest.NewRecorder()
 	server.handleProcessRoutes(rr, req)
 	if rr.Code != http.StatusOK {
@@ -408,7 +408,7 @@ func TestHandleProcessDownloadsPartialNotFoundAndMismatch(t *testing.T) {
 			},
 		}
 
-		req := httptest.NewRequest(http.MethodGet, "/process/"+primitive.NewObjectID().Hex()+"/downloads", nil)
+		req := httptest.NewRequest(http.MethodGet, "/instance/"+primitive.NewObjectID().Hex()+"/downloads", nil)
 		rr := httptest.NewRecorder()
 		server.handleProcessRoutes(rr, req)
 		if rr.Code != http.StatusNotFound {
@@ -433,7 +433,7 @@ func TestHandleProcessDownloadsPartialNotFoundAndMismatch(t *testing.T) {
 			},
 		}
 
-		req := httptest.NewRequest(http.MethodGet, "/process/"+processID.Hex()+"/downloads", nil)
+		req := httptest.NewRequest(http.MethodGet, "/instance/"+processID.Hex()+"/downloads", nil)
 		req = req.WithContext(context.WithValue(req.Context(), workflowContextKey{}, workflowContextValue{
 			Key: "workflow",
 			Cfg: testRuntimeConfig(),
@@ -466,7 +466,7 @@ func TestHandleProcessDownloadsPartialTemplateAndConfigErrors(t *testing.T) {
 			},
 		}
 
-		req := httptest.NewRequest(http.MethodGet, "/process/"+processID.Hex()+"/downloads", nil)
+		req := httptest.NewRequest(http.MethodGet, "/instance/"+processID.Hex()+"/downloads", nil)
 		rr := httptest.NewRecorder()
 		server.handleProcessRoutes(rr, req)
 		if rr.Code != http.StatusInternalServerError {
@@ -483,7 +483,7 @@ func TestHandleProcessDownloadsPartialTemplateAndConfigErrors(t *testing.T) {
 			},
 		}
 
-		req := httptest.NewRequest(http.MethodGet, "/process/"+processID.Hex()+"/downloads", nil)
+		req := httptest.NewRequest(http.MethodGet, "/instance/"+processID.Hex()+"/downloads", nil)
 		rr := httptest.NewRecorder()
 		server.handleProcessRoutes(rr, req)
 		if rr.Code != http.StatusInternalServerError {

--- a/server/cmd/server/process_routes_test.go
+++ b/server/cmd/server/process_routes_test.go
@@ -49,12 +49,12 @@ func TestHandleProcessRoutesDispatchesEndpoints(t *testing.T) {
 		wantStatus int
 		wantBody   string
 	}{
-		{name: "process page", method: http.MethodGet, path: "/process/" + process.ID.Hex(), wantStatus: http.StatusOK, wantBody: "PROCESS"},
-		{name: "process content", method: http.MethodGet, path: "/process/" + process.ID.Hex() + "/content", wantStatus: http.StatusOK, wantBody: "PROCESS_CONTENT"},
-		{name: "notarized export", method: http.MethodGet, path: "/process/" + process.ID.Hex() + "/notarized.json", wantStatus: http.StatusOK},
-		{name: "merkle export", method: http.MethodGet, path: "/process/" + process.ID.Hex() + "/merkle.json", wantStatus: http.StatusOK},
-		{name: "all files zip", method: http.MethodGet, path: "/process/" + process.ID.Hex() + "/files.zip", wantStatus: http.StatusOK},
-		{name: "complete substep", method: http.MethodPost, path: "/process/" + process.ID.Hex() + "/substep/1.1/complete", body: "value=%7B%22status%22%3A%22ok%22%7D", wantStatus: http.StatusOK, wantBody: "PROCESS " + process.ID.Hex()},
+		{name: "process page", method: http.MethodGet, path: "/instance/" + process.ID.Hex(), wantStatus: http.StatusOK, wantBody: "PROCESS"},
+		{name: "process content", method: http.MethodGet, path: "/instance/" + process.ID.Hex() + "/content", wantStatus: http.StatusOK, wantBody: "PROCESS_CONTENT"},
+		{name: "notarized export", method: http.MethodGet, path: "/instance/" + process.ID.Hex() + "/notarized.json", wantStatus: http.StatusOK},
+		{name: "merkle export", method: http.MethodGet, path: "/instance/" + process.ID.Hex() + "/merkle.json", wantStatus: http.StatusOK},
+		{name: "all files zip", method: http.MethodGet, path: "/instance/" + process.ID.Hex() + "/files.zip", wantStatus: http.StatusOK},
+		{name: "complete substep", method: http.MethodPost, path: "/instance/" + process.ID.Hex() + "/substep/1.1/complete", body: "value=%7B%22status%22%3A%22ok%22%7D", wantStatus: http.StatusOK, wantBody: "PROCESS " + process.ID.Hex()},
 	}
 
 	for _, tc := range tests {
@@ -89,10 +89,10 @@ func TestHandleProcessRoutesReturns404ForInvalidPaths(t *testing.T) {
 		method string
 		path   string
 	}{
-		{name: "missing process id", method: http.MethodGet, path: "/process/"},
-		{name: "wrong method for process page", method: http.MethodPost, path: "/process/" + primitive.NewObjectID().Hex()},
-		{name: "wrong method for complete", method: http.MethodGet, path: "/process/" + primitive.NewObjectID().Hex() + "/substep/1.1/complete"},
-		{name: "unknown path", method: http.MethodGet, path: "/process/" + primitive.NewObjectID().Hex() + "/unknown"},
+		{name: "missing process id", method: http.MethodGet, path: "/instance/"},
+		{name: "wrong method for process page", method: http.MethodPost, path: "/instance/" + primitive.NewObjectID().Hex()},
+		{name: "wrong method for complete", method: http.MethodGet, path: "/instance/" + primitive.NewObjectID().Hex() + "/substep/1.1/complete"},
+		{name: "unknown path", method: http.MethodGet, path: "/instance/" + primitive.NewObjectID().Hex() + "/unknown"},
 	}
 
 	for _, tc := range tests {
@@ -132,16 +132,16 @@ func TestHandleWorkflowRoutesDispatchAndUnknownWorkflow(t *testing.T) {
 		configDir:  tempDir,
 	}
 
-	okReq := httptest.NewRequest(http.MethodGet, "/w/workflow/process/"+process.ID.Hex(), nil)
+	okReq := httptest.NewRequest(http.MethodGet, "/streams/workflow/instance/"+process.ID.Hex(), nil)
 	okRec := httptest.NewRecorder()
-	server.handleWorkflowRoutes(okRec, okReq)
+	server.handleStreamRoutes(okRec, okReq)
 	if okRec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", okRec.Code, http.StatusOK)
 	}
 
-	missingReq := httptest.NewRequest(http.MethodGet, "/w/missing/process/"+process.ID.Hex(), nil)
+	missingReq := httptest.NewRequest(http.MethodGet, "/streams/missing/instance/"+process.ID.Hex(), nil)
 	missingRec := httptest.NewRecorder()
-	server.handleWorkflowRoutes(missingRec, missingReq)
+	server.handleStreamRoutes(missingRec, missingReq)
 	if missingRec.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want %d", missingRec.Code, http.StatusNotFound)
 	}
@@ -160,30 +160,30 @@ func TestHandleWorkflowRoutesAdditionalBranches(t *testing.T) {
 		configDir:  tempDir,
 	}
 
-	reqMissingWorkflow := httptest.NewRequest(http.MethodGet, "/w/", nil)
+	reqMissingWorkflow := httptest.NewRequest(http.MethodGet, "/streams/", nil)
 	recMissingWorkflow := httptest.NewRecorder()
-	server.handleWorkflowRoutes(recMissingWorkflow, reqMissingWorkflow)
+	server.handleStreamRoutes(recMissingWorkflow, reqMissingWorkflow)
 	if recMissingWorkflow.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want %d", recMissingWorkflow.Code, http.StatusNotFound)
 	}
 
-	reqWorkflowHome := httptest.NewRequest(http.MethodGet, "/w/workflow/", nil)
+	reqWorkflowHome := httptest.NewRequest(http.MethodGet, "/streams/workflow/", nil)
 	recWorkflowHome := httptest.NewRecorder()
-	server.handleWorkflowRoutes(recWorkflowHome, reqWorkflowHome)
+	server.handleStreamRoutes(recWorkflowHome, reqWorkflowHome)
 	if recWorkflowHome.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", recWorkflowHome.Code, http.StatusOK)
 	}
 
-	reqUnknown := httptest.NewRequest(http.MethodGet, "/w/workflow/unknown", nil)
+	reqUnknown := httptest.NewRequest(http.MethodGet, "/streams/workflow/unknown", nil)
 	recUnknown := httptest.NewRecorder()
-	server.handleWorkflowRoutes(recUnknown, reqUnknown)
+	server.handleStreamRoutes(recUnknown, reqUnknown)
 	if recUnknown.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want %d", recUnknown.Code, http.StatusNotFound)
 	}
 
-	reqEvents := httptest.NewRequest(http.MethodGet, "/w/workflow/events?role=qa", nil)
+	reqEvents := httptest.NewRequest(http.MethodGet, "/streams/workflow/events?role=qa", nil)
 	recEvents := httptest.NewRecorder()
-	server.handleWorkflowRoutes(recEvents, reqEvents)
+	server.handleStreamRoutes(recEvents, reqEvents)
 	if recEvents.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d", recEvents.Code, http.StatusBadRequest)
 	}
@@ -227,10 +227,10 @@ func TestHandleWorkflowRoutesRedirectsInvalidWorkflowToWorkflowHome(t *testing.T
 		configDir:   tempDir,
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/w/workflow/process/"+process.ID.Hex(), nil)
+	req := httptest.NewRequest(http.MethodGet, "/streams/workflow/instance/"+process.ID.Hex(), nil)
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
 	rec := httptest.NewRecorder()
-	server.handleWorkflowRoutes(rec, req)
+	server.handleStreamRoutes(rec, req)
 
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
@@ -240,8 +240,8 @@ func TestHandleWorkflowRoutesRedirectsInvalidWorkflowToWorkflowHome(t *testing.T
 	if err != nil {
 		t.Fatalf("parse location: %v", err)
 	}
-	if parsed.Path != "/w/workflow/" {
-		t.Fatalf("redirect path = %q, want %q", parsed.Path, "/w/workflow/")
+	if parsed.Path != "/my/streams/workflow/" {
+		t.Fatalf("redirect path = %q, want %q", parsed.Path, "/my/streams/workflow/")
 	}
 	if got := parsed.Query().Get("error"); !strings.Contains(got, "workflow references are invalid") {
 		t.Fatalf("redirect error = %q, want workflow validation message", got)
@@ -255,9 +255,9 @@ func TestHandleWorkflowRoutesRequiresAuthWhenEnabled(t *testing.T) {
 		enforceAuth: true,
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/w/workflow", nil)
+	req := httptest.NewRequest(http.MethodGet, "/my/streams/workflow", nil)
 	rec := httptest.NewRecorder()
-	server.handleWorkflowRoutes(rec, req)
+	server.handleMyRoutes(rec, req)
 
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)

--- a/server/cmd/server/process_template_test.go
+++ b/server/cmd/server/process_template_test.go
@@ -14,7 +14,7 @@ func TestProcessTemplateRendersAccordionSubstepContent(t *testing.T) {
 			Body:         "process_body",
 			WorkflowKey:  "workflow",
 			WorkflowName: "Main Workflow",
-			WorkflowPath: "/w/workflow",
+			WorkflowPath: "/my/streams/workflow",
 		},
 		ProcessID:    "process-1",
 		InstanceName: "Pilot batch",

--- a/server/cmd/server/store_test.go
+++ b/server/cmd/server/store_test.go
@@ -52,8 +52,8 @@ func TestHandleStartProcessWithMemoryStore(t *testing.T) {
 		t.Fatalf("expected status %d, got %d", http.StatusSeeOther, rr.Code)
 	}
 	location := rr.Header().Get("Location")
-	if !strings.HasPrefix(location, "/w/workflow/process/") {
-		t.Fatalf("expected redirect location /w/workflow/process/:id, got %q", location)
+	if !strings.HasPrefix(location, "/my/streams/workflow/instance/") {
+		t.Fatalf("expected redirect location /my/streams/workflow/instance/:id, got %q", location)
 	}
 
 	processes, err := store.ListRecentProcessesByWorkflow(t.Context(), "workflow", 10)

--- a/server/cmd/server/stream_card_test.go
+++ b/server/cmd/server/stream_card_test.go
@@ -24,7 +24,7 @@ func TestStreamCardTemplateRendersCoreFields(t *testing.T) {
 		CanEdit:     true,
 		CanDelete:   true,
 		EditAction:  "/org-admin/formata-builder?stream=demo",
-		DeleteAction: "/w/demo/delete",
+		DeleteAction: "/my/streams/demo/delete",
 	}
 	if err := tmpl.ExecuteTemplate(&out, "stream_card", card); err != nil {
 		t.Fatalf("render stream_card template: %v", err)
@@ -39,7 +39,7 @@ func TestStreamCardTemplateRendersCoreFields(t *testing.T) {
 		`class="stream-card-footer"`,
 		`class="stream-card-turn-indicator"`,
 		`class="btn btn-ghost btn-icon stream-card-menu-trigger"`,
-		`href="/w/demo/"`,
+		`href="/my/streams/demo/"`,
 		"Demo Stream",
 		"Track a pilot batch end to end",
 		"<td>2</td>",

--- a/server/cmd/server/stream_card_test.go
+++ b/server/cmd/server/stream_card_test.go
@@ -23,7 +23,7 @@ func TestStreamCardTemplateRendersCoreFields(t *testing.T) {
 		CanClone:    true,
 		CanEdit:     true,
 		CanDelete:   true,
-		EditAction:  "/org-admin/formata-builder?stream=demo",
+		EditAction:  "/my/organization/formata-builder?stream=demo",
 		DeleteAction: "/my/streams/demo/delete",
 	}
 	if err := tmpl.ExecuteTemplate(&out, "stream_card", card); err != nil {
@@ -64,7 +64,7 @@ func TestStreamCardCreateTemplateRendersCTA(t *testing.T) {
 	for _, want := range []string{
 		`class="stream-card stream-card-create"`,
 		`class="stream-card-cta"`,
-		`href="/org-admin/formata-builder"`,
+		`href="/my/organization/formata-builder"`,
 		"Create new stream",
 	} {
 		if !strings.Contains(body, want) {

--- a/server/cmd/server/stream_delete_handler_test.go
+++ b/server/cmd/server/stream_delete_handler_test.go
@@ -48,10 +48,10 @@ func TestHandleDeleteWorkflow(t *testing.T) {
 			t.Fatalf("workflowByKey: %v", err)
 		}
 
-		req := httptest.NewRequest(http.MethodPost, "/w/"+saved.ID.Hex()+"/delete", nil)
+		req := httptest.NewRequest(http.MethodPost, "/streams/"+saved.ID.Hex()+"/delete", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: sessionID})
 		rec := httptest.NewRecorder()
-		server.handleWorkflowRoutes(rec, req)
+		server.handleStreamRoutes(rec, req)
 
 		if rec.Code != http.StatusSeeOther {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
@@ -101,10 +101,10 @@ func TestHandleDeleteWorkflow(t *testing.T) {
 			now:         func() time.Time { return now },
 		}
 
-		req := httptest.NewRequest(http.MethodPost, "/w/"+saved.ID.Hex()+"/delete", nil)
+		req := httptest.NewRequest(http.MethodPost, "/streams/"+saved.ID.Hex()+"/delete", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: sessionID})
 		rec := httptest.NewRecorder()
-		server.handleWorkflowRoutes(rec, req)
+		server.handleStreamRoutes(rec, req)
 
 		if rec.Code != http.StatusSeeOther {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
@@ -163,10 +163,10 @@ func TestHandleDeleteWorkflow(t *testing.T) {
 			now:         func() time.Time { return now },
 		}
 
-		req := httptest.NewRequest(http.MethodPost, "/w/"+saved.ID.Hex()+"/delete", nil)
+		req := httptest.NewRequest(http.MethodPost, "/streams/"+saved.ID.Hex()+"/delete", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
-		server.handleWorkflowRoutes(rec, req)
+		server.handleStreamRoutes(rec, req)
 
 		if rec.Code != http.StatusSeeOther {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
@@ -221,10 +221,10 @@ func TestHandleDeleteWorkflow(t *testing.T) {
 			now:         func() time.Time { return now },
 		}
 
-		req := httptest.NewRequest(http.MethodPost, "/w/"+saved.ID.Hex()+"/delete", nil)
+		req := httptest.NewRequest(http.MethodPost, "/streams/"+saved.ID.Hex()+"/delete", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: sessionID})
 		rec := httptest.NewRecorder()
-		server.handleWorkflowRoutes(rec, req)
+		server.handleStreamRoutes(rec, req)
 
 		if rec.Code != http.StatusBadGateway {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadGateway)
@@ -269,10 +269,10 @@ func TestHandleDeleteWorkflow(t *testing.T) {
 			now:         func() time.Time { return now },
 		}
 
-		req := httptest.NewRequest(http.MethodPost, "/w/"+saved.ID.Hex()+"/delete", nil)
+		req := httptest.NewRequest(http.MethodPost, "/streams/"+saved.ID.Hex()+"/delete", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: sessionID})
 		rec := httptest.NewRecorder()
-		server.handleWorkflowRoutes(rec, req)
+		server.handleStreamRoutes(rec, req)
 
 		if rec.Code != http.StatusSeeOther {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
@@ -400,11 +400,11 @@ func TestHandleDeleteWorkflow(t *testing.T) {
 			enforceAuth: true,
 			now:         func() time.Time { return now },
 		}
-		req := httptest.NewRequest(http.MethodPost, "/w/"+saved.ID.Hex()+"/delete", nil)
+		req := httptest.NewRequest(http.MethodPost, "/streams/"+saved.ID.Hex()+"/delete", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-has-err"})
 		rec := httptest.NewRecorder()
 
-		server.handleWorkflowRoutes(rec, req)
+		server.handleStreamRoutes(rec, req)
 
 		if rec.Code != http.StatusInternalServerError {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
@@ -429,11 +429,11 @@ func TestHandleDeleteWorkflow(t *testing.T) {
 			enforceAuth: true,
 			now:         func() time.Time { return now },
 		}
-		req := httptest.NewRequest(http.MethodPost, "/w/"+saved.ID.Hex()+"/delete", nil)
+		req := httptest.NewRequest(http.MethodPost, "/streams/"+saved.ID.Hex()+"/delete", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-no-authorizer"})
 		rec := httptest.NewRecorder()
 
-		server.handleWorkflowRoutes(rec, req)
+		server.handleStreamRoutes(rec, req)
 
 		if rec.Code != http.StatusBadGateway {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadGateway)
@@ -470,11 +470,11 @@ func TestHandleDeleteWorkflow(t *testing.T) {
 			enforceAuth: true,
 			now:         func() time.Time { return now },
 		}
-		req := httptest.NewRequest(http.MethodPost, "/w/"+saved.ID.Hex()+"/delete", nil)
+		req := httptest.NewRequest(http.MethodPost, "/streams/"+saved.ID.Hex()+"/delete", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
 
-		server.handleWorkflowRoutes(rec, req)
+		server.handleStreamRoutes(rec, req)
 
 		if rec.Code != http.StatusInternalServerError {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
@@ -502,11 +502,11 @@ func TestHandleDeleteWorkflow(t *testing.T) {
 			enforceAuth: true,
 			now:         func() time.Time { return now },
 		}
-		req := httptest.NewRequest(http.MethodPost, "/w/"+saved.ID.Hex()+"/delete", nil)
+		req := httptest.NewRequest(http.MethodPost, "/streams/"+saved.ID.Hex()+"/delete", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-non-creator"})
 		rec := httptest.NewRecorder()
 
-		server.handleWorkflowRoutes(rec, req)
+		server.handleStreamRoutes(rec, req)
 
 		if rec.Code != http.StatusSeeOther {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
@@ -538,11 +538,11 @@ func TestHandleDeleteWorkflow(t *testing.T) {
 			enforceAuth: true,
 			now:         func() time.Time { return now },
 		}
-		req := httptest.NewRequest(http.MethodPost, "/w/"+saved.ID.Hex()+"/delete", nil)
+		req := httptest.NewRequest(http.MethodPost, "/streams/"+saved.ID.Hex()+"/delete", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-delete-stream-err"})
 		rec := httptest.NewRecorder()
 
-		server.handleWorkflowRoutes(rec, req)
+		server.handleStreamRoutes(rec, req)
 
 		if rec.Code != http.StatusInternalServerError {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)

--- a/server/cmd/server/stream_instance_card_test.go
+++ b/server/cmd/server/stream_instance_card_test.go
@@ -15,7 +15,7 @@ func TestStreamInstanceCardTemplateRendersDetailLink(t *testing.T) {
 		Name:          "Pilot batch",
 		Status:        "available",
 		StatusLabel:   "Available",
-		DetailHref:    "/w/workflow/process/process-1",
+		DetailHref:    "/my/streams/workflow/instance/process-1",
 		Percent:       25,
 		DoneSubsteps:  1,
 		TotalSubsteps: 4,
@@ -39,7 +39,7 @@ func TestStreamInstanceCardTemplateRendersDetailLink(t *testing.T) {
 		`class="stream-instance-card-progress-fill"`,
 		`class="stream-instance-card-meta"`,
 		`class="stream-instance-card-meta-primary"`,
-		`href="/w/workflow/process/process-1"`,
+		`href="/my/streams/workflow/instance/process-1"`,
 		`class="status-tag status-tag-compact"`,
 		`data-stream-status="available"`,
 		`class="js-local-datetime"`,
@@ -74,7 +74,7 @@ func TestStreamInstanceCardTemplateRendersStatusIcon(t *testing.T) {
 			card := StreamInstanceCard{
 				ID:         "process-1",
 				Status:     tc.status,
-				DetailHref: "/w/workflow/process/process-1",
+				DetailHref: "/my/streams/workflow/instance/process-1",
 			}
 			if err := tmpl.ExecuteTemplate(&out, "stream_instance_card", card); err != nil {
 				t.Fatalf("render stream_instance_card template: %v", err)

--- a/server/cmd/server/stream_instance_detail.go
+++ b/server/cmd/server/stream_instance_detail.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"strings"
 )
 
@@ -18,7 +17,7 @@ func (s *Server) buildStreamInstanceDetailView(ctx context.Context, cfg RuntimeC
 
 	view := StreamInstanceDetailView{
 		WorkflowKey:       workflowKey,
-		WorkflowPath:      workflowPath(workflowKey),
+		WorkflowPath:      streamPath(workflowKey),
 		ProcessID:         processIDString(process),
 		CurrentUser:       actor,
 		SelectedSubstepID: selected,
@@ -29,7 +28,7 @@ func (s *Server) buildStreamInstanceDetailView(ctx context.Context, cfg RuntimeC
 	if process != nil && !processDone {
 		if action, ok := nextAuthorizedSubstepBody(cfg.Workflow, process, workflowKey, actor, roleMeta, cfg.Roles); ok {
 			view.CanTerminate = true
-			view.TerminateAction = fmt.Sprintf("%s/process/%s/terminate", workflowPath(workflowKey), process.ID.Hex())
+			view.TerminateAction = streamInstancePath(workflowKey, process.ID.Hex()) + "/terminate"
 			view.TerminateSubstep = action.SubstepID
 			view.TerminateRoles = append([]SubstepRoleOption(nil), action.MatchingRoles...)
 		}

--- a/server/cmd/server/substep_body_test.go
+++ b/server/cmd/server/substep_body_test.go
@@ -48,7 +48,7 @@ func TestSubstepBodyTemplateRendersResultMode(t *testing.T) {
 		Attachments: []SubstepAttachmentView{
 			{
 				Key:      "photo",
-				URL:      "/w/workflow/process/process-1/substep/1.1/file?id=abc",
+				URL:      "/my/streams/workflow/instance/process-1/attachment/abc/file",
 				Filename: "photo.jpg",
 			},
 		},

--- a/server/cmd/server/substep_override_test.go
+++ b/server/cmd/server/substep_override_test.go
@@ -133,7 +133,7 @@ func TestAuthorizeSubstepOverrideRequestBranches(t *testing.T) {
 	server, processID, _ := newServerForCompleteTests(t, store, fakeAuthorizer{})
 	cfg := testFormataRuntimeConfig()
 	user := &AccountUser{Email: "u1@example.com", RoleSlugs: []string{"dep1"}}
-	req := httptest.NewRequest(http.MethodGet, "/process/"+processID+"/substep/1.2/override", nil)
+	req := httptest.NewRequest(http.MethodGet, "/instance/"+processID+"/substep/1.2/override", nil)
 	if _, _, _, _, status, _, ok := server.authorizeSubstepOverrideRequest(req, user, "workflow", cfg, processID, "1.2"); ok || status != http.StatusConflict {
 		t.Fatalf("locked status = %d ok=%v, want conflict false", status, ok)
 	}
@@ -194,7 +194,7 @@ func TestGetSubstepOverrideRendersFormataURLAndTargetData(t *testing.T) {
 	store := NewMemoryStore()
 	server, processID, _ := newServerForCompleteTests(t, store, fakeAuthorizer{})
 	server.formataArchURL = "https://forms.example.test"
-	req := httptest.NewRequest(http.MethodGet, "/process/"+processID+"/substep/1.1/override", nil)
+	req := httptest.NewRequest(http.MethodGet, "/instance/"+processID+"/substep/1.1/override", nil)
 	req.AddCookie(&http.Cookie{Name: "demo_user", Value: "u1|dep1"})
 	rr := httptest.NewRecorder()
 	server.handleGetSubstepOverride(rr, req, processID, "1.1")
@@ -202,7 +202,7 @@ func TestGetSubstepOverrideRendersFormataURLAndTargetData(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
 	}
 	body := rr.Body.String()
-	if !strings.Contains(body, "https://forms.example.test") || !strings.Contains(body, "/process/"+processID+"/substep/1.1/override") {
+	if !strings.Contains(body, "https://forms.example.test") || !strings.Contains(body, "/instance/"+processID+"/substep/1.1/override") {
 		t.Fatalf("editor body missing formata url/save route: %s", body)
 	}
 }
@@ -210,7 +210,7 @@ func TestGetSubstepOverrideRendersFormataURLAndTargetData(t *testing.T) {
 func TestGetSubstepOverrideAllowsSameOriginBuilderWhenFormataURLMissing(t *testing.T) {
 	store := NewMemoryStore()
 	server, processID, _ := newServerForCompleteTests(t, store, fakeAuthorizer{})
-	req := httptest.NewRequest(http.MethodGet, "/process/"+processID+"/substep/1.1/override", nil)
+	req := httptest.NewRequest(http.MethodGet, "/instance/"+processID+"/substep/1.1/override", nil)
 	req.AddCookie(&http.Cookie{Name: "demo_user", Value: "u1|dep1"})
 	rr := httptest.NewRecorder()
 	server.handleGetSubstepOverride(rr, req, processID, "1.1")
@@ -227,7 +227,7 @@ func TestGetSubstepOverrideReturnsRequestErrors(t *testing.T) {
 		store := NewMemoryStore()
 		server, _, _ := newServerForCompleteTests(t, store, fakeAuthorizer{})
 		missingID := primitive.NewObjectID().Hex()
-		req := httptest.NewRequest(http.MethodGet, "/process/"+missingID+"/substep/1.1/override", nil)
+		req := httptest.NewRequest(http.MethodGet, "/instance/"+missingID+"/substep/1.1/override", nil)
 		req.AddCookie(&http.Cookie{Name: "demo_user", Value: "u1|dep1"})
 		rr := httptest.NewRecorder()
 		server.handleGetSubstepOverride(rr, req, missingID, "1.1")
@@ -242,7 +242,7 @@ func TestGetSubstepOverrideReturnsRequestErrors(t *testing.T) {
 		cfg := testFormataRuntimeConfig()
 		cfg.Workflow.Steps[0].Substep[0].InputType = "plain"
 		server.configProvider = func() (RuntimeConfig, error) { return cfg, nil }
-		req := httptest.NewRequest(http.MethodGet, "/process/"+processID+"/substep/1.1/override", nil)
+		req := httptest.NewRequest(http.MethodGet, "/instance/"+processID+"/substep/1.1/override", nil)
 		req.AddCookie(&http.Cookie{Name: "demo_user", Value: "u1|dep1"})
 		rr := httptest.NewRecorder()
 		server.handleGetSubstepOverride(rr, req, processID, "1.1")
@@ -346,7 +346,7 @@ func saveSubstepOverrideForTest(t *testing.T, server *Server, processID, substep
 
 func postSubstepOverrideForTest(t *testing.T, server *Server, processID, substepID, body string) *httptest.ResponseRecorder {
 	t.Helper()
-	req := httptest.NewRequest(http.MethodPost, "/process/"+processID+"/substep/"+substepID+"/override", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/instance/"+processID+"/substep/"+substepID+"/override", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(&http.Cookie{Name: "demo_user", Value: "u1|dep1"})
 	rr := httptest.NewRecorder()

--- a/server/cmd/server/substep_views_builder.go
+++ b/server/cmd/server/substep_views_builder.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -165,7 +164,7 @@ func buildSubstepViews(def WorkflowDef, process *Process, workflowKey string, ac
 		canAdaptForm := status == "available" && !disabled && substepSupportsLocalOverride(sub)
 		adaptURL := ""
 		if canAdaptForm {
-			adaptURL = fmt.Sprintf("/w/%s/process/%s/substep/%s/override", workflowKey, processIDString(process), sub.SubstepID)
+			adaptURL = streamInstancePath(workflowKey, processIDString(process)) + "/substep/" + sub.SubstepID + "/override"
 		}
 		actions = append(actions, withSubstepBodyMode(SubstepBodyView{
 			WorkflowKey:    workflowKey,

--- a/server/cmd/server/substep_views_builder_test.go
+++ b/server/cmd/server/substep_views_builder_test.go
@@ -68,7 +68,7 @@ func TestBuildSubstepViewsDoneFileAttachments(t *testing.T) {
 		t.Fatalf("expected 1 attachment, got %d", len(action.Attachments))
 	}
 	got := action.Attachments[0]
-	wantURL := "/w/workflow/process/" + processID.Hex() + "/attachment/" + attachmentID + "/file"
+	wantURL := "/my/streams/workflow/instance/" + processID.Hex() + "/attachment/" + attachmentID + "/file"
 	if got.URL != wantURL {
 		t.Fatalf("expected URL %q, got %q", wantURL, got.URL)
 	}
@@ -203,7 +203,7 @@ func TestBuildSubstepViewsDoneFormataValuesAndAttachments(t *testing.T) {
 	if len(action.Attachments) != 1 {
 		t.Fatalf("expected one nested attachment, got %#v", action.Attachments)
 	}
-	wantURL := "/w/workflow/process/" + processID.Hex() + "/attachment/" + attachmentID + "/file"
+	wantURL := "/my/streams/workflow/instance/" + processID.Hex() + "/attachment/" + attachmentID + "/file"
 	if action.Attachments[0].URL != wantURL {
 		t.Fatalf("expected URL %q, got %q", wantURL, action.Attachments[0].URL)
 	}

--- a/server/cmd/server/test_helpers_test.go
+++ b/server/cmd/server/test_helpers_test.go
@@ -74,6 +74,7 @@ func testTemplates() *template.Template {
 	{{define "layout.html"}}
 	  NAV Home Backoffice{{if .ShowOrgsLink}} Orgs{{end}}{{if .ShowMyOrgLink}} MyOrg{{end}} |
 	  {{if eq .Body "home_picker_body"}}{{template "home_picker_body" .}}
+	  {{else if eq .Body "public_home_body"}}{{template "public_home_body" .}}
 	  {{else if eq .Body "signup_body"}}{{template "signup_body" .}}
 	  {{else if eq .Body "platform_admin_body"}}{{template "platform_admin_body" .}}
 	  {{else if eq .Body "dashboard_body"}}{{template "dashboard_body" .}}
@@ -88,6 +89,8 @@ func testTemplates() *template.Template {
   {{else if eq .Body "dept_process_body"}}{{template "dept_process_body" .}}{{end}}
 {{end}}
 	{{define "home_picker_body"}}HOME_PICKER {{range .Workflows}}{{.Key}}:{{.Name}}{{if .Description}}:{{.Description}}{{end}}:{{.Counts.NotStarted}}/{{.Counts.Started}}/{{.Counts.Terminated}}|{{end}}{{end}}
+	{{define "public_home_body"}}PUBLIC_HOME{{end}}
+	{{define "public_home.html"}}{{template "layout.html" .}}{{end}}
 	{{define "signup_body"}}SIGNUP {{.Email}} {{.Error}}{{end}}
 	{{define "signup.html"}}{{template "layout.html" .}}{{end}}
 	{{define "platform_admin_body"}}PLATFORM_ADMIN ORGS {{len .Organizations}} {{.Confirmation}}{{if .Error}} {{.Error}}{{end}}{{end}}

--- a/server/cmd/server/workflow_coverage_test.go
+++ b/server/cmd/server/workflow_coverage_test.go
@@ -86,18 +86,30 @@ func TestHandleWorkflowRoutesDispatchFallbacks(t *testing.T) {
 	}
 }
 
-func TestLegacyWorkflowMountReturns404(t *testing.T) {
+func TestLegacyRoutesGone(t *testing.T) {
 	server := &Server{
 		store: NewMemoryStore(),
 		tmpl:  testTemplates(),
 		sse:   newSSEHub(),
 	}
+	mux := server.newMux()
 
-	req := httptest.NewRequest(http.MethodGet, "/w/workflow/", nil)
-	rec := httptest.NewRecorder()
-	server.newMux().ServeHTTP(rec, req)
-	if rec.Code != http.StatusNotFound {
-		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	cases := []string{
+		"/w/workflow/",
+		"/w/workflow/process/abc",
+		"/org-admin/profile",
+		"/dashboard",
+		"/dashboard/streams/workflow",
+	}
+	for _, path := range cases {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+			if rec.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+			}
+		})
 	}
 }
 

--- a/server/cmd/server/workflow_coverage_test.go
+++ b/server/cmd/server/workflow_coverage_test.go
@@ -66,23 +66,38 @@ func TestHandleWorkflowRoutesDispatchFallbacks(t *testing.T) {
 		path   string
 		want   int
 	}{
-		{name: "missing key", method: http.MethodGet, path: "/w/", want: http.StatusNotFound},
-		{name: "unknown tail", method: http.MethodGet, path: "/w/workflow/unknown", want: http.StatusNotFound},
-		{name: "events validation", method: http.MethodGet, path: "/w/workflow/events", want: http.StatusBadRequest},
-		{name: "start method guard", method: http.MethodGet, path: "/w/workflow/process/start", want: http.StatusMethodNotAllowed},
-		{name: "backoffice unknown role", method: http.MethodGet, path: "/w/workflow/backoffice/unknown", want: http.StatusNotFound},
-		{name: "dashboard removed", method: http.MethodGet, path: "/w/workflow/dashboard", want: http.StatusNotFound},
+		{name: "missing key", method: http.MethodGet, path: "/streams/", want: http.StatusNotFound},
+		{name: "unknown tail", method: http.MethodGet, path: "/streams/workflow/unknown", want: http.StatusNotFound},
+		{name: "events validation", method: http.MethodGet, path: "/streams/workflow/events", want: http.StatusBadRequest},
+		{name: "start method guard", method: http.MethodGet, path: "/streams/workflow/instance/start", want: http.StatusMethodNotAllowed},
+		{name: "backoffice unknown role", method: http.MethodGet, path: "/streams/workflow/backoffice/unknown", want: http.StatusNotFound},
+		{name: "dashboard removed", method: http.MethodGet, path: "/streams/workflow/dashboard", want: http.StatusNotFound},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequest(tc.method, tc.path, nil)
 			rec := httptest.NewRecorder()
-			server.handleWorkflowRoutes(rec, req)
+			server.handleStreamRoutes(rec, req)
 			if rec.Code != tc.want {
 				t.Fatalf("status = %d, want %d", rec.Code, tc.want)
 			}
 		})
+	}
+}
+
+func TestLegacyWorkflowMountReturns404(t *testing.T) {
+	server := &Server{
+		store: NewMemoryStore(),
+		tmpl:  testTemplates(),
+		sse:   newSSEHub(),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/w/workflow/", nil)
+	rec := httptest.NewRecorder()
+	server.newMux().ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
 	}
 }
 
@@ -163,7 +178,7 @@ func TestSelectedWorkflowUsesContextValueWhenPresent(t *testing.T) {
 		enforceAuth: false,
 	}
 	cfg := testRuntimeConfig()
-	req := httptest.NewRequest(http.MethodGet, "/w/workflow", nil)
+	req := httptest.NewRequest(http.MethodGet, "/streams/workflow", nil)
 	req = req.WithContext(context.WithValue(req.Context(), workflowContextKey{}, workflowContextValue{
 		Key: "from-context",
 		Cfg: cfg,

--- a/server/design/design.go
+++ b/server/design/design.go
@@ -13,12 +13,22 @@ var _ = API("attesta", func() {
 })
 
 var _ = Service("workflow", func() {
-	Description("Workflow-scoped process, workflow management, and event endpoints.")
+	Description("Workflow-scoped process, workflow management, and event endpoints under /my/streams.")
 
 	Method("home", func() {
+		Description("Public homepage (unauthenticated landing page).")
 		Result(Empty)
 		HTTP(func() {
 			GET("/")
+			Response(StatusOK)
+		})
+	})
+
+	Method("appHome", func() {
+		Description("Authenticated app home (stream picker).")
+		Result(Empty)
+		HTTP(func() {
+			GET("/my")
 			Response(StatusOK)
 		})
 	})
@@ -30,7 +40,7 @@ var _ = Service("workflow", func() {
 		})
 		Result(Empty)
 		HTTP(func() {
-			GET("/w/{workflow_key}")
+			GET("/my/streams/{workflow_key}")
 			Response(StatusOK)
 		})
 	})
@@ -42,7 +52,7 @@ var _ = Service("workflow", func() {
 		})
 		Result(Empty)
 		HTTP(func() {
-			POST("/w/{workflow_key}/process/start")
+			POST("/my/streams/{workflow_key}/instance/start")
 			Response(StatusSeeOther)
 			Response(StatusBadRequest)
 			Response(StatusInternalServerError)
@@ -56,7 +66,7 @@ var _ = Service("workflow", func() {
 		})
 		Result(Empty)
 		HTTP(func() {
-			POST("/w/{workflow_key}/delete")
+			POST("/my/streams/{workflow_key}/delete")
 			Response(StatusSeeOther)
 			Response(StatusForbidden)
 			Response(StatusNotFound)
@@ -72,7 +82,7 @@ var _ = Service("workflow", func() {
 		})
 		Result(Empty)
 		HTTP(func() {
-			GET("/w/{workflow_key}/process/{process_id}")
+			GET("/my/streams/{workflow_key}/instance/{process_id}")
 			Response(StatusOK)
 			Response(StatusNotFound)
 		})
@@ -87,7 +97,7 @@ var _ = Service("workflow", func() {
 		})
 		Result(Empty)
 		HTTP(func() {
-			GET("/w/{workflow_key}/process/{process_id}/content")
+			GET("/my/streams/{workflow_key}/instance/{process_id}/content")
 			Param("substep")
 			Response(StatusOK)
 			Response(StatusNotFound)
@@ -102,7 +112,7 @@ var _ = Service("workflow", func() {
 		})
 		Result(Empty)
 		HTTP(func() {
-			GET("/w/{workflow_key}/process/{process_id}/downloads")
+			GET("/my/streams/{workflow_key}/instance/{process_id}/downloads")
 			Response(StatusOK)
 			Response(StatusNotFound)
 		})
@@ -116,7 +126,7 @@ var _ = Service("workflow", func() {
 		})
 		Result(Empty)
 		HTTP(func() {
-			GET("/w/{workflow_key}/process/{process_id}/files.zip")
+			GET("/my/streams/{workflow_key}/instance/{process_id}/files.zip")
 			Response(StatusOK)
 			Response(StatusNotFound)
 		})
@@ -130,7 +140,7 @@ var _ = Service("workflow", func() {
 		})
 		Result(Empty)
 		HTTP(func() {
-			GET("/w/{workflow_key}/process/{process_id}/notarized.json")
+			GET("/my/streams/{workflow_key}/instance/{process_id}/notarized.json")
 			Response(StatusOK)
 			Response(StatusNotFound)
 		})
@@ -144,7 +154,7 @@ var _ = Service("workflow", func() {
 		})
 		Result(Empty)
 		HTTP(func() {
-			GET("/w/{workflow_key}/process/{process_id}/merkle.json")
+			GET("/my/streams/{workflow_key}/instance/{process_id}/merkle.json")
 			Response(StatusOK)
 			Response(StatusNotFound)
 		})
@@ -159,7 +169,7 @@ var _ = Service("workflow", func() {
 		})
 		Result(Empty)
 		HTTP(func() {
-			POST("/w/{workflow_key}/process/{process_id}/substep/{substep_id}/complete")
+			POST("/my/streams/{workflow_key}/instance/{process_id}/substep/{substep_id}/complete")
 			Response(StatusOK)
 			Response(StatusConflict)
 			Response(StatusForbidden)
@@ -176,7 +186,7 @@ var _ = Service("workflow", func() {
 		})
 		Result(Empty)
 		HTTP(func() {
-			GET("/w/{workflow_key}/process/{process_id}/substep/{substep_id}/file")
+			GET("/my/streams/{workflow_key}/instance/{process_id}/substep/{substep_id}/file")
 			Response(StatusOK)
 			Response(StatusNotFound)
 		})
@@ -192,7 +202,7 @@ var _ = Service("workflow", func() {
 		})
 		Result(Empty)
 		HTTP(func() {
-			GET("/w/{workflow_key}/process/{process_id}/attachment/{attachment_id}/file")
+			GET("/my/streams/{workflow_key}/instance/{process_id}/attachment/{attachment_id}/file")
 			Param("inline")
 			Response(StatusOK)
 			Response(StatusNotFound)
@@ -206,7 +216,7 @@ var _ = Service("workflow", func() {
 		})
 		Result(Empty)
 		HTTP(func() {
-			GET("/w/{workflow_key}/events")
+			GET("/my/streams/{workflow_key}/events")
 			Response(StatusOK)
 			Response(StatusBadRequest)
 		})
@@ -452,7 +462,7 @@ var _ = Service("admin", func() {
 	Method("orgAdminProfile", func() {
 		Result(Empty)
 		HTTP(func() {
-			GET("/org-admin/profile")
+			GET("/my/organization/profile")
 			Response(StatusOK)
 			Response(StatusUnauthorized)
 			Response(StatusForbidden)
@@ -464,7 +474,7 @@ var _ = Service("admin", func() {
 	Method("orgAdminMembers", func() {
 		Result(Empty)
 		HTTP(func() {
-			GET("/org-admin/members")
+			GET("/my/organization/members")
 			Response(StatusOK)
 			Response(StatusUnauthorized)
 			Response(StatusForbidden)
@@ -476,8 +486,8 @@ var _ = Service("admin", func() {
 	Method("orgAdminUsers", func() {
 		Result(Empty)
 		HTTP(func() {
-			// Legacy entry: GET redirects to /org-admin/profile.
-			GET("/org-admin/users")
+			// Legacy entry: GET redirects to /my/organization/profile.
+			GET("/my/organization/users")
 			Response(StatusSeeOther)
 			Response(StatusUnauthorized)
 			Response(StatusForbidden)
@@ -489,7 +499,7 @@ var _ = Service("admin", func() {
 	Method("orgAdminUserAction", func() {
 		Result(Empty)
 		HTTP(func() {
-			POST("/org-admin/users")
+			POST("/my/organization/users")
 			Response(StatusOK)
 			Response(StatusSeeOther)
 			Response(StatusBadRequest)
@@ -503,7 +513,7 @@ var _ = Service("admin", func() {
 	Method("orgAdminRoles", func() {
 		Result(Empty)
 		HTTP(func() {
-			GET("/org-admin/roles")
+			GET("/my/organization/roles")
 			Response(StatusOK)
 			Response(StatusUnauthorized)
 			Response(StatusForbidden)
@@ -514,7 +524,7 @@ var _ = Service("admin", func() {
 	Method("orgAdminRoleAction", func() {
 		Result(Empty)
 		HTTP(func() {
-			POST("/org-admin/roles")
+			POST("/my/organization/roles")
 			Response(StatusSeeOther)
 			Response(StatusBadRequest)
 			Response(StatusUnauthorized)
@@ -531,7 +541,7 @@ var _ = Service("admin", func() {
 		})
 		Result(Empty)
 		HTTP(func() {
-			GET("/org-admin/logo/{logo_id}")
+			GET("/my/organization/logo/{logo_id}")
 			Response(StatusOK)
 			Response(StatusNotFound)
 			Response(StatusUnauthorized)
@@ -560,7 +570,7 @@ var _ = Service("formata_builder", func() {
 	Method("builderApp", func() {
 		Result(Empty)
 		HTTP(func() {
-			GET("/org-admin/formata-builder")
+			GET("/my/organization/formata-builder")
 			Response(StatusOK)
 			Response(StatusForbidden)
 			Response(StatusUnauthorized)
@@ -577,7 +587,7 @@ var _ = Service("formata_builder", func() {
 		})
 		Result(Empty)
 		HTTP(func() {
-			GET("/org-admin/formata-builder/{asset_path}")
+			GET("/my/organization/formata-builder/{asset_path}")
 			Response(StatusOK)
 			Response(StatusForbidden)
 			Response(StatusUnauthorized)
@@ -594,7 +604,7 @@ var _ = Service("formata_builder", func() {
 		})
 		Result(Any)
 		HTTP(func() {
-			GET("/org-admin/formata-builder/stream/{stream_id}")
+			GET("/my/organization/formata-builder/stream/{stream_id}")
 			Response(StatusOK)
 			Response(StatusForbidden)
 			Response(StatusUnauthorized)
@@ -613,7 +623,7 @@ var _ = Service("formata_builder", func() {
 		})
 		Result(Empty)
 		HTTP(func() {
-			POST("/org-admin/formata-builder")
+			POST("/my/organization/formata-builder")
 			Param("stream")
 			Param("new")
 			Body("body")

--- a/server/design/design.go
+++ b/server/design/design.go
@@ -177,21 +177,6 @@ var _ = Service("workflow", func() {
 		})
 	})
 
-	Method("downloadSubstepFile", func() {
-		Payload(func() {
-			Field(1, "workflow_key", String)
-			Field(2, "process_id", String)
-			Field(3, "substep_id", String)
-			Required("workflow_key", "process_id", "substep_id")
-		})
-		Result(Empty)
-		HTTP(func() {
-			GET("/my/streams/{workflow_key}/instance/{process_id}/substep/{substep_id}/file")
-			Response(StatusOK)
-			Response(StatusNotFound)
-		})
-	})
-
 	Method("downloadAttachmentFile", func() {
 		Payload(func() {
 			Field(1, "workflow_key", String)
@@ -654,6 +639,25 @@ var _ = Service("dpp", func() {
 		HTTP(func() {
 			GET("/01/{gtin}/10/{lot}/21/{serial}")
 			Param("format")
+			Response(StatusOK)
+			Response(StatusNotFound)
+		})
+	})
+
+	Method("downloadAttachmentFile", func() {
+		Description("Public attachment download for a DPP Digital Link.")
+		Payload(func() {
+			Field(1, "gtin", String)
+			Field(2, "lot", String)
+			Field(3, "serial", String)
+			Field(4, "attachment_id", String)
+			Field(5, "inline", String)
+			Required("gtin", "lot", "serial", "attachment_id")
+		})
+		Result(Empty)
+		HTTP(func() {
+			GET("/01/{gtin}/10/{lot}/21/{serial}/attachment/{attachment_id}/file")
+			Param("inline")
 			Response(StatusOK)
 			Response(StatusNotFound)
 		})

--- a/server/templates/components/stream_card.html
+++ b/server/templates/components/stream_card.html
@@ -191,7 +191,7 @@
 {{ define "stream_card_create" }}
   <a
     class="stream-card stream-card-create"
-    href="/org-admin/formata-builder"
+    href="/my/organization/formata-builder"
   >
     <span class="stream-card-cta">
       {{ template "icon-plus" . }}

--- a/server/templates/components/stream_card.html
+++ b/server/templates/components/stream_card.html
@@ -4,7 +4,7 @@
   <div class="stream-card-shell">
     <div class="stream-card">
       <div class="stream-card-head">
-        <a class="stream-card-title-link" href="/w/{{ .Key }}/">
+        <a class="stream-card-title-link" href="/my/streams/{{ .Key }}/">
           <h2 class="stream-card-title">{{ .Name }}</h2>
         </a>
         {{ if .CanClone }}
@@ -70,7 +70,7 @@
           </details>
         {{ end }}
       </div>
-      <a class="stream-card-body" href="/w/{{ .Key }}/">
+      <a class="stream-card-body" href="/my/streams/{{ .Key }}/">
         <p
           class="stream-card-description{{ if not .Description }}
             is-empty

--- a/server/templates/components/substep_body.html
+++ b/server/templates/components/substep_body.html
@@ -76,9 +76,9 @@
     class="substep-body-form"
     {{ if not .ReadOnly }}
       method="post"
-      action="/w/{{ .WorkflowKey }}/process/{{ .ProcessID }}/substep/{{ .SubstepID }}/complete?substep={{ .SubstepID }}"
+      action="/my/streams/{{ .WorkflowKey }}/instance/{{ .ProcessID }}/substep/{{ .SubstepID }}/complete?substep={{ .SubstepID }}"
       data-formata-substep="true"
-      data-formata-post="/w/{{ .WorkflowKey }}/process/{{ .ProcessID }}/substep/{{ .SubstepID }}/complete?substep={{ .SubstepID }}"
+      data-formata-post="/my/streams/{{ .WorkflowKey }}/instance/{{ .ProcessID }}/substep/{{ .SubstepID }}/complete?substep={{ .SubstepID }}"
       {{ if and .MatchingRoles (gt (len .MatchingRoles) 1) }}
         data-active-role-dialog="active-role-dialog-{{ .ProcessID }}-{{ .SubstepID }}"
       {{ end }}

--- a/server/templates/icons.html
+++ b/server/templates/icons.html
@@ -58,6 +58,25 @@
   </svg>
 {{ end }}
 
+{{ define "icon-layout-dashboard" }}
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="icon-svg icon-svg-md"
+    aria-hidden="true"
+  >
+    <rect width="7" height="9" x="3" y="3" rx="1" />
+    <rect width="7" height="5" x="14" y="3" rx="1" />
+    <rect width="7" height="9" x="14" y="12" rx="1" />
+    <rect width="7" height="5" x="3" y="16" rx="1" />
+  </svg>
+{{ end }}
+
 {{ define "icon-building-grid" }}
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -112,6 +131,24 @@
     <path d="m16 17 5-5-5-5" />
     <path d="M21 12H9" />
     <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+  </svg>
+{{ end }}
+
+{{ define "icon-log-in" }}
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="icon-svg icon-svg-md"
+    aria-hidden="true"
+  >
+    <path d="m10 17 5-5-5-5" />
+    <path d="M15 12H3" />
+    <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
   </svg>
 {{ end }}
 

--- a/server/templates/layout.html
+++ b/server/templates/layout.html
@@ -179,7 +179,7 @@
                       </a>
                     {{ end }}
                     {{ if .ShowMyOrgLink }}
-                      <a href="/org-admin/profile" class="account-menu-item">
+                      <a href="/my/organization/profile" class="account-menu-item">
                         {{ template "icon-users-group" . }}
                         My organization
                       </a>

--- a/server/templates/layout.html
+++ b/server/templates/layout.html
@@ -172,6 +172,10 @@
                     </p>
                   </section>
                   <section class="account-menu-section">
+                    <a href="/my" class="account-menu-item">
+                      {{ template "icon-layout-dashboard" . }}
+                      Dashboard
+                    </a>
                     {{ if .ShowOrgsLink }}
                       <a href="/admin/orgs" class="account-menu-item">
                         {{ template "icon-building-grid" . }}
@@ -196,6 +200,11 @@
                   </section>
                 </div>
               </details>
+            {{ else if and (ne .Body "login_body") (ne .Body "signup_body") (ne .Body "invite_body") (ne .Body "reset_request_body") (ne .Body "reset_set_body") }}
+              <a href="/login" class="btn btn-ghost btn-lg nav-action">
+                {{ template "icon-log-in" . }}
+                Login
+              </a>
             {{ end }}
           </nav>
         </div>
@@ -203,8 +212,12 @@
       <main class="page">
         {{ if eq .Body "home_picker_body" }}
           {{ template "home_picker_body" . }}
+        {{ else if eq .Body "public_home_body" }}
+          {{ template "public_home_body" . }}
         {{ else if eq .Body "login_body" }}
           {{ template "login_body" . }}
+        {{ else if eq .Body "signup_body" }}
+          {{ template "signup_body" . }}
         {{ else if eq .Body "invite_body" }}
           {{ template "invite_body" . }}
         {{ else if eq .Body "reset_request_body" }}

--- a/server/templates/pages/home.html
+++ b/server/templates/pages/home.html
@@ -1,4 +1,4 @@
-{{/* Used on / to render the stream picker (home_picker_body). */}}
+{{/* Used on /my to render the stream picker (home_picker_body). */}}
 
 {{ define "home_picker_body" }}
   <section class="stack u-max-w-7xl u-mx-auto">

--- a/server/templates/pages/org_admin.html
+++ b/server/templates/pages/org_admin.html
@@ -1,4 +1,4 @@
-{{/* Used on /org-admin/profile, /org-admin/roles, and /org-admin/members */}}
+{{/* Used on /my/organization/profile, /my/organization/roles, and /my/organization/members */}}
 
 {{ define "org_admin_body" }}
 
@@ -29,7 +29,7 @@
           </div>
           <form
             method="post"
-            action="/org-admin/users"
+            action="/my/organization/users"
             class="input-form"
             enctype="multipart/form-data"
           >
@@ -58,7 +58,7 @@
             aria-label="Organization admin sections"
           >
             <a
-              href="/org-admin/profile"
+              href="/my/organization/profile"
               class="sidebar-nav-link{{ if eq .ActivePanel "profile" }} is-active{{ end }}"
               data-org-admin-nav="profile"
               aria-controls="org-admin-panel-profile"
@@ -72,7 +72,7 @@
               >
             </a>
             <a
-              href="/org-admin/roles"
+              href="/my/organization/roles"
               class="sidebar-nav-link{{ if eq .ActivePanel "roles" }} is-active{{ end }}"
               data-org-admin-nav="roles"
               aria-controls="org-admin-panel-roles"
@@ -84,7 +84,7 @@
               >
             </a>
             <a
-              href="/org-admin/members"
+              href="/my/organization/members"
               class="sidebar-nav-link{{ if eq .ActivePanel "members" }} is-active{{ end }}"
               data-org-admin-nav="members"
               aria-controls="org-admin-panel-members"
@@ -139,7 +139,7 @@
             </div>
             <form
               method="post"
-              action="/org-admin/users"
+              action="/my/organization/users"
               class="input-form org-profile-form"
               enctype="multipart/form-data"
             >
@@ -281,7 +281,7 @@
                           </div>
                           <form
                             method="post"
-                            action="/org-admin/roles"
+                            action="/my/organization/roles"
                             class="input-form"
                           >
                             <input
@@ -414,7 +414,7 @@
                           {{ end }}
                           <form
                             method="post"
-                            action="/org-admin/roles"
+                            action="/my/organization/roles"
                             class="input-form"
                           >
                             <input
@@ -537,7 +537,7 @@
 
                         <form
                           method="post"
-                          action="/org-admin/users"
+                          action="/my/organization/users"
                           class="input-form"
                         >
                           <input
@@ -651,7 +651,7 @@
                         </p>
                         <form
                           method="post"
-                          action="/org-admin/users"
+                          action="/my/organization/users"
                           class="input-form"
                         >
                           <input
@@ -703,7 +703,7 @@
                 </button>
               </header>
 
-              <form method="post" action="/org-admin/roles" class="input-form">
+              <form method="post" action="/my/organization/roles" class="input-form">
                 <input type="hidden" name="intent" value="create_role" />
                 <div class="form-field">
                   <label for="role-name">Role name</label>
@@ -793,7 +793,7 @@
                 </button>
               </header>
 
-              <form method="post" action="/org-admin/users" class="input-form">
+              <form method="post" action="/my/organization/users" class="input-form">
                 <input type="hidden" name="intent" value="invite" />
                 <div class="form-field">
                   <label for="user-email">Email</label>
@@ -872,17 +872,17 @@
     const orgAdminMobilePanelMedia = window.matchMedia("(max-width: 767px)");
     const orgAdminPanels = new Set(["profile", "roles", "members"]);
     const orgAdminPanelPaths = {
-      profile: "/org-admin/profile",
-      roles: "/org-admin/roles",
-      members: "/org-admin/members",
+      profile: "/my/organization/profile",
+      roles: "/my/organization/roles",
+      members: "/my/organization/members",
     };
     const orgAdminPanelFromPath = (path) => {
       switch (path) {
-        case "/org-admin/profile":
+        case "/my/organization/profile":
           return "profile";
-        case "/org-admin/roles":
+        case "/my/organization/roles":
           return "roles";
-        case "/org-admin/members":
+        case "/my/organization/members":
           return "members";
         default:
           return null;

--- a/server/templates/pages/process.html
+++ b/server/templates/pages/process.html
@@ -1,4 +1,4 @@
-{{/* Used on /w/.WorkflowKey/process/.ProcessID to render process details page
+{{/* Used on /my/streams/.WorkflowKey/instance/.ProcessID to render process details page
 */}} {{ define "process_body" }}
 <div
   id="process-page"
@@ -129,7 +129,7 @@
     <button
       type="button"
       class="btn btn-secondary js-download-link"
-      data-download-url="{{ .WorkflowPath }}/process/{{ .ProcessID }}/files.zip"
+      data-download-url="{{ .WorkflowPath }}/instance/{{ .ProcessID }}/files.zip"
     >
       {{ template "icon-download" . }} Download all files
     </button>
@@ -139,7 +139,7 @@
       <span class="field-label">Notarized stream data</span>
       <div class="field-row">
         <a
-          href="{{ .WorkflowPath }}/process/{{ .ProcessID }}/notarized.json"
+          href="{{ .WorkflowPath }}/instance/{{ .ProcessID }}/notarized.json"
           target="_blank"
           rel="noopener noreferrer"
           >notarized.json</a
@@ -147,7 +147,7 @@
         <button
           type="button"
           class="btn btn-ghost btn-icon btn-xs js-download-link"
-          data-download-url="{{ .WorkflowPath }}/process/{{ .ProcessID }}/notarized.json"
+          data-download-url="{{ .WorkflowPath }}/instance/{{ .ProcessID }}/notarized.json"
           aria-label="Download notarized.json"
         >
           {{ template "icon-download" . }}

--- a/server/templates/pages/public_home.html
+++ b/server/templates/pages/public_home.html
@@ -1,0 +1,13 @@
+{{ define "public_home_body" }}
+  <section class="stack u-max-w-7xl u-mx-auto">
+    <section class="page-header">
+      <div class="page-header-body">
+        <h1>Attesta</h1>
+      </div>
+    </section>
+  </section>
+{{ end }}
+
+{{ define "public_home.html" }}
+  {{ template "layout.html" . }}
+{{ end }}

--- a/server/templates/pages/stream.html
+++ b/server/templates/pages/stream.html
@@ -1,4 +1,4 @@
-{{/* Used on /w/.WorkflowKey to render the stream page (home_body). */}}
+{{/* Used on /my/streams/.WorkflowKey to render the stream page (home_body). */}}
 
 {{ define "home_body" }}
   <div class="stack stream-page u-max-w-7xl u-mx-auto">

--- a/server/templates/pages/stream.html
+++ b/server/templates/pages/stream.html
@@ -69,7 +69,7 @@
           </header>
           <form
             method="post"
-            action="{{ .WorkflowPath }}/process/start"
+            action="{{ .WorkflowPath }}/instance/start"
             class="input-form"
           >
             <div class="form-field">

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -250,7 +250,7 @@ const loadProcessContent = async (substepId = currentSelectedSubstep()) => {
     return;
   }
   const query = substepId ? `?substep=${encodeURIComponent(substepId)}` : "";
-  const url = `/w/${workflowKey}/process/${processId}/content${query}`;
+  const url = `/my/streams/${workflowKey}/instance/${processId}/content${query}`;
   if (window.htmx?.ajax) {
     window.htmx.ajax("GET", url, {
       target: "#process-page-content",
@@ -1144,7 +1144,7 @@ const initializeFormataForms = async (container = document) => {
 
 if (processId && workflowKey && processPageContent) {
   const source = new EventSource(
-    `/w/${workflowKey}/events?workflow=${workflowKey}&processId=${processId}`,
+    `/my/streams/${workflowKey}/events?workflow=${workflowKey}&processId=${processId}`,
   );
   source.addEventListener("process-updated", () => {
     if (skipNextProcessUpdatedEvent) {
@@ -1429,12 +1429,12 @@ if (deptRoot) {
   const dashboard = document.getElementById("dept-dashboard");
   if (role && deptWorkflowKey && dashboard) {
     const source = new EventSource(
-      `/w/${deptWorkflowKey}/events?workflow=${deptWorkflowKey}&role=${role}`,
+      `/my/streams/${deptWorkflowKey}/events?workflow=${deptWorkflowKey}&role=${role}`,
     );
     source.addEventListener("role-updated", async () => {
       try {
         const response = await fetch(
-          `/w/${deptWorkflowKey}/backoffice/${role}/partial`,
+          `/my/streams/${deptWorkflowKey}/backoffice/${role}/partial`,
         );
         if (!response.ok) {
           return;

--- a/web/src/styles/components/button.css
+++ b/web/src/styles/components/button.css
@@ -69,7 +69,7 @@ a.btn:hover {
 .btn-ghost {
   background: transparent;
   border-color: transparent;
-  color: var(--muted-foreground);
+  color: var(--foreground);
 }
 
 .btn-ghost:hover:not(:disabled, .is-disabled) {


### PR DESCRIPTION
## Summary
- Make `/` a public blank homepage and move the authenticated stream picker to `/my`
- Remount stream/instance routes as `/my/streams/:id` and `/my/streams/:id/instance/:id` (hard cut of `/w/`)
- Move org admin to `/my/organization/...` (hard cut of `/org-admin/`); keep platform admin at `/admin`

## Test plan
- [ ] Unauthenticated `GET /` shows blank public homepage (no login redirect)
- [ ] Unauthenticated `GET /my` redirects to `/login?next=.../my`
- [ ] Login lands on `/my` (stream picker); logged-in visit to `/` stays on public home
- [ ] Open a stream at `/my/streams/<id>`, start an instance, land on `/my/streams/<id>/instance/<id>`
- [ ] Complete a substep / SSE content refresh still works
- [ ] Org admin pages load at `/my/organization/profile|roles|members`; Formata builder load/save works
- [ ] Legacy `/w/...`, `/org-admin/...`, `/dashboard` return 404
- [ ] `cd server && go test $(go list ./... | grep -v /gen)`


Made with [Cursor](https://cursor.com)