### PR TITLE
Temporarily redirect / to /my

### DIFF
--- a/server/cmd/server/home_handler_test.go
+++ b/server/cmd/server/home_handler_test.go
@@ -14,7 +14,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-func TestHandlePublicHomeIsBlankAndPublic(t *testing.T) {
+func TestHandlePublicHomeRedirectsToMy(t *testing.T) {
 	server := &Server{
 		store: NewMemoryStore(),
 		tmpl:  parseTestTemplates(t),
@@ -22,28 +22,15 @@ func TestHandlePublicHomeIsBlankAndPublic(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	server.handlePublicHome(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d", rec.Code)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 	}
-	if loc := rec.Header().Get("Location"); loc != "" {
-		t.Fatalf("unexpected redirect to %q", loc)
-	}
-	body := rec.Body.String()
-	if !strings.Contains(body, `href="/login"`) {
-		t.Fatalf("expected Login link on public home, got %q", body)
-	}
-	if !strings.Contains(body, `class="btn btn-ghost btn-lg nav-action"`) {
-		t.Fatalf("expected Login styled as ghost nav button, got %q", body)
-	}
-	if strings.Contains(body, `account-menu`) {
-		t.Fatalf("expected no account menu on public home, got %q", body)
-	}
-	if strings.Contains(body, "Dashboard") {
-		t.Fatalf("expected no Dashboard link when logged out, got %q", body)
+	if got := rec.Header().Get("Location"); got != appHomePath {
+		t.Fatalf("location = %q, want %q", got, appHomePath)
 	}
 }
 
-func TestHandlePublicHomeShowsDashboardWhenLoggedIn(t *testing.T) {
+func TestHandlePublicHomeRedirectsToMyWhenLoggedIn(t *testing.T) {
 	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
 	server := &Server{
 		store: NewMemoryStore(),
@@ -66,21 +53,11 @@ func TestHandlePublicHomeShowsDashboardWhenLoggedIn(t *testing.T) {
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-public-home"})
 	rec := httptest.NewRecorder()
 	server.handlePublicHome(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d", rec.Code)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 	}
-	body := rec.Body.String()
-	if !strings.Contains(body, `account-menu`) {
-		t.Fatalf("expected account menu when logged in, got %q", body)
-	}
-	if !strings.Contains(body, `href="/my"`) || !strings.Contains(body, "Dashboard") {
-		t.Fatalf("expected Dashboard item under account menu when logged in, got %q", body)
-	}
-	if strings.Contains(body, `class="btn btn-ghost btn-lg nav-action">Dashboard`) {
-		t.Fatalf("expected Dashboard inside menu, not topbar button, got %q", body)
-	}
-	if strings.Contains(body, `>Login</a>`) {
-		t.Fatalf("expected no Login link when logged in, got %q", body)
+	if got := rec.Header().Get("Location"); got != appHomePath {
+		t.Fatalf("location = %q, want %q", got, appHomePath)
 	}
 }
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -2028,16 +2028,9 @@ func (s *Server) handlePublicHome(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	base := s.pageBase("public_home_body", "", "")
-	if user, _, err := s.currentUser(r); err == nil {
-		base = s.pageBaseForUser(user, "public_home_body", "", "")
-	}
-	view := struct {
-		PageBase
-	}{PageBase: base}
-	if err := s.tmpl.ExecuteTemplate(w, "public_home.html", view); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
+	// Temporary: treat / as app entry until the real public homepage ships.
+	// Auth is handled by /my (anonymous visitors continue to login/signup).
+	http.Redirect(w, r, appHomePath, http.StatusSeeOther)
 }
 
 func (s *Server) handleHome(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Temporary bridge until the real public homepage ships: `GET /` always `303` redirects to `/my`.
- Auth stays on `/my` — anonymous visitors continue to login/signup via the existing gate.
- Leaves blank `public_home` templates in place; docs/glossary unchanged.

## Test plan
- [x] Unit tests for public home redirect (logged out + logged in)
- [ ] Visit `/` while logged out → `/my` → `/login?next=/my`
- [ ] Visit `/` while logged in → `/my` stream picker