### PR TITLE
feat(admin): shared HTMX soft-nav for admin consoles

### DIFF
--- a/docs/superpowers/plans/2026-07-28-admin-console-htmx-soft-nav.md
+++ b/docs/superpowers/plans/2026-07-28-admin-console-htmx-soft-nav.md
@@ -1,0 +1,783 @@
+# Admin Console HTMX Soft-Nav Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give platform admin and org admin one shared HTMX soft-nav shell (`admin_console`) so sidebar navigation updates page-header + rail without a full reload, while form POSTs stay full-page.
+
+**Architecture:** Extract a full `admin_console` component (header + sidebar + main slot via existing `render` template func). Same panel URLs return the console fragment when `HX-Request` targets `#admin-console`; platform orgs search keeps targeting `#platform-admin-results` and is distinguished via the `HX-Target` header. Org admin drops multi-panel DOM + History JS and renders one panel per route.
+
+**Tech Stack:** Go `html/template`, HTMX (already in layout), existing `isHTMXRequest` / `render` helpers, Vite CSS (reuse `.sidebar-nav` / `.rail-layout` / `.page-header`).
+
+## Global Constraints
+
+- Work only in the git worktree `.worktrees/assess-admin-sidebar-nav` on branch `assess/admin-sidebar-nav` (from current `master`).
+- Soft-nav swaps `#admin-console` (page-header including breadcrumbs + title/subtitle + sidebar + main). Layout chrome (topbar) is not swapped.
+- Same URLs for full page and soft-nav partial; no new `/content` routes.
+- Form POSTs stay full-page redirect/re-render (no HTMX forms in this plan).
+- Nested platform orgs search/pagination HTMX must keep targeting `#platform-admin-results`.
+- Prefer minimal diffs; match `attesta-ui-components` full-tier tracer (`stream_card`: define stem, DTO in `components.go`, struct literals).
+- Read `docs/css.md` before adding CSS; prefer reusing existing classes (no new stylesheet unless required).
+- TDD: failing test → implement → pass → commit per task.
+
+---
+
+## File map
+
+| File | Role |
+|------|------|
+| `server/cmd/server/components.go` | Add `AdminConsoleNavItem`, `AdminConsoleView` |
+| `server/templates/components/admin_console.html` | Shared shell template (`admin_console`) |
+| `server/cmd/server/admin_console.go` | Nav builders + `hxTarget` helper + render helpers (optional peel from `main.go`) |
+| `server/cmd/server/admin_console_test.go` | Unit tests for builders / HX-Target branching helper |
+| `server/cmd/server/admin_console_template_test.go` | Template markup contract for `admin_console` |
+| `server/templates/pages/platform_admin.html` | Embed `admin_console`; main defines for orgs/categories |
+| `server/templates/pages/org_admin.html` | Embed `admin_console`; one panel; remove panel-switcher JS |
+| `server/cmd/server/main.go` | HTMX branch for platform/org GETs; wire console views |
+| Existing `*_test.go` files listed in tasks | Update markers / add HTMX handler cases |
+
+---
+
+### Task 1: `AdminConsoleView` DTO + `admin_console` template
+
+**Files:**
+- Create: `server/templates/components/admin_console.html`
+- Create: `server/cmd/server/admin_console_template_test.go`
+- Modify: `server/cmd/server/components.go` (append after `BreadcrumbsView`)
+
+**Interfaces:**
+- Consumes: existing `BreadcrumbsView`, template func `render(name string, data any) (template.HTML, error)` from `withTemplateFuncs`
+- Produces:
+  - `type AdminConsoleNavItem struct { Href, Title, Copy string; Active bool }`
+  - `type AdminConsoleView struct { ID, NavLabel, Title, Subtitle string; Breadcrumbs BreadcrumbsView; NavItems []AdminConsoleNavItem; MainTemplate string; MainData any }`
+  - Template define name `"admin_console"`
+
+- [ ] **Step 1: Write the failing template test**
+
+Create `server/cmd/server/admin_console_template_test.go`:
+
+```go
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestAdminConsoleTemplateSoftNavContract(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+
+	mainCrumbs := BreadcrumbsView{Items: []BreadcrumbItem{
+		{Label: "MainSlot", Href: "/main-slot", Current: true},
+	}}
+	view := AdminConsoleView{
+		ID:       "admin-console",
+		NavLabel: "Test sections",
+		Title:    "Test dashboard",
+		Subtitle: "Test subtitle",
+		Breadcrumbs: BreadcrumbsView{Items: []BreadcrumbItem{
+			{Label: "Dashboard", Href: "/my"},
+			{Label: "Test", Href: "/test", Current: true},
+		}},
+		NavItems: []AdminConsoleNavItem{
+			{Href: "/test/a", Title: "Alpha", Copy: "First", Active: true},
+			{Href: "/test/b", Title: "Beta", Copy: "Second", Active: false},
+		},
+		// Reuse existing "breadcrumbs" define as the main slot via render().
+		MainTemplate: "breadcrumbs",
+		MainData:     mainCrumbs,
+	}
+
+	var out bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&out, "admin_console", view); err != nil {
+		t.Fatalf("render admin_console: %v", err)
+	}
+	body := out.String()
+	for _, want := range []string{
+		`id="admin-console"`,
+		`class="page-header"`,
+		`class="breadcrumbs"`,
+		"<h1>Test dashboard</h1>",
+		"Test subtitle",
+		`aria-label="Test sections"`,
+		`class="sidebar-nav"`,
+		`hx-get="/test/a"`,
+		`hx-get="/test/b"`,
+		`hx-target="#admin-console"`,
+		`hx-select="#admin-console"`,
+		`hx-swap="outerHTML"`,
+		`hx-push-url="true"`,
+		`class="sidebar-nav-link is-active"`,
+		`aria-current="page"`,
+		"MainSlot",
+		`href="/main-slot"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in admin_console, got:\n%s", want, body)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from worktree `server/`):
+
+```bash
+cd /Users/giovanniabbatepaolo/Documents/GitHub/forkbomb/attesta/.worktrees/assess-admin-sidebar-nav/server
+go test ./cmd/server/ -count=1 -run 'TestAdminConsoleTemplateSoftNavContract' -v
+```
+
+Expected: FAIL (undefined `AdminConsoleView` and/or missing template `admin_console`).
+
+- [ ] **Step 3: Add DTOs to `components.go`**
+
+Append after `BreadcrumbsView`:
+
+```go
+// AdminConsoleNavItem is one soft-nav link in templates/components/admin_console.html.
+type AdminConsoleNavItem struct {
+	Href   string
+	Title  string
+	Copy   string
+	Active bool
+}
+
+// AdminConsoleView is the view model for templates/components/admin_console.html.
+// MainTemplate is executed via the render func with MainData as the dot.
+type AdminConsoleView struct {
+	ID           string // default "admin-console" when empty
+	NavLabel     string
+	Title        string
+	Subtitle     string
+	Breadcrumbs  BreadcrumbsView
+	NavItems     []AdminConsoleNavItem
+	MainTemplate string
+	MainData     any
+}
+```
+
+- [ ] **Step 4: Create `admin_console.html`**
+
+Create `server/templates/components/admin_console.html`:
+
+```html
+{{/* Shared admin soft-nav shell: page-header + sidebar + main (HTMX swap root). */}}
+
+{{ define "admin_console" }}
+  <div
+    id="{{ if .ID }}{{ .ID }}{{ else }}admin-console{{ end }}"
+    class="admin-console"
+  >
+    <section class="page-header">
+      {{ template "breadcrumbs" .Breadcrumbs }}
+      <div class="page-header-body">
+        <h1>{{ .Title }}</h1>
+        {{ if .Subtitle }}
+          <p>{{ .Subtitle }}</p>
+        {{ end }}
+      </div>
+    </section>
+
+    <div class="rail-layout rail-layout-ready">
+      <section class="panel panel-sticky">
+        <nav
+          class="sidebar-nav"
+          aria-label="{{ .NavLabel }}"
+        >
+          {{ range .NavItems }}
+            <a
+              href="{{ .Href }}"
+              class="sidebar-nav-link{{ if .Active }} is-active{{ end }}"
+              hx-get="{{ .Href }}"
+              hx-target="#{{ if $.ID }}{{ $.ID }}{{ else }}admin-console{{ end }}"
+              hx-select="#{{ if $.ID }}{{ $.ID }}{{ else }}admin-console{{ end }}"
+              hx-swap="outerHTML"
+              hx-push-url="true"
+              {{ if .Active }}aria-current="page"{{ end }}
+            >
+              <span class="sidebar-nav-title">{{ .Title }}</span>
+              {{ if .Copy }}
+                <span class="sidebar-nav-copy">{{ .Copy }}</span>
+              {{ end }}
+            </a>
+          {{ end }}
+        </nav>
+      </section>
+
+      <section class="panel rail-layout-main">
+        {{ render .MainTemplate .MainData }}
+      </section>
+    </div>
+  </div>
+{{ end }}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+go test ./cmd/server/ -count=1 -run 'TestAdminConsoleTemplateSoftNavContract' -v
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/giovanniabbatepaolo/Documents/GitHub/forkbomb/attesta/.worktrees/assess-admin-sidebar-nav
+git add server/cmd/server/components.go \
+  server/templates/components/admin_console.html \
+  server/cmd/server/admin_console_template_test.go
+git commit -m "$(cat <<'EOF'
+feat(ui): add admin_console soft-nav shell component
+
+EOF
+)"
+```
+
+---
+
+### Task 2: HX-Target helper + platform/org console builders
+
+**Files:**
+- Create: `server/cmd/server/admin_console.go`
+- Create: `server/cmd/server/admin_console_test.go`
+
+**Interfaces:**
+- Consumes: `AdminConsoleView`, `AdminConsoleNavItem`, `organizationPath`, `buildOrgAdminBreadcrumbs`, `buildPlatformAdminBreadcrumbs`
+- Produces:
+  - `func htmxTargetID(r *http.Request) string`
+  - `func wantsAdminConsolePartial(r *http.Request) bool` — true when `isHTMXRequest(r)` and target is empty or `admin-console` (not `platform-admin-results`)
+  - `func platformAdminConsole(view PlatformAdminView) AdminConsoleView`
+  - `func orgAdminConsole(view OrgAdminView) AdminConsoleView`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `server/cmd/server/admin_console_test.go`:
+
+```go
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWantsAdminConsolePartial(t *testing.T) {
+	t.Parallel()
+
+	full := httptest.NewRequest(http.MethodGet, "/admin/orgs", nil)
+	if wantsAdminConsolePartial(full) {
+		t.Fatal("non-HTMX must be false")
+	}
+
+	results := httptest.NewRequest(http.MethodGet, "/admin/orgs?q=a", nil)
+	results.Header.Set("HX-Request", "true")
+	results.Header.Set("HX-Target", "platform-admin-results")
+	if wantsAdminConsolePartial(results) {
+		t.Fatal("orgs search HTMX must stay on results partial")
+	}
+
+	console := httptest.NewRequest(http.MethodGet, "/admin/categories", nil)
+	console.Header.Set("HX-Request", "true")
+	console.Header.Set("HX-Target", "admin-console")
+	if !wantsAdminConsolePartial(console) {
+		t.Fatal("sidebar soft-nav must request admin_console partial")
+	}
+}
+
+func TestPlatformAdminConsoleNav(t *testing.T) {
+	t.Parallel()
+	view := PlatformAdminView{ActivePanel: "categories", Breadcrumbs: buildPlatformAdminBreadcrumbs("categories")}
+	c := platformAdminConsole(view)
+	if c.MainTemplate != "platform_admin_main" {
+		t.Fatalf("MainTemplate = %q", c.MainTemplate)
+	}
+	if len(c.NavItems) != 2 || !c.NavItems[1].Active || c.NavItems[1].Href != "/admin/categories" {
+		t.Fatalf("unexpected nav: %+v", c.NavItems)
+	}
+	if c.Subtitle != "Browse stream discovery categories" {
+		t.Fatalf("Subtitle = %q", c.Subtitle)
+	}
+}
+
+func TestOrgAdminConsoleNav(t *testing.T) {
+	t.Parallel()
+	view := OrgAdminView{ActivePanel: "roles", Breadcrumbs: buildOrgAdminBreadcrumbs("roles")}
+	c := orgAdminConsole(view)
+	if c.MainTemplate != "org_admin_main" {
+		t.Fatalf("MainTemplate = %q", c.MainTemplate)
+	}
+	if len(c.NavItems) != 3 || !c.NavItems[1].Active || c.NavItems[1].Href != organizationPath("roles") {
+		t.Fatalf("unexpected nav: %+v", c.NavItems)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+```bash
+go test ./cmd/server/ -count=1 -run 'TestWantsAdminConsolePartial|TestPlatformAdminConsoleNav|TestOrgAdminConsoleNav' -v
+```
+
+Expected: FAIL (undefined funcs).
+
+- [ ] **Step 3: Implement `admin_console.go`**
+
+```go
+package main
+
+import (
+	"net/http"
+	"strings"
+)
+
+func htmxTargetID(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	return strings.TrimSpace(r.Header.Get("HX-Target"))
+}
+
+func wantsAdminConsolePartial(r *http.Request) bool {
+	if !isHTMXRequest(r) {
+		return false
+	}
+	target := htmxTargetID(r)
+	return target == "" || target == "admin-console"
+}
+
+func platformAdminConsole(view PlatformAdminView) AdminConsoleView {
+	active := strings.TrimSpace(view.ActivePanel)
+	subtitle := "Create and manage organizations"
+	if active == "categories" {
+		subtitle = "Browse stream discovery categories"
+	}
+	return AdminConsoleView{
+		ID:          "admin-console",
+		NavLabel:    "Platform admin sections",
+		Title:       "Platform admin dashboard",
+		Subtitle:    subtitle,
+		Breadcrumbs: view.Breadcrumbs,
+		NavItems: []AdminConsoleNavItem{
+			{
+				Href:   "/admin/orgs",
+				Title:  "Organizations",
+				Copy:   "Create and manage organizations",
+				Active: active != "categories",
+			},
+			{
+				Href:   "/admin/categories",
+				Title:  "Categories",
+				Copy:   "Browse stream discovery categories",
+				Active: active == "categories",
+			},
+		},
+		MainTemplate: "platform_admin_main",
+		MainData:     view,
+	}
+}
+
+func orgAdminConsole(view OrgAdminView) AdminConsoleView {
+	active := strings.TrimSpace(view.ActivePanel)
+	if active == "" {
+		active = "profile"
+	}
+	return AdminConsoleView{
+		ID:          "admin-console",
+		NavLabel:    "Organization admin sections",
+		Title:       "Organization admin dashboard",
+		Subtitle:    "Manage organization settings, roles, and members",
+		Breadcrumbs: view.Breadcrumbs,
+		NavItems: []AdminConsoleNavItem{
+			{
+				Href:   organizationPath("profile"),
+				Title:  "Organization profile",
+				Copy:   "Update your organization name and logo",
+				Active: active == "profile",
+			},
+			{
+				Href:   organizationPath("roles"),
+				Title:  "Roles",
+				Copy:   "Manage the role catalog for your organization",
+				Active: active == "roles",
+			},
+			{
+				Href:   organizationPath("members"),
+				Title:  "Members",
+				Copy:   "Invite people and update member access",
+				Active: active == "members",
+			},
+		},
+		MainTemplate: "org_admin_main",
+		MainData:     view,
+	}
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+```bash
+go test ./cmd/server/ -count=1 -run 'TestWantsAdminConsolePartial|TestPlatformAdminConsoleNav|TestOrgAdminConsoleNav' -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/cmd/server/admin_console.go server/cmd/server/admin_console_test.go
+git commit -m "$(cat <<'EOF'
+feat(admin): add console builders and HX-Target partial gating
+
+EOF
+)"
+```
+
+---
+
+### Task 3: Wire platform admin templates + HTMX GET branching
+
+**Files:**
+- Modify: `server/templates/pages/platform_admin.html`
+- Modify: `server/cmd/server/main.go` (`renderPlatformAdmin`, `handleAdminCategories`, `handleAdminOrgs` GET)
+- Modify: `server/cmd/server/platform_admin_template_test.go`
+- Modify: `server/cmd/server/panel_markup_test.go` (`TestPlatformAdminPanelMarkup`)
+- Create or modify: `server/cmd/server/admin_categories_handler_test.go` / new `platform_admin_htmx_test.go`
+
+**Interfaces:**
+- Consumes: `platformAdminConsole`, `wantsAdminConsolePartial`, template `"admin_console"`, `"platform_admin_main"`
+- Produces: platform body embeds console; HTMX sidebar returns console fragment; search HTMX still returns `platform_admin_results`
+
+- [ ] **Step 1: Write failing HTMX handler test**
+
+Add to new file `server/cmd/server/platform_admin_htmx_test.go` (reuse session/admin setup from `admin_categories_handler_test.go`):
+
+```go
+func TestHandleAdminCategoriesHTMXReturnsAdminConsole(t *testing.T) {
+	// arrange platform admin server + taxonomy seed (copy pattern from TestHandleAdminCategories*)
+	req := httptest.NewRequest(http.MethodGet, "/admin/categories", nil)
+	req.Header.Set("HX-Request", "true")
+	req.Header.Set("HX-Target", "admin-console")
+	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "admin-session"})
+	rec := httptest.NewRecorder()
+	server.handleAdminCategories(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `id="admin-console"`) {
+		t.Fatalf("expected admin-console fragment, got: %s", body)
+	}
+	if strings.Contains(body, `class="topbar"`) || strings.Contains(body, "<html") {
+		t.Fatalf("HTMX soft-nav must not include layout, got: %s", body)
+	}
+	if !strings.Contains(body, "Categories") || !strings.Contains(body, "hx-get=\"/admin/orgs\"") {
+		t.Fatalf("expected categories console nav, got: %s", body)
+	}
+}
+
+func TestHandleAdminOrgsHTMXSearchStillReturnsResults(t *testing.T) {
+	// GET /admin/orgs with HX-Request + HX-Target: platform-admin-results
+	// expect id="platform-admin-results" and NOT require full admin-console wrapper swap root as sole content
+	// (results partial may appear without page-header)
+}
+```
+
+Fill arrange blocks by copying the working platform-admin server setup from existing tests in `admin_categories_handler_test.go` / `admin_handler_identity_test.go` (platform admin session cookie + `ADMIN_EMAIL`/`ADMIN_PASSWORD` env).
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+go test ./cmd/server/ -count=1 -run 'TestHandleAdminCategoriesHTMXReturnsAdminConsole|TestHandleAdminOrgsHTMXSearchStillReturnsResults' -v
+```
+
+- [ ] **Step 3: Refactor `platform_admin.html`**
+
+Replace the duplicated page-header + sidebar block in `platform_admin_body` with:
+
+```html
+{{ define "platform_admin_body" }}
+  <div class="stack u-max-w-7xl u-mx-auto">
+    {{ template "admin_console" (platformAdminConsoleDot .) }}
+  </div>
+  {{/* keep dialogs that today live outside main if any — move dialogs into platform_admin_main or keep after console if they use document.getElementById */}}
+{{ end }}
+```
+
+Go templates cannot call `platformAdminConsole` unless it is a template func. **Do not add a template func.** Instead build console in the handler / view:
+
+Option A (preferred): add field `Console AdminConsoleView` on `PlatformAdminView`, set it in `platformAdminView` / categories handler before render.
+
+```go
+view.Console = platformAdminConsole(view)
+```
+
+Template:
+
+```html
+{{ define "platform_admin_body" }}
+  <div class="stack u-max-w-7xl u-mx-auto">
+    {{ template "admin_console" .Console }}
+  </div>
+{{ end }}
+
+{{ define "platform_admin_main" }}
+  {{ if eq .ActivePanel "categories" }}
+    {{ template "platform_admin_categories_panel" . }}
+  {{ else }}
+    {{/* existing orgs main markup: head-actions, search, results — NOT the outer header/sidebar */}}
+    ...
+  {{ end }}
+{{ end }}
+```
+
+Ensure create/edit/invite `<dialog>` elements remain in the DOM for orgs (inside `platform_admin_main` or after console inside the stack — keep current click handlers working).
+
+- [ ] **Step 4: Update render paths in `main.go`**
+
+In `platformAdminView` / categories view construction, set `view.Console = platformAdminConsole(view)` (Console.MainData must be the `PlatformAdminView` value **without** infinite nest — set MainData to a copy or set Console after filling other fields:
+
+```go
+view := PlatformAdminView{ ... }
+view.Console = platformAdminConsole(view)
+// platformAdminConsole sets MainData: view — at that moment Console is zero; OK because main template only needs ActivePanel/Orgs/Categories/etc.
+```
+
+`renderPlatformAdmin`:
+
+```go
+func (s *Server) renderPlatformAdmin(w http.ResponseWriter, r *http.Request, user *AccountUser, confirmation string, errs PlatformAdminErrors) {
+	view := s.platformAdminView(user, confirmation, errs)
+	view.Console = platformAdminConsole(view)
+	if wantsAdminConsolePartial(r) {
+		if err := s.tmpl.ExecuteTemplate(w, "admin_console", view.Console); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+	if err := s.tmpl.ExecuteTemplate(w, "platform_admin.html", view); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+```
+
+Update all `renderPlatformAdmin` call sites to pass `r` (or keep a wrapper). For `handleAdminOrgs` GET:
+
+```go
+if isHTMXRequest(r) && htmxTargetID(r) == "platform-admin-results" {
+	s.renderPlatformAdminResults(...)
+	return
+}
+if wantsAdminConsolePartial(r) {
+	s.renderPlatformAdmin(w, r, ...)
+	return
+}
+s.renderPlatformAdmin(w, r, ...)
+```
+
+(Same function handles both full and console partial via `wantsAdminConsolePartial`.)
+
+`handleAdminCategories`: build view, set Console, then if `wantsAdminConsolePartial(r)` execute `admin_console`, else `platform_admin.html`.
+
+- [ ] **Step 5: Update template tests**
+
+- `TestPlatformAdminCategoriesPanelMarkup` / `TestPlatformAdminPanelMarkup`: expect `id="admin-console"`, `hx-get="/admin/categories"`, `hx-target="#admin-console"`; keep categories/orgs content assertions.
+- Remove expectations that conflict with moved markup.
+
+- [ ] **Step 6: Run focused tests**
+
+```bash
+go test ./cmd/server/ -count=1 -run 'TestAdminConsole|TestPlatformAdmin|TestHandleAdminCategories|TestHandleAdminOrgsHTMX|TestPanelMarkup' -v
+```
+
+Expected: PASS (fix any remaining marker failures).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/templates/pages/platform_admin.html server/cmd/server/main.go \
+  server/cmd/server/platform_admin_template_test.go server/cmd/server/panel_markup_test.go \
+  server/cmd/server/platform_admin_htmx_test.go
+git commit -m "$(cat <<'EOF'
+feat(admin): platform admin soft-nav via shared admin_console
+
+EOF
+)"
+```
+
+---
+
+### Task 4: Rewrite org admin to single-panel + soft-nav
+
+**Files:**
+- Modify: `server/templates/pages/org_admin.html`
+- Modify: `server/cmd/server/main.go` (`renderOrgAdminWithErrors` signature to accept `r`, HTMX branch)
+- Modify: `server/cmd/server/org_admin_template_sidebar_test.go`
+- Modify: `server/cmd/server/org_admin_section_urls_test.go`
+- Modify: `server/cmd/server/panel_markup_test.go` (`TestOrgAdminRolesPanelMarkup`)
+- Modify: other org admin template tests if they assume all three panel IDs
+
+**Interfaces:**
+- Consumes: `orgAdminConsole`, `wantsAdminConsolePartial`
+- Produces: one panel HTML per `ActivePanel`; no `data-org-admin-*` panel switcher; soft-nav HTMX on console
+
+- [ ] **Step 1: Update sidebar test to new contract (fails on old markup)**
+
+Rewrite `TestOrgAdminTemplateRendersSidebarPanels` expectations:
+
+```go
+// ActivePanel profile only
+view.ActivePanel = "profile"
+// expect:
+// id="admin-console", hx-get organizationPath links, org profile form
+// must NOT contain: data-org-admin-nav, data-org-admin-shell, id="org-admin-panel-roles", history.pushState
+// must NOT contain members invite list markers if those only lived in members panel
+```
+
+Add sibling tests or table cases for `roles` and `members` ActivePanel ensuring only that panel’s main content appears.
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+go test ./cmd/server/ -count=1 -run 'TestOrgAdminTemplateRendersSidebarPanels' -v
+```
+
+- [ ] **Step 3: Restructure `org_admin.html`**
+
+1. `NeedsOrganizationSetup`: keep existing setup form UI (no `admin_console` soft-nav).
+2. Otherwise:
+
+```html
+{{ define "org_admin_body" }}
+  <div class="stack u-max-w-7xl u-mx-auto">
+    {{ if .NeedsOrganizationSetup }}
+      {{/* existing setup header + form */}}
+    {{ else }}
+      {{ template "admin_console" .Console }}
+    {{ end }}
+  </div>
+  {{/* keep role/member dialogs required by the active panel; drop inactive panel dialogs if unused */}}
+{{ end }}
+
+{{ define "org_admin_main" }}
+  {{ if eq .ActivePanel "roles" }}
+    {{ template "org_admin_roles_panel" . }}
+  {{ else if eq .ActivePanel "members" }}
+    {{ template "org_admin_members_panel" . }}
+  {{ else }}
+    {{ template "org_admin_profile_panel" . }}
+  {{ end }}
+{{ end }}
+```
+
+Split existing panel sections into `org_admin_profile_panel` / `org_admin_roles_panel` / `org_admin_members_panel` defines (move markup out of the triple-`hidden` sections).
+
+3. Delete the panel-switcher IIFE (`data-org-admin-shell`, `history.pushState`, `preventDefault` on nav). **Keep** role-palette picker / invite-copy / other scripts that do not depend on multi-panel shell — if they are intertwined, split carefully so palette pickers still work on roles/members panels.
+
+- [ ] **Step 4: Wire `Console` + HTMX in `renderOrgAdminWithErrors`**
+
+```go
+view.Console = orgAdminConsole(view)
+if !view.NeedsOrganizationSetup && wantsAdminConsolePartial(r) {
+	_ = s.tmpl.ExecuteTemplate(w, "admin_console", view.Console)
+	return
+}
+_ = s.tmpl.ExecuteTemplate(w, "org_admin.html", view)
+```
+
+Thread `*http.Request` into `renderOrgAdminWithErrors` (update all call sites).
+
+- [ ] **Step 5: Fix section URL / panel markup tests**
+
+- `TestOrgAdminSectionURLHandlers`: stop asserting `data-org-admin-default-panel` and sibling panel IDs; assert active panel content + `aria-current` / `is-active` on the matching nav href; assert other panels’ unique strings absent.
+- `TestOrgAdminRolesPanelMarkup`: set `ActivePanel: "roles"`; assert roles markup without requiring `org-admin-panel-members` boundary.
+
+- [ ] **Step 6: Run org-admin + related tests**
+
+```bash
+go test ./cmd/server/ -count=1 -run 'TestOrgAdmin|TestAdminConsole|TestListRow|TestDialogMarkup' -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/templates/pages/org_admin.html server/cmd/server/main.go \
+  server/cmd/server/org_admin_*.go server/cmd/server/panel_markup_test.go \
+  server/cmd/server/list_row_markup_test.go server/cmd/server/dialog_markup_test.go
+git commit -m "$(cat <<'EOF'
+feat(admin): org admin single-panel soft-nav via admin_console
+
+EOF
+)"
+```
+
+---
+
+### Task 5: Regression sweep + manual checklist
+
+**Files:**
+- Test only (fix stragglers)
+
+- [ ] **Step 1: Run broader test suite**
+
+```bash
+cd /Users/giovanniabbatepaolo/Documents/GitHub/forkbomb/attesta/.worktrees/assess-admin-sidebar-nav/server
+go test ./cmd/server/ -count=1 -timeout 120s
+```
+
+Expected: PASS. Fix any leftover assertions referencing `data-org-admin-*` or missing `hx-` attrs.
+
+- [ ] **Step 2: Manual smoke (if `task dev` available in worktree)**
+
+From worktree:
+
+```bash
+task dev
+```
+
+Open printed URL:
+
+1. Platform admin: click Organizations ↔ Categories — no full reload (Network: document not refetched; `HX-Request` fragment); breadcrumbs update; topbar persists.
+2. Platform admin: search orgs — still updates results list only.
+3. Org admin: Profile ↔ Roles ↔ Members — soft-nav; only one panel’s content; forms POST still full reload.
+4. Org admin without org: setup form still works.
+5. Disable JS: sidebar links still navigate full page.
+
+- [ ] **Step 3: Commit any test fixes** (if needed)
+
+```bash
+git commit -m "$(cat <<'EOF'
+test(admin): finish soft-nav regression fixes
+
+EOF
+)"
+```
+
+---
+
+## Spec coverage (self-review)
+
+| Decision | Task |
+|----------|------|
+| Shared full `admin_console` component | Task 1 |
+| Swap page-header + nav + main | Task 1 template |
+| Same URL + `HX-Request` partial | Tasks 3–4 |
+| Distinguish orgs search via `HX-Target` | Task 2–3 |
+| POSTs stay full-page | Tasks 3–4 (no form hx attrs) |
+| Org admin single panel, remove History JS | Task 4 |
+| Org setup without soft-nav | Task 4 |
+| Nested results HTMX preserved | Task 3 |
+| Tests for fragment vs layout | Tasks 1, 3, 4, 5 |
+
+## Placeholder scan
+
+No TBD/TODO left in tasks; handler arrange blocks point at concrete existing test files to copy.
+
+## Type consistency
+
+- `AdminConsoleView` / `AdminConsoleNavItem` names stable across tasks
+- `wantsAdminConsolePartial` / `htmxTargetID` / `platformAdminConsole` / `orgAdminConsole` names stable
+- Main template names: `platform_admin_main`, `org_admin_main`
+- DOM id: `admin-console`; results id unchanged: `platform-admin-results`

--- a/server/cmd/server/admin_console.go
+++ b/server/cmd/server/admin_console.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+)
+
+func htmxTargetID(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	return strings.TrimSpace(r.Header.Get("HX-Target"))
+}
+
+func wantsAdminConsolePartial(r *http.Request) bool {
+	if !isHTMXRequest(r) {
+		return false
+	}
+	target := htmxTargetID(r)
+	return target == "" || target == "admin-console"
+}
+
+func platformAdminConsole(view PlatformAdminView) AdminConsoleView {
+	active := strings.TrimSpace(view.ActivePanel)
+	subtitle := "Create and manage organizations"
+	if active == "categories" {
+		subtitle = "Browse stream discovery categories"
+	}
+	return AdminConsoleView{
+		ID:          "admin-console",
+		NavLabel:    "Platform admin sections",
+		Title:       "Platform admin dashboard",
+		Subtitle:    subtitle,
+		Breadcrumbs: view.Breadcrumbs,
+		NavItems: []AdminConsoleNavItem{
+			{
+				Href:   "/admin/orgs",
+				Title:  "Organizations",
+				Copy:   "Create and manage organizations",
+				Active: active != "categories",
+			},
+			{
+				Href:   "/admin/categories",
+				Title:  "Categories",
+				Copy:   "Browse stream discovery categories",
+				Active: active == "categories",
+			},
+		},
+		MainTemplate: "platform_admin_main",
+		MainData:     view,
+	}
+}
+
+func orgAdminConsole(view OrgAdminView) AdminConsoleView {
+	active := strings.TrimSpace(view.ActivePanel)
+	if active == "" {
+		active = "profile"
+	}
+	return AdminConsoleView{
+		ID:          "admin-console",
+		NavLabel:    "Organization admin sections",
+		Title:       "Organization admin dashboard",
+		Subtitle:    "Manage organization settings, roles, and members",
+		Breadcrumbs: view.Breadcrumbs,
+		NavItems: []AdminConsoleNavItem{
+			{
+				Href:   organizationPath("profile"),
+				Title:  "Organization profile",
+				Copy:   "Update your organization name and logo",
+				Active: active == "profile",
+			},
+			{
+				Href:   organizationPath("roles"),
+				Title:  "Roles",
+				Copy:   "Manage the role catalog for your organization",
+				Active: active == "roles",
+			},
+			{
+				Href:   organizationPath("members"),
+				Title:  "Members",
+				Copy:   "Invite people and update member access",
+				Active: active == "members",
+			},
+		},
+		MainTemplate: "org_admin_main",
+		MainData:     view,
+	}
+}

--- a/server/cmd/server/admin_console_template_test.go
+++ b/server/cmd/server/admin_console_template_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestAdminConsoleTemplateSoftNavContract(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+
+	mainCrumbs := BreadcrumbsView{Items: []BreadcrumbItem{
+		{Label: "MainSlot", Href: "/main-slot", Current: true},
+	}}
+	view := AdminConsoleView{
+		ID:       "admin-console",
+		NavLabel: "Test sections",
+		Title:    "Test dashboard",
+		Subtitle: "Test subtitle",
+		Breadcrumbs: BreadcrumbsView{Items: []BreadcrumbItem{
+			{Label: "Dashboard", Href: "/my"},
+			{Label: "Test", Href: "/test", Current: true},
+		}},
+		NavItems: []AdminConsoleNavItem{
+			{Href: "/test/a", Title: "Alpha", Copy: "First", Active: true},
+			{Href: "/test/b", Title: "Beta", Copy: "Second", Active: false},
+		},
+		MainTemplate: "breadcrumbs",
+		MainData:     mainCrumbs,
+	}
+
+	var out bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&out, "admin_console", view); err != nil {
+		t.Fatalf("render admin_console: %v", err)
+	}
+	body := out.String()
+	for _, want := range []string{
+		`id="admin-console"`,
+		`class="page-header"`,
+		`class="breadcrumbs"`,
+		"<h1>Test dashboard</h1>",
+		"Test subtitle",
+		`aria-label="Test sections"`,
+		`class="sidebar-nav"`,
+		`hx-get="/test/a"`,
+		`hx-get="/test/b"`,
+		`hx-target="#admin-console"`,
+		`hx-select="#admin-console"`,
+		`hx-swap="outerHTML"`,
+		`hx-push-url="true"`,
+		`class="sidebar-nav-link is-active"`,
+		`aria-current="page"`,
+		"MainSlot",
+		`href="/main-slot"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in admin_console, got:\n%s", want, body)
+		}
+	}
+}

--- a/server/cmd/server/admin_console_test.go
+++ b/server/cmd/server/admin_console_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWantsAdminConsolePartial(t *testing.T) {
+	t.Parallel()
+
+	full := httptest.NewRequest(http.MethodGet, "/admin/orgs", nil)
+	if wantsAdminConsolePartial(full) {
+		t.Fatal("non-HTMX must be false")
+	}
+
+	results := httptest.NewRequest(http.MethodGet, "/admin/orgs?q=a", nil)
+	results.Header.Set("HX-Request", "true")
+	results.Header.Set("HX-Target", "platform-admin-results")
+	if wantsAdminConsolePartial(results) {
+		t.Fatal("orgs search HTMX must stay on results partial")
+	}
+
+	console := httptest.NewRequest(http.MethodGet, "/admin/categories", nil)
+	console.Header.Set("HX-Request", "true")
+	console.Header.Set("HX-Target", "admin-console")
+	if !wantsAdminConsolePartial(console) {
+		t.Fatal("sidebar soft-nav must request admin_console partial")
+	}
+}
+
+func TestPlatformAdminConsoleNav(t *testing.T) {
+	t.Parallel()
+	view := PlatformAdminView{ActivePanel: "categories", Breadcrumbs: buildPlatformAdminBreadcrumbs("categories")}
+	c := platformAdminConsole(view)
+	if c.MainTemplate != "platform_admin_main" {
+		t.Fatalf("MainTemplate = %q", c.MainTemplate)
+	}
+	if len(c.NavItems) != 2 || !c.NavItems[1].Active || c.NavItems[1].Href != "/admin/categories" {
+		t.Fatalf("unexpected nav: %+v", c.NavItems)
+	}
+	if c.Subtitle != "Browse stream discovery categories" {
+		t.Fatalf("Subtitle = %q", c.Subtitle)
+	}
+}
+
+func TestOrgAdminConsoleNav(t *testing.T) {
+	t.Parallel()
+	view := OrgAdminView{ActivePanel: "roles", Breadcrumbs: buildOrgAdminBreadcrumbs("roles")}
+	c := orgAdminConsole(view)
+	if c.MainTemplate != "org_admin_main" {
+		t.Fatalf("MainTemplate = %q", c.MainTemplate)
+	}
+	if len(c.NavItems) != 3 || !c.NavItems[1].Active || c.NavItems[1].Href != organizationPath("roles") {
+		t.Fatalf("unexpected nav: %+v", c.NavItems)
+	}
+}

--- a/server/cmd/server/admin_handler_identity_test.go
+++ b/server/cmd/server/admin_handler_identity_test.go
@@ -156,7 +156,7 @@ func TestPlatformOrganizationsAndRenderPlatformAdmin(t *testing.T) {
 			now:         func() time.Time { return now },
 		}
 		rec := httptest.NewRecorder()
-		server.renderPlatformAdmin(rec, &AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "invite sent", PlatformAdminErrors{})
+		server.renderPlatformAdmin(rec, httptest.NewRequest(http.MethodGet, "/admin/orgs", nil), &AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "invite sent", PlatformAdminErrors{})
 		if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "PLATFORM_ADMIN orgs 1 invite sent") {
 			t.Fatalf("status=%d body=%q", rec.Code, rec.Body.String())
 		}

--- a/server/cmd/server/admin_handler_identity_test.go
+++ b/server/cmd/server/admin_handler_identity_test.go
@@ -686,6 +686,7 @@ func TestHandleAdminOrgsPlatformAdminHTMXGetAndLogo(t *testing.T) {
 	t.Run("htmx get renders partial", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/admin/orgs?q=acme", nil)
 		req.Header.Set("HX-Request", "true")
+		req.Header.Set("HX-Target", "platform-admin-results")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
 

--- a/server/cmd/server/components.go
+++ b/server/cmd/server/components.go
@@ -284,3 +284,24 @@ type BreadcrumbItem struct {
 type BreadcrumbsView struct {
 	Items []BreadcrumbItem
 }
+
+// AdminConsoleNavItem is one soft-nav link in templates/components/admin_console.html.
+type AdminConsoleNavItem struct {
+	Href   string
+	Title  string
+	Copy   string
+	Active bool
+}
+
+// AdminConsoleView is the view model for templates/components/admin_console.html.
+// MainTemplate is executed via the render func with MainData as the dot.
+type AdminConsoleView struct {
+	ID           string // default "admin-console" when empty
+	NavLabel     string
+	Title        string
+	Subtitle     string
+	Breadcrumbs  BreadcrumbsView
+	NavItems     []AdminConsoleNavItem
+	MainTemplate string
+	MainData     any
+}

--- a/server/cmd/server/helpers_misc_coverage_test.go
+++ b/server/cmd/server/helpers_misc_coverage_test.go
@@ -107,7 +107,7 @@ func TestRenderPlatformAdminAdditionalBranches(t *testing.T) {
 	}
 	rec := httptest.NewRecorder()
 
-	server.renderPlatformAdmin(rec, &AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "", PlatformAdminErrors{Invite: " invite failed "})
+	server.renderPlatformAdmin(rec, httptest.NewRequest(http.MethodGet, "/admin/orgs", nil), &AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "", PlatformAdminErrors{Invite: " invite failed "})
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
@@ -119,7 +119,7 @@ func TestRenderPlatformAdminAdditionalBranches(t *testing.T) {
 	broken := &Server{
 		authorizer: fakeAuthorizer{}, tmpl: template.Must(template.New("broken").Parse(`{{define "platform_admin.html"}}{{template "missing" .}}{{end}}`)), now: func() time.Time { return now }}
 	errRec := httptest.NewRecorder()
-	broken.renderPlatformAdmin(errRec, &AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "", PlatformAdminErrors{})
+	broken.renderPlatformAdmin(errRec, httptest.NewRequest(http.MethodGet, "/admin/orgs", nil), &AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "", PlatformAdminErrors{})
 	if errRec.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want %d", errRec.Code, http.StatusInternalServerError)
 	}

--- a/server/cmd/server/list_row_markup_test.go
+++ b/server/cmd/server/list_row_markup_test.go
@@ -10,6 +10,7 @@ func TestOrgAdminListRowMarkup(t *testing.T) {
 	tmpl := parseTestTemplates(t)
 
 	view := OrgAdminView{
+		ActivePanel:  "roles",
 		Organization: Organization{Name: "Acme Org", Slug: "acme-org"},
 		RoleRows: []OrgAdminRoleRow{
 			{Slug: "qa-reviewer", Name: "QA Reviewer", Palette: "emerald", InUse: false},
@@ -23,22 +24,35 @@ func TestOrgAdminListRowMarkup(t *testing.T) {
 		},
 	}
 
-	var out bytes.Buffer
-	if err := tmpl.ExecuteTemplate(&out, "org_admin_body", view); err != nil {
-		t.Fatalf("render org_admin_body: %v", err)
+	var rolesOut bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&rolesOut, "org_admin_body", view); err != nil {
+		t.Fatalf("render org_admin_body roles: %v", err)
 	}
-	body := out.String()
+	rolesBody := rolesOut.String()
 
 	for _, want := range []string{
 		`class="list-rows"`,
 		`class="list-row"`,
 		`class="list-row-main"`,
 		`class="list-row-actions"`,
+	} {
+		if !strings.Contains(rolesBody, want) {
+			t.Fatalf("expected %q in roles markup, got:\n%s", want, rolesBody)
+		}
+	}
+
+	view.ActivePanel = "members"
+	var membersOut bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&membersOut, "org_admin_body", view); err != nil {
+		t.Fatalf("render org_admin_body members: %v", err)
+	}
+	membersBody := membersOut.String()
+	for _, want := range []string{
 		`class="user-email"`,
 		`class="user-tags"`,
 	} {
-		if !strings.Contains(body, want) {
-			t.Fatalf("expected %q in org admin markup, got:\n%s", want, body)
+		if !strings.Contains(membersBody, want) {
+			t.Fatalf("expected %q in members markup, got:\n%s", want, membersBody)
 		}
 	}
 
@@ -50,17 +64,17 @@ func TestOrgAdminListRowMarkup(t *testing.T) {
 		`class="user-main"`,
 		`class="user-actions"`,
 	} {
-		if strings.Contains(body, legacy) {
+		if strings.Contains(rolesBody, legacy) || strings.Contains(membersBody, legacy) {
 			t.Fatalf("did not expect legacy class %q in org admin markup", legacy)
 		}
 	}
 
 	// Roles pill lives inside list-row-main (not a bare first child beside actions).
-	rowIdx := strings.Index(body, `class="list-row"`)
+	rowIdx := strings.Index(rolesBody, `class="list-row"`)
 	if rowIdx < 0 {
 		t.Fatal("expected list-row")
 	}
-	snippet := body[rowIdx:]
+	snippet := rolesBody[rowIdx:]
 	mainIdx := strings.Index(snippet, `class="list-row-main"`)
 	actionsIdx := strings.Index(snippet, `class="list-row-actions"`)
 	pillIdx := strings.Index(snippet, `class="pill pill-lg role-pill"`)
@@ -71,7 +85,6 @@ func TestOrgAdminListRowMarkup(t *testing.T) {
 		t.Fatalf("expected role pill inside list-row-main before list-row-actions")
 	}
 }
-
 func TestPlatformAdminListRowMarkup(t *testing.T) {
 	tmpl := parseTestTemplates(t)
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -3747,12 +3747,15 @@ func resolveOrgAdminActivePanel(r *http.Request, errs OrgAdminErrors, inviteLink
 		return "profile"
 	}
 	if r != nil {
-		switch r.URL.Path {
-		case organizationPath("roles"):
+		// handleMyRoutes rewrites /my/organization/... to /organization/... before handlers run.
+		// Match both forms (and trailing slash) via shared suffixes.
+		path := strings.TrimSuffix(r.URL.Path, "/")
+		switch {
+		case strings.HasSuffix(path, "/organization/roles"):
 			return "roles"
-		case organizationPath("members"):
+		case strings.HasSuffix(path, "/organization/members"):
 			return "members"
-		case organizationPath("profile"):
+		case strings.HasSuffix(path, "/organization/profile"):
 			return "profile"
 		}
 	}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -3981,6 +3981,12 @@ func (s *Server) renderOrgAdminWithErrors(w http.ResponseWriter, r *http.Request
 	if strings.TrimSpace(org.LogoAttachmentID) == "" {
 		view.OrganizationLogoURL = ""
 	}
+	if wantsAdminConsolePartial(r) {
+		if err := s.tmpl.ExecuteTemplate(w, "admin_console", orgAdminConsole(view)); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
 	if err := s.tmpl.ExecuteTemplate(w, "org_admin.html", view); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
@@ -7505,6 +7511,9 @@ func effectiveSubstep(canonical WorkflowSub, override *SubstepOverride) Workflow
 }
 
 func isHTMXRequest(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
 	return strings.EqualFold(r.Header.Get("HX-Request"), "true")
 }
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -414,6 +414,7 @@ type PlatformAdminView struct {
 	ActivePanel              string
 	Categories               []TaxonomyCategoryNode
 	Breadcrumbs              BreadcrumbsView
+	Console                  AdminConsoleView
 	SearchQuery              string
 	CurrentPage              int
 	TotalPages               int
@@ -1301,7 +1302,7 @@ func logAndHTTPError(w http.ResponseWriter, r *http.Request, status int, userMes
 
 func (s *Server) logAndRenderPlatformAdminError(w http.ResponseWriter, r *http.Request, user *AccountUser, confirmation string, errs PlatformAdminErrors, err error, message string, args ...interface{}) {
 	logRequestError(r, err, message, args...)
-	s.renderPlatformAdmin(w, user, confirmation, errs)
+	s.renderPlatformAdmin(w, r, user, confirmation, errs)
 }
 
 func (s *Server) logAndRenderOrgAdminError(w http.ResponseWriter, r *http.Request, user *AccountUser, orgSlug, inviteLink string, errs OrgAdminErrors, err error, message string, args ...interface{}) {
@@ -3403,7 +3404,7 @@ func (s *Server) platformAdminView(user *AccountUser, confirmation string, errs 
 		pageNumbers = append(pageNumbers, page)
 	}
 	rows := platformAdminOrganizationRows(context.Background(), pagedOrganizations, s.identity)
-	return PlatformAdminView{
+	view := PlatformAdminView{
 		PageBase:                 s.pageBaseForUser(user, "platform_admin_body", "", ""),
 		ActivePanel:              "orgs",
 		Breadcrumbs:              buildPlatformAdminBreadcrumbs("orgs"),
@@ -3426,10 +3427,18 @@ func (s *Server) platformAdminView(user *AccountUser, confirmation string, errs 
 		InviteDialogEmail:        errs.InviteEmail,
 		Error:                    firstNonEmpty(errs.Organization, errs.Invite),
 	}
+	view.Console = platformAdminConsole(view)
+	return view
 }
 
-func (s *Server) renderPlatformAdmin(w http.ResponseWriter, user *AccountUser, confirmation string, errs PlatformAdminErrors) {
+func (s *Server) renderPlatformAdmin(w http.ResponseWriter, r *http.Request, user *AccountUser, confirmation string, errs PlatformAdminErrors) {
 	view := s.platformAdminView(user, confirmation, errs)
+	if wantsAdminConsolePartial(r) {
+		if err := s.tmpl.ExecuteTemplate(w, "admin_console", view.Console); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
 	if err := s.tmpl.ExecuteTemplate(w, "platform_admin.html", view); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
@@ -3462,6 +3471,13 @@ func (s *Server) handleAdminCategories(w http.ResponseWriter, r *http.Request) {
 		Categories:  categories,
 		Breadcrumbs: buildPlatformAdminBreadcrumbs("categories"),
 	}
+	view.Console = platformAdminConsole(view)
+	if wantsAdminConsolePartial(r) {
+		if err := s.tmpl.ExecuteTemplate(w, "admin_console", view.Console); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
 	if err := s.tmpl.ExecuteTemplate(w, "platform_admin.html", view); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
@@ -3489,11 +3505,11 @@ func (s *Server) handleAdminOrgs(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		searchQuery, page := platformAdminListStateFromRequest(r)
 		confirmation := homePickerMessage(r, "confirmation")
-		if isHTMXRequest(r) {
+		if isHTMXRequest(r) && htmxTargetID(r) == "platform-admin-results" {
 			s.renderPlatformAdminResults(w, admin, confirmation, PlatformAdminErrors{SearchQuery: searchQuery, Page: page})
 			return
 		}
-		s.renderPlatformAdmin(w, admin, confirmation, PlatformAdminErrors{SearchQuery: searchQuery, Page: page})
+		s.renderPlatformAdmin(w, r, admin, confirmation, PlatformAdminErrors{SearchQuery: searchQuery, Page: page})
 		return
 	case http.MethodPost:
 		contentType := strings.ToLower(strings.TrimSpace(r.Header.Get("Content-Type")))
@@ -3501,7 +3517,7 @@ func (s *Server) handleAdminOrgs(w http.ResponseWriter, r *http.Request) {
 			r.Body = http.MaxBytesReader(w, r.Body, organizationLogoMaxBytes())
 			if err := r.ParseMultipartForm(1 << 20); err != nil {
 				if isRequestTooLarge(err) {
-					s.renderPlatformAdmin(w, admin, "", PlatformAdminErrors{Organization: "logo file too large"})
+					s.renderPlatformAdmin(w, r, admin, "", PlatformAdminErrors{Organization: "logo file too large"})
 					return
 				}
 				logAndHTTPError(w, r, http.StatusBadRequest, "invalid form", err, "failed to parse platform admin multipart form")
@@ -3523,11 +3539,11 @@ func (s *Server) handleAdminOrgs(w http.ResponseWriter, r *http.Request) {
 			orgSlug := strings.TrimSpace(r.FormValue("org_slug"))
 			email := strings.ToLower(strings.TrimSpace(r.FormValue("email")))
 			if email == "" {
-				s.renderPlatformAdmin(w, admin, "", PlatformAdminErrors{Invite: "email is required", DialogAction: "invite", OrgSlug: orgSlug, InviteEmail: email, SearchQuery: searchQuery, Page: page})
+				s.renderPlatformAdmin(w, r, admin, "", PlatformAdminErrors{Invite: "email is required", DialogAction: "invite", OrgSlug: orgSlug, InviteEmail: email, SearchQuery: searchQuery, Page: page})
 				return
 			}
 			if orgSlug == "" {
-				s.renderPlatformAdmin(w, admin, "", PlatformAdminErrors{Invite: "organization is required", DialogAction: "invite", OrgSlug: orgSlug, InviteEmail: email, SearchQuery: searchQuery, Page: page})
+				s.renderPlatformAdmin(w, r, admin, "", PlatformAdminErrors{Invite: "organization is required", DialogAction: "invite", OrgSlug: orgSlug, InviteEmail: email, SearchQuery: searchQuery, Page: page})
 				return
 			}
 			redirectURL := inviteRedirectURL(r)
@@ -3536,7 +3552,7 @@ func (s *Server) handleAdminOrgs(w http.ResponseWriter, r *http.Request) {
 				if err != nil {
 					logRequestError(r, err, "failed to load organization %s for platform admin invite", orgSlug)
 				}
-				s.renderPlatformAdmin(w, admin, "", PlatformAdminErrors{Invite: "organization not found", DialogAction: "invite", OrgSlug: orgSlug, InviteEmail: email, SearchQuery: searchQuery, Page: page})
+				s.renderPlatformAdmin(w, r, admin, "", PlatformAdminErrors{Invite: "organization not found", DialogAction: "invite", OrgSlug: orgSlug, InviteEmail: email, SearchQuery: searchQuery, Page: page})
 				return
 			}
 			platformSession, err := s.ensurePlatformAdminOwnsOrganization(r.Context(), org.Slug, redirectURL)
@@ -3549,14 +3565,14 @@ func (s *Server) handleAdminOrgs(w http.ResponseWriter, r *http.Request) {
 			}()
 			message, err := s.inviteOrganizationAdminWithSession(r.Context(), platformSession.Secret, *org, email, redirectURL)
 			if errors.Is(err, errPlatformAdminInviteCrossOrg) {
-				s.renderPlatformAdmin(w, admin, "", PlatformAdminErrors{Invite: "email already belongs to another organization", DialogAction: "invite", OrgSlug: orgSlug, InviteEmail: email, SearchQuery: searchQuery, Page: page})
+				s.renderPlatformAdmin(w, r, admin, "", PlatformAdminErrors{Invite: "email already belongs to another organization", DialogAction: "invite", OrgSlug: orgSlug, InviteEmail: email, SearchQuery: searchQuery, Page: page})
 				return
 			}
 			if err != nil {
 				s.logAndRenderPlatformAdminError(w, r, admin, "", PlatformAdminErrors{Invite: "failed to create invite", DialogAction: "invite", OrgSlug: orgSlug, InviteEmail: email, SearchQuery: searchQuery, Page: page}, err, "failed to create org admin invite for %s in %s", email, org.Slug)
 				return
 			}
-			s.renderPlatformAdmin(w, admin, message, PlatformAdminErrors{SearchQuery: searchQuery, Page: page})
+			s.renderPlatformAdmin(w, r, admin, message, PlatformAdminErrors{SearchQuery: searchQuery, Page: page})
 			return
 		}
 		switch intent {
@@ -3564,17 +3580,17 @@ func (s *Server) handleAdminOrgs(w http.ResponseWriter, r *http.Request) {
 			name := strings.TrimSpace(r.FormValue("name"))
 			inviteEmail := strings.ToLower(strings.TrimSpace(r.FormValue("invite_email")))
 			if name == "" {
-				s.renderPlatformAdmin(w, admin, "", PlatformAdminErrors{Organization: "organization name is required", DialogAction: "create", OrgName: name, InviteEmail: inviteEmail, SearchQuery: searchQuery, Page: page})
+				s.renderPlatformAdmin(w, r, admin, "", PlatformAdminErrors{Organization: "organization name is required", DialogAction: "create", OrgName: name, InviteEmail: inviteEmail, SearchQuery: searchQuery, Page: page})
 				return
 			}
 			orgSlug := canonifySlug(name)
 			if existing, err := s.identity.GetOrganizationBySlug(r.Context(), orgSlug); err == nil && existing != nil {
-				s.renderPlatformAdmin(w, admin, "", PlatformAdminErrors{Organization: "organization slug already exists", DialogAction: "create", OrgName: name, InviteEmail: inviteEmail, SearchQuery: searchQuery, Page: page})
+				s.renderPlatformAdmin(w, r, admin, "", PlatformAdminErrors{Organization: "organization slug already exists", DialogAction: "create", OrgName: name, InviteEmail: inviteEmail, SearchQuery: searchQuery, Page: page})
 				return
 			}
 			logoUpload, logoErrMsg := s.readOrganizationLogoUpload(r)
 			if logoErrMsg != "" {
-				s.renderPlatformAdmin(w, admin, "", PlatformAdminErrors{Organization: logoErrMsg, DialogAction: "create", OrgName: name, InviteEmail: inviteEmail, SearchQuery: searchQuery, Page: page})
+				s.renderPlatformAdmin(w, r, admin, "", PlatformAdminErrors{Organization: logoErrMsg, DialogAction: "create", OrgName: name, InviteEmail: inviteEmail, SearchQuery: searchQuery, Page: page})
 				return
 			}
 			platformSession, err := s.platformAdminIdentitySession(r.Context())
@@ -3588,7 +3604,7 @@ func (s *Server) handleAdminOrgs(w http.ResponseWriter, r *http.Request) {
 			createdOrg, err := s.identity.CreateOrganization(r.Context(), platformSession.Secret, name)
 			if err != nil {
 				if isDuplicateSlugError(err) {
-					s.renderPlatformAdmin(w, admin, "", PlatformAdminErrors{Organization: "organization slug already exists", DialogAction: "create", OrgName: name, InviteEmail: inviteEmail, SearchQuery: searchQuery, Page: page})
+					s.renderPlatformAdmin(w, r, admin, "", PlatformAdminErrors{Organization: "organization slug already exists", DialogAction: "create", OrgName: name, InviteEmail: inviteEmail, SearchQuery: searchQuery, Page: page})
 					return
 				}
 				s.logAndRenderPlatformAdminError(w, r, admin, "", PlatformAdminErrors{Organization: "failed to create organization", DialogAction: "create", OrgName: name, InviteEmail: inviteEmail, SearchQuery: searchQuery, Page: page}, err, "failed to create organization %s", name)
@@ -3612,7 +3628,7 @@ func (s *Server) handleAdminOrgs(w http.ResponseWriter, r *http.Request) {
 			if inviteEmail != "" {
 				message, err := s.inviteOrganizationAdminWithSession(r.Context(), platformSession.Secret, createdOrg, inviteEmail, inviteRedirectURL(r))
 				if errors.Is(err, errPlatformAdminInviteCrossOrg) {
-					s.renderPlatformAdmin(w, admin, "organization created", PlatformAdminErrors{Invite: "email already belongs to another organization", DialogAction: "invite", OrgSlug: createdOrg.Slug, InviteEmail: inviteEmail, SearchQuery: searchQuery, Page: page})
+					s.renderPlatformAdmin(w, r, admin, "organization created", PlatformAdminErrors{Invite: "email already belongs to another organization", DialogAction: "invite", OrgSlug: createdOrg.Slug, InviteEmail: inviteEmail, SearchQuery: searchQuery, Page: page})
 					return
 				}
 				if err != nil {
@@ -3628,11 +3644,11 @@ func (s *Server) handleAdminOrgs(w http.ResponseWriter, r *http.Request) {
 			currentSlug := strings.TrimSpace(r.FormValue("org_slug"))
 			name := strings.TrimSpace(r.FormValue("name"))
 			if currentSlug == "" {
-				s.renderPlatformAdmin(w, admin, "", PlatformAdminErrors{Organization: "organization not found", DialogAction: "edit", SearchQuery: searchQuery, Page: page})
+				s.renderPlatformAdmin(w, r, admin, "", PlatformAdminErrors{Organization: "organization not found", DialogAction: "edit", SearchQuery: searchQuery, Page: page})
 				return
 			}
 			if name == "" {
-				s.renderPlatformAdmin(w, admin, "", PlatformAdminErrors{Organization: "organization name is required", DialogAction: "edit", OrgSlug: currentSlug, OrgName: name, SearchQuery: searchQuery, Page: page})
+				s.renderPlatformAdmin(w, r, admin, "", PlatformAdminErrors{Organization: "organization name is required", DialogAction: "edit", OrgSlug: currentSlug, OrgName: name, SearchQuery: searchQuery, Page: page})
 				return
 			}
 			org, err := s.identity.GetOrganizationBySlug(r.Context(), currentSlug)
@@ -3640,19 +3656,19 @@ func (s *Server) handleAdminOrgs(w http.ResponseWriter, r *http.Request) {
 				if err != nil {
 					logRequestError(r, err, "failed to load organization %s for platform admin update", currentSlug)
 				}
-				s.renderPlatformAdmin(w, admin, "", PlatformAdminErrors{Organization: "organization not found", DialogAction: "edit", OrgSlug: currentSlug, OrgName: name, SearchQuery: searchQuery, Page: page})
+				s.renderPlatformAdmin(w, r, admin, "", PlatformAdminErrors{Organization: "organization not found", DialogAction: "edit", OrgSlug: currentSlug, OrgName: name, SearchQuery: searchQuery, Page: page})
 				return
 			}
 			targetOrgSlug := canonifySlug(name)
 			if targetOrgSlug != strings.TrimSpace(org.Slug) {
 				if existing, err := s.identity.GetOrganizationBySlug(r.Context(), targetOrgSlug); err == nil && existing != nil && strings.TrimSpace(existing.ID) != strings.TrimSpace(org.ID) {
-					s.renderPlatformAdmin(w, admin, "", PlatformAdminErrors{Organization: "organization slug already exists", DialogAction: "edit", OrgSlug: currentSlug, OrgName: name, SearchQuery: searchQuery, Page: page})
+					s.renderPlatformAdmin(w, r, admin, "", PlatformAdminErrors{Organization: "organization slug already exists", DialogAction: "edit", OrgSlug: currentSlug, OrgName: name, SearchQuery: searchQuery, Page: page})
 					return
 				}
 			}
 			logoUpload, logoErrMsg := s.readOrganizationLogoUpload(r)
 			if logoErrMsg != "" {
-				s.renderPlatformAdmin(w, admin, "", PlatformAdminErrors{Organization: logoErrMsg, DialogAction: "edit", OrgSlug: currentSlug, OrgName: name, SearchQuery: searchQuery, Page: page})
+				s.renderPlatformAdmin(w, r, admin, "", PlatformAdminErrors{Organization: logoErrMsg, DialogAction: "edit", OrgSlug: currentSlug, OrgName: name, SearchQuery: searchQuery, Page: page})
 				return
 			}
 			previousLogoFileID := strings.TrimSpace(org.LogoFileID)
@@ -3672,7 +3688,7 @@ func (s *Server) handleAdminOrgs(w http.ResponseWriter, r *http.Request) {
 			updatedOrg, err := s.identity.UpdateOrganizationAsAdmin(r.Context(), currentSlug, name, logoFileID, append([]IdentityRole(nil), org.Roles...))
 			if err != nil {
 				if isDuplicateSlugError(err) {
-					s.renderPlatformAdmin(w, admin, "", PlatformAdminErrors{Organization: "organization slug already exists", DialogAction: "edit", OrgSlug: currentSlug, OrgName: name, SearchQuery: searchQuery, Page: page})
+					s.renderPlatformAdmin(w, r, admin, "", PlatformAdminErrors{Organization: "organization slug already exists", DialogAction: "edit", OrgSlug: currentSlug, OrgName: name, SearchQuery: searchQuery, Page: page})
 					return
 				}
 				s.logAndRenderPlatformAdminError(w, r, admin, "", PlatformAdminErrors{Organization: "failed to update organization", DialogAction: "edit", OrgSlug: currentSlug, OrgName: name, SearchQuery: searchQuery, Page: page}, err, "failed to update organization %s", currentSlug)
@@ -3683,12 +3699,12 @@ func (s *Server) handleAdminOrgs(w http.ResponseWriter, r *http.Request) {
 					log.Printf("failed to delete previous organization logo %q: %v", previousLogoFileID, err)
 				}
 			}
-			s.renderPlatformAdmin(w, admin, "organization updated", PlatformAdminErrors{SearchQuery: searchQuery, Page: page})
+			s.renderPlatformAdmin(w, r, admin, "organization updated", PlatformAdminErrors{SearchQuery: searchQuery, Page: page})
 			return
 		case "delete_org":
 			currentSlug := strings.TrimSpace(r.FormValue("org_slug"))
 			if currentSlug == "" {
-				s.renderPlatformAdmin(w, admin, "", PlatformAdminErrors{Organization: "organization not found", DialogAction: "delete", SearchQuery: searchQuery, Page: page})
+				s.renderPlatformAdmin(w, r, admin, "", PlatformAdminErrors{Organization: "organization not found", DialogAction: "delete", SearchQuery: searchQuery, Page: page})
 				return
 			}
 			org, err := s.identity.GetOrganizationBySlug(r.Context(), currentSlug)
@@ -3696,7 +3712,7 @@ func (s *Server) handleAdminOrgs(w http.ResponseWriter, r *http.Request) {
 				if err != nil {
 					logRequestError(r, err, "failed to load organization %s for platform admin deletion", currentSlug)
 				}
-				s.renderPlatformAdmin(w, admin, "", PlatformAdminErrors{Organization: "organization not found", DialogAction: "delete", OrgSlug: currentSlug, SearchQuery: searchQuery, Page: page})
+				s.renderPlatformAdmin(w, r, admin, "", PlatformAdminErrors{Organization: "organization not found", DialogAction: "delete", OrgSlug: currentSlug, SearchQuery: searchQuery, Page: page})
 				return
 			}
 			previousLogoFileID := strings.TrimSpace(org.LogoFileID)
@@ -3709,10 +3725,10 @@ func (s *Server) handleAdminOrgs(w http.ResponseWriter, r *http.Request) {
 					log.Printf("failed to delete organization logo %q after deleting org %s: %v", previousLogoFileID, currentSlug, err)
 				}
 			}
-			s.renderPlatformAdmin(w, admin, "organization deleted", PlatformAdminErrors{SearchQuery: searchQuery, Page: page})
+			s.renderPlatformAdmin(w, r, admin, "organization deleted", PlatformAdminErrors{SearchQuery: searchQuery, Page: page})
 			return
 		default:
-			s.renderPlatformAdmin(w, admin, "", PlatformAdminErrors{Organization: "unsupported action", SearchQuery: searchQuery, Page: page})
+			s.renderPlatformAdmin(w, r, admin, "", PlatformAdminErrors{Organization: "unsupported action", SearchQuery: searchQuery, Page: page})
 			return
 		}
 	default:

--- a/server/cmd/server/org_admin_section_urls_test.go
+++ b/server/cmd/server/org_admin_section_urls_test.go
@@ -124,6 +124,10 @@ func TestResolveOrgAdminActivePanelFromPath(t *testing.T) {
 		{path: "/my/organization/members", want: "members"},
 		{path: "/my/organization/roles", want: "roles"},
 		{path: "/my/organization/users", want: "profile"},
+		{path: "/organization/profile", want: "profile"},
+		{path: "/organization/members", want: "members"},
+		{path: "/organization/roles", want: "roles"},
+		{path: "/organization/roles/", want: "roles"},
 	}
 	for _, tc := range tests {
 		req := httptest.NewRequest(http.MethodGet, tc.path, nil)

--- a/server/cmd/server/org_admin_section_urls_test.go
+++ b/server/cmd/server/org_admin_section_urls_test.go
@@ -136,50 +136,49 @@ func TestResolveOrgAdminActivePanelFromPath(t *testing.T) {
 func assertOrgAdminActivePanel(t *testing.T, body, panel string) {
 	t.Helper()
 
+	if !strings.Contains(body, `id="admin-console"`) {
+		t.Fatalf("expected admin-console soft-nav shell for %q", panel)
+	}
 	if !strings.Contains(body, `class="sidebar-nav-link is-active"`) {
 		t.Fatalf("expected active sidebar nav link for %q", panel)
 	}
-	if !strings.Contains(body, `href="/my/organization/`+panel+`"`) {
-		t.Fatalf("expected nav href for %q panel", panel)
+
+	href := "/my/organization/" + panel
+	activeIdx := strings.Index(body, `class="sidebar-nav-link is-active"`)
+	if activeIdx == -1 {
+		t.Fatalf("expected active sidebar nav link for %q", panel)
 	}
-	if !strings.Contains(body, `data-org-admin-default-panel="`+panel+`"`) {
-		preview := body
-		if len(preview) > 400 {
-			preview = preview[:400]
-		}
-		t.Fatalf("expected default panel %q, got body prefix:\n%s", panel, preview)
+	start := activeIdx - 200
+	if start < 0 {
+		start = 0
+	}
+	end := activeIdx + 350
+	if end > len(body) {
+		end = len(body)
+	}
+	window := body[start:end]
+	if !strings.Contains(window, `href="`+href+`"`) {
+		t.Fatalf("expected active soft-nav link for %q, got snippet:\n%s", panel, window)
+	}
+	if !strings.Contains(window, `aria-current="page"`) {
+		t.Fatalf("expected aria-current on active %q link, got snippet:\n%s", panel, window)
+	}
+	if !strings.Contains(window, `hx-target="#admin-console"`) {
+		t.Fatalf("expected hx-target on soft-nav for %q, got snippet:\n%s", panel, window)
 	}
 
-	panelID := `id="org-admin-panel-` + panel + `"` 
-	panelStart := strings.Index(body, panelID)
-	if panelStart == -1 {
+	panelID := `id="org-admin-panel-` + panel + `"`
+	if !strings.Contains(body, panelID) {
 		t.Fatalf("expected %s section in body", panelID)
-	}
-	panelEnd := strings.Index(body[panelStart:], ">")
-	if panelEnd == -1 {
-		t.Fatalf("expected opening tag for %s", panelID)
-	}
-	panelTag := body[panelStart : panelStart+panelEnd+1]
-	if strings.Contains(panelTag, "hidden") {
-		t.Fatalf("active panel %q must not be hidden, got tag %q", panel, panelTag)
 	}
 
 	for _, other := range []string{"profile", "roles", "members"} {
 		if other == panel {
 			continue
 		}
-		otherID := `id="org-admin-panel-` + other + `"` 
-		otherStart := strings.Index(body, otherID)
-		if otherStart == -1 {
-			t.Fatalf("expected %s section in body", otherID)
-		}
-		otherEnd := strings.Index(body[otherStart:], ">")
-		if otherEnd == -1 {
-			t.Fatalf("expected opening tag for %s", otherID)
-		}
-		otherTag := body[otherStart : otherStart+otherEnd+1]
-		if !strings.Contains(otherTag, "hidden") {
-			t.Fatalf("inactive panel %q should be hidden, got tag %q", other, otherTag)
+		otherID := `id="org-admin-panel-` + other + `"`
+		if strings.Contains(body, otherID) {
+			t.Fatalf("inactive panel %q must not be rendered, found %s", other, otherID)
 		}
 	}
 }

--- a/server/cmd/server/org_admin_soft_nav_mux_test.go
+++ b/server/cmd/server/org_admin_soft_nav_mux_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOrgAdminSoftNavViaMuxReturnsRequestedPanel(t *testing.T) {
+	now := time.Now().UTC()
+	server := orgAdminSectionURLTestServer(t, now)
+	mux := server.newMux()
+
+	req := httptest.NewRequest(http.MethodGet, "/my/organization/roles", nil)
+	req.Header.Set("HX-Request", "true")
+	req.Header.Set("HX-Target", "admin-console")
+	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-1"})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `id="admin-console"`) {
+		t.Fatalf("expected admin-console fragment, got: %s", body)
+	}
+	if strings.Contains(body, `class="topbar"`) || strings.Contains(body, "<html") {
+		t.Fatalf("HTMX soft-nav must not include layout, got: %s", body)
+	}
+	assertOrgAdminActivePanel(t, body, "roles")
+}
+
+func TestResolveOrgAdminActivePanelStrippedMyPrefix(t *testing.T) {
+	// handleMyRoutes clones to /organization/... before handlers run.
+	req := httptest.NewRequest(http.MethodGet, "/organization/roles", nil)
+	if got := resolveOrgAdminActivePanel(req, OrgAdminErrors{}, ""); got != "roles" {
+		t.Fatalf("resolveOrgAdminActivePanel(%q) = %q, want roles", req.URL.Path, got)
+	}
+}

--- a/server/cmd/server/org_admin_template_role_style_test.go
+++ b/server/cmd/server/org_admin_template_role_style_test.go
@@ -10,6 +10,7 @@ func TestOrgAdminTemplateRolePillRendersCSSVariables(t *testing.T) {
 	tmpl := parseTestTemplates(t)
 
 	view := OrgAdminView{
+		ActivePanel: "members",
 		Roles: []Role{
 			{Slug: "org-admin", Name: "Org Admin"},
 			{Slug: "qa-reviewer", Name: "QA Reviewer"},
@@ -87,7 +88,8 @@ func TestOrgAdminTemplateRolePillRendersCSSVariables(t *testing.T) {
 func TestOrgAdminTemplateLastInviteCopyButton(t *testing.T) {
 	tmpl := parseTestTemplates(t)
 	view := OrgAdminView{
-		InviteLink: "/invite/token-pending",
+		ActivePanel: "members",
+		InviteLink:  "/invite/token-pending",
 	}
 
 	var out bytes.Buffer

--- a/server/cmd/server/org_admin_template_role_usage_test.go
+++ b/server/cmd/server/org_admin_template_role_usage_test.go
@@ -10,6 +10,7 @@ func TestOrgAdminTemplateRoleUsageStates(t *testing.T) {
 	tmpl := parseTestTemplates(t)
 
 	view := OrgAdminView{
+		ActivePanel: "roles",
 		RoleRows: []OrgAdminRoleRow{
 			{
 				Slug:    "approver",

--- a/server/cmd/server/org_admin_template_sidebar_test.go
+++ b/server/cmd/server/org_admin_template_sidebar_test.go
@@ -10,6 +10,7 @@ func TestOrgAdminTemplateRendersSidebarPanels(t *testing.T) {
 	tmpl := parseTestTemplates(t)
 
 	view := OrgAdminView{
+		ActivePanel: "profile",
 		Organization: Organization{
 			Name: "Acme Org",
 			Slug: "acme-org",
@@ -41,25 +42,59 @@ func TestOrgAdminTemplateRendersSidebarPanels(t *testing.T) {
 	body := out.String()
 
 	for _, marker := range []string{
-		`panel-sticky`,
+		`id="admin-console"`,
 		`class="sidebar-nav"`,
-		`class="sidebar-nav-link"`,
-		`class="sidebar-nav-title"`,
-		`class="sidebar-nav-copy"`,
-		`data-org-admin-nav="profile"`,
-		`data-org-admin-nav="roles"`,
-		`data-org-admin-nav="members"`,
+		`class="sidebar-nav-link is-active"`,
+		`hx-get="/my/organization/profile"`,
+		`hx-get="/my/organization/roles"`,
+		`hx-get="/my/organization/members"`,
+		`hx-target="#admin-console"`,
 		`id="org-admin-panel-profile"`,
-		`id="org-admin-panel-roles"`,
-		`id="org-admin-panel-members"`,
-		`data-org-admin-shell`,
+		`name="intent" value="update_org"`,
 	} {
 		if !strings.Contains(body, marker) {
 			t.Fatalf("expected marker %q in output, got: %s", marker, body)
 		}
 	}
 
+	for _, banned := range []string{
+		`data-org-admin-nav=`,
+		`data-org-admin-shell`,
+		`id="org-admin-panel-roles"`,
+		`id="org-admin-panel-members"`,
+		`history.pushState`,
+	} {
+		if strings.Contains(body, banned) {
+			t.Fatalf("did not expect %q in single-panel profile render, got: %s", banned, body)
+		}
+	}
+
 	if count := strings.Count(body, `name="intent" value="update_org"`); count != 1 {
 		t.Fatalf("expected one update_org form, got %d in %s", count, body)
+	}
+}
+
+func TestOrgAdminTemplateRendersRolesPanelOnly(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+	view := OrgAdminView{
+		ActivePanel: "roles",
+		Organization: Organization{
+			Name: "Acme Org",
+			Slug: "acme-org",
+		},
+		RoleRows: []OrgAdminRoleRow{
+			{Slug: "qa-reviewer", Name: "QA Reviewer", Palette: "emerald"},
+		},
+	}
+	var out bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&out, "org_admin_body", view); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := out.String()
+	if !strings.Contains(body, `id="org-admin-panel-roles"`) {
+		t.Fatalf("expected roles panel, got: %s", body)
+	}
+	if strings.Contains(body, `id="org-admin-panel-profile"`) || strings.Contains(body, `id="org-admin-panel-members"`) {
+		t.Fatalf("roles render must not include other panels, got: %s", body)
 	}
 }

--- a/server/cmd/server/panel_markup_test.go
+++ b/server/cmd/server/panel_markup_test.go
@@ -340,6 +340,7 @@ func TestOrgAdminRolesPanelMarkup(t *testing.T) {
 	tmpl := parseTestTemplates(t)
 
 	view := OrgAdminView{
+		ActivePanel: "roles",
 		Organization: Organization{
 			Name: "Acme Org",
 			Slug: "acme-org",
@@ -363,11 +364,12 @@ func TestOrgAdminRolesPanelMarkup(t *testing.T) {
 	if rolesStart == -1 {
 		t.Fatalf("expected org-admin roles panel section, got:\n%s", body)
 	}
-	rolesEnd := strings.Index(body[rolesStart:], `id="org-admin-panel-members"`)
-	if rolesEnd == -1 {
-		t.Fatalf("expected org-admin members panel section after roles, got:\n%s", body)
+	// Include the opening <section ...> which places class before id.
+	sectionStart := strings.LastIndex(body[:rolesStart], "<section")
+	if sectionStart == -1 {
+		t.Fatal("expected opening section tag before roles panel id")
 	}
-	rolesSection := body[rolesStart : rolesStart+rolesEnd]
+	rolesSection := body[sectionStart:]
 
 	for _, want := range []string{
 		`class="org-admin-panel-section"`,

--- a/server/cmd/server/platform_admin_htmx_test.go
+++ b/server/cmd/server/platform_admin_htmx_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHandleAdminCategoriesHTMXReturnsAdminConsole(t *testing.T) {
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "change-me")
+
+	now := time.Now().UTC()
+	store := NewMemoryStore()
+	seedPlatformAdminTaxonomy(t, store)
+
+	server := &Server{
+		authorizer:  fakeAuthorizer{},
+		store:       store,
+		identity:    &fakeIdentityStore{},
+		tmpl:        parseTestTemplates(t),
+		enforceAuth: true,
+		now:         func() time.Time { return now },
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/categories", nil)
+	req.Header.Set("HX-Request", "true")
+	req.Header.Set("HX-Target", "admin-console")
+	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
+	rec := httptest.NewRecorder()
+
+	server.handleAdminCategories(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `id="admin-console"`) {
+		t.Fatalf("expected admin-console fragment, got: %s", body)
+	}
+	if strings.Contains(body, `class="topbar"`) || strings.Contains(body, "<html") {
+		t.Fatalf("HTMX soft-nav must not include layout, got: %s", body)
+	}
+	for _, want := range []string{
+		`hx-get="/admin/orgs"`,
+		`hx-target="#admin-console"`,
+		"Browse stream discovery categories",
+		"Supply Chain",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in categories console, got: %s", want, body)
+		}
+	}
+}
+
+func TestHandleAdminOrgsHTMXSearchStillReturnsResults(t *testing.T) {
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "change-me")
+
+	now := time.Now().UTC()
+	server := &Server{
+		authorizer:  fakeAuthorizer{},
+		store:       NewMemoryStore(),
+		identity:    &fakeIdentityStore{},
+		tmpl:        testTemplates(),
+		enforceAuth: true,
+		now:         func() time.Time { return now },
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/orgs?q=acme", nil)
+	req.Header.Set("HX-Request", "true")
+	req.Header.Set("HX-Target", "platform-admin-results")
+	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
+	rec := httptest.NewRecorder()
+
+	server.handleAdminOrgs(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "PLATFORM_ADMIN_RESULTS") {
+		t.Fatalf("expected results partial, got: %s", body)
+	}
+	if strings.Contains(body, "ADMIN_CONSOLE") || strings.Contains(body, `id="admin-console"`) {
+		t.Fatalf("search HTMX must not return admin_console, got: %s", body)
+	}
+}

--- a/server/cmd/server/templates.go
+++ b/server/cmd/server/templates.go
@@ -23,8 +23,10 @@ func templateFuncs() template.FuncMap {
 		"streamTimelineSubstep": func(substep TimelineSubstep, hideStatus bool) StreamTimelineSubstepView {
 			return StreamTimelineSubstepView{Substep: substep, HideStatus: hideStatus}
 		},
-		"substepShellDisplay": substepShellDisplay,
+		"substepShellDisplay":      substepShellDisplay,
 		"effectiveSubstepBodyMode": effectiveSubstepBodyMode,
+		"platformAdminConsole":     platformAdminConsole,
+		"orgAdminConsole":          orgAdminConsole,
 		"dict": func(values ...any) (map[string]any, error) {
 			if len(values)%2 != 0 {
 				return nil, fmt.Errorf("dict: odd number of arguments")

--- a/server/cmd/server/test_helpers_test.go
+++ b/server/cmd/server/test_helpers_test.go
@@ -94,6 +94,7 @@ func testTemplates() *template.Template {
 	{{define "signup_body"}}SIGNUP {{.Email}} {{.Error}}{{end}}
 	{{define "signup.html"}}{{template "layout.html" .}}{{end}}
 	{{define "platform_admin_body"}}PLATFORM_ADMIN {{.ActivePanel}} {{len .Organizations}} {{.Confirmation}}{{range .Categories}} CAT {{.Name}} {{.IconURL}}{{range .SubCategories}} SUB {{.Name}} {{.IconURL}}{{end}}{{end}}{{if .Error}} {{.Error}}{{end}}{{end}}
+	{{define "admin_console"}}ADMIN_CONSOLE {{.Title}} {{.Subtitle}}{{end}}
 	{{define "platform_admin_results"}}PLATFORM_ADMIN_RESULTS ORGS {{len .Organizations}} {{.Confirmation}}{{if .Error}} {{.Error}}{{end}}{{end}}
 	{{define "platform_admin.html"}}{{template "layout.html" .}}{{end}}
 	{{define "home_body"}}HOME{{end}}

--- a/server/cmd/server/test_helpers_test.go
+++ b/server/cmd/server/test_helpers_test.go
@@ -104,6 +104,7 @@ func testTemplates() *template.Template {
 {{define "dashboard.html"}}{{template "layout.html" .}}{{end}}
 {{define "dashboard_partial.html"}}{{template "dashboard_body" .}}{{end}}
 {{define "org_admin_body"}}ORG_ADMIN {{.Organization.Slug}} ROLES {{len .Roles}} INVITES {{len .Invites}} USERS {{len .Users}} {{range .Users}}{{range .RoleOptions}}{{if .Selected}}ROLE_STYLE {{.Palette}} {{end}}{{end}}{{end}} {{.InviteLink}}{{if .Error}} {{.Error}}{{end}}{{end}}
+{{define "org_admin_main"}}ORG_ADMIN_MAIN {{.ActivePanel}}{{end}}
 {{define "org_admin.html"}}{{template "layout.html" .}}{{end}}
 {{define "process_body"}}PROCESS {{.ProcessID}} {{template "process_content.html" .}}{{end}}
 {{define "process_content.html"}}PROCESS_CONTENT {{.ProcessID}} {{.DPPURL}} {{.Detail.Error}}{{with .Detail.SelectedBody}}{{.SubstepID}}{{end}}{{end}}

--- a/server/templates/components/admin_console.html
+++ b/server/templates/components/admin_console.html
@@ -1,0 +1,49 @@
+{{/* Shared admin soft-nav shell: page-header + sidebar + main (HTMX swap root). */}}
+
+{{ define "admin_console" }}
+  <div
+    id="{{ if .ID }}{{ .ID }}{{ else }}admin-console{{ end }}"
+    class="admin-console"
+  >
+    <section class="page-header">
+      {{ template "breadcrumbs" .Breadcrumbs }}
+      <div class="page-header-body">
+        <h1>{{ .Title }}</h1>
+        {{ if .Subtitle }}
+          <p>{{ .Subtitle }}</p>
+        {{ end }}
+      </div>
+    </section>
+
+    <div class="rail-layout rail-layout-ready">
+      <section class="panel panel-sticky">
+        <nav
+          class="sidebar-nav"
+          aria-label="{{ .NavLabel }}"
+        >
+          {{ range .NavItems }}
+            <a
+              href="{{ .Href }}"
+              class="sidebar-nav-link{{ if .Active }} is-active{{ end }}"
+              hx-get="{{ .Href }}"
+              hx-target="#{{ if $.ID }}{{ $.ID }}{{ else }}admin-console{{ end }}"
+              hx-select="#{{ if $.ID }}{{ $.ID }}{{ else }}admin-console{{ end }}"
+              hx-swap="outerHTML"
+              hx-push-url="true"
+              {{ if .Active }}aria-current="page"{{ end }}
+            >
+              <span class="sidebar-nav-title">{{ .Title }}</span>
+              {{ if .Copy }}
+                <span class="sidebar-nav-copy">{{ .Copy }}</span>
+              {{ end }}
+            </a>
+          {{ end }}
+        </nav>
+      </section>
+
+      <section class="panel rail-layout-main">
+        {{ render .MainTemplate .MainData }}
+      </section>
+    </div>
+  </div>
+{{ end }}

--- a/server/templates/pages/org_admin.html
+++ b/server/templates/pages/org_admin.html
@@ -3,24 +3,16 @@
 {{ define "org_admin_body" }}
 
   <div class="stack u-max-w-7xl u-mx-auto">
-    <section class="page-header">
-      {{ template "breadcrumbs" .Breadcrumbs }}
-      <div class="page-header-body">
-        <h1>Organization admin dashboard</h1>
-        <p>Manage organization settings, roles, and members</p>
-      </div>
-    </section>
-    <div
-      class="rail-layout{{ if not .NeedsOrganizationSetup }}
-        rail-layout-ready
-      {{ end }}"
-    >
-      <section
-        class="panel{{ if not .NeedsOrganizationSetup }}
-          panel-sticky
-        {{ end }}"
-      >
-        {{ if .NeedsOrganizationSetup }}
+    {{ if .NeedsOrganizationSetup }}
+      <section class="page-header">
+        {{ template "breadcrumbs" .Breadcrumbs }}
+        <div class="page-header-body">
+          <h1>Organization admin dashboard</h1>
+          <p>Manage organization settings, roles, and members</p>
+        </div>
+      </section>
+      <div class="rail-layout">
+        <section class="panel">
           <div class="panel-heading">
             <p>
               Your org admin invite is not assigned to an organization yet.
@@ -52,924 +44,15 @@
             {{ end }}
             <button class="btn btn-primary" type="submit">Create organization</button>
           </form>
-        {{ else }}
-          <nav
-            class="sidebar-nav"
-            aria-label="Organization admin sections"
-          >
-            <a
-              href="/my/organization/profile"
-              class="sidebar-nav-link{{ if eq .ActivePanel "profile" }} is-active{{ end }}"
-              data-org-admin-nav="profile"
-              aria-controls="org-admin-panel-profile"
-              {{ if eq .ActivePanel "profile" }}aria-current="page"{{ end }}
-            >
-              <span class="sidebar-nav-title"
-                >Organization profile</span
-              >
-              <span class="sidebar-nav-copy"
-                >Update your organization name and logo</span
-              >
-            </a>
-            <a
-              href="/my/organization/roles"
-              class="sidebar-nav-link{{ if eq .ActivePanel "roles" }} is-active{{ end }}"
-              data-org-admin-nav="roles"
-              aria-controls="org-admin-panel-roles"
-              {{ if eq .ActivePanel "roles" }}aria-current="page"{{ end }}
-            >
-              <span class="sidebar-nav-title">Roles</span>
-              <span class="sidebar-nav-copy"
-                >Manage the role catalog for your organization</span
-              >
-            </a>
-            <a
-              href="/my/organization/members"
-              class="sidebar-nav-link{{ if eq .ActivePanel "members" }} is-active{{ end }}"
-              data-org-admin-nav="members"
-              aria-controls="org-admin-panel-members"
-              {{ if eq .ActivePanel "members" }}aria-current="page"{{ end }}
-            >
-              <span class="sidebar-nav-title">Members</span>
-              <span class="sidebar-nav-copy"
-                >Invite people and update member access</span
-              >
-            </a>
-          </nav>
-        {{ end }}
-      </section>
-
-      {{ if not .NeedsOrganizationSetup }}
-        <section
-          class="panel rail-layout-main org-admin-panel-main"
-          data-org-admin-shell
-          data-org-admin-default-panel="{{ .ActivePanel }}"
-        >
-          <section
-            class="org-admin-panel-section"
-            id="org-admin-panel-profile"
-            data-org-admin-panel="profile"
-            {{ if ne .ActivePanel "profile" }}hidden{{ end }}
-          >
-            <div class="panel-heading">
-              <h2>Organization profile</h2>
-              <p>Review and update your organization details</p>
-            </div>
-            <div class="org-profile-summary">
-              {{ if .OrganizationLogoURL }}
-                <img
-                  src="{{ .OrganizationLogoURL }}"
-                  alt="{{ .Organization.Name }} logo"
-                  class="org-profile-logo"
-                />
-              {{ else }}
-                <span class="org-profile-logo-placeholder">
-                  {{ template "icon-no-org" . }}
-                </span>
-              {{ end }}
-              <div class="org-profile-meta">
-                <p class="org-profile-name">
-                  <strong>{{ .Organization.Name }}</strong>
-                </p>
-                <p class="muted org-profile-slug">
-                  Slug:
-                  {{ .Organization.Slug }}
-                </p>
-              </div>
-            </div>
-            <form
-              method="post"
-              action="/my/organization/users"
-              class="input-form org-profile-form"
-              enctype="multipart/form-data"
-            >
-              <input type="hidden" name="intent" value="update_org" />
-              <div class="form-field">
-                <label for="org-name-profile">Organization name</label>
-                <input
-                  id="org-name-profile"
-                  name="name"
-                  type="text"
-                  value="{{ .Organization.Name }}"
-                  required
-                />
-              </div>
-              <div class="form-field">
-                <label for="org-logo-profile"
-                  >Organization logo (optional)</label
-                >
-                <input
-                  id="org-logo-profile"
-                  name="logo"
-                  type="file"
-                  accept=".png,.jpg,.jpeg,.webp,.svg,image/png,image/jpeg,image/webp,image/svg+xml"
-                />
-              </div>
-              {{ if .OrganizationError }}
-                <p class="error">{{ .OrganizationError }}</p>
-              {{ end }}
-              <div class="org-admin-form-actions">
-                <button class="btn btn-primary" type="submit">Save organization</button>
-              </div>
-            </form>
-          </section>
-          <section
-            class="org-admin-panel-section"
-            id="org-admin-panel-roles"
-            data-org-admin-panel="roles"
-            {{ if ne .ActivePanel "roles" }}hidden{{ end }}
-          >
-            <div class="panel-head-actions">
-              <div class="panel-heading">
-                <h2>Roles</h2>
-                <p>Available roles for your organization</p>
-              </div>
-              <button
-                class="btn btn-primary"
-                type="button"
-                onclick="document.getElementById('add-role-dialog').showModal()"
-              >
-                {{ template "icon-plus" . }}
-                Add role
-              </button>
-            </div>
-            {{ if .RoleRows }}
-              <ul class="list-rows">
-                {{ range .RoleRows }}
-                  <li class="list-row">
-                    <div class="list-row-main">
-                      <span
-                        class="pill pill-lg role-pill"
-                        data-role-palette="{{ .Palette }}"
-                      >
-                        {{ .Name }}
-                      </span>
-                    </div>
-                    <div class="list-row-actions">
-                      {{ if .InUse }}
-                        <button
-                          type="button"
-                          class="btn btn-ghost btn-icon btn-xs"
-                          aria-label="Edit role"
-                          title="Role in use"
-                          disabled
-                        >
-                          {{ template "icon-settings-muted" . }}
-                        </button>
-                        <button
-                          type="button"
-                          class="btn btn-ghost-danger btn-icon btn-xs"
-                          aria-label="Delete role"
-                          title="Role in use"
-                          disabled
-                        >
-                          {{ template "icon-trash-muted" . }}
-                        </button>
-                      {{ else }}
-                        <span class="muted u-text-xs"
-                          >Not used</span
-                        >
-                        <button
-                          type="button"
-                          class="btn btn-ghost btn-icon btn-xs"
-                          aria-label="Edit role"
-                          onclick="document.getElementById('edit-role-{{ .Slug }}').showModal()"
-                        >
-                          {{ template "icon-settings" . }}
-                        </button>
-                        <button
-                          type="button"
-                          class="btn btn-ghost-danger btn-icon btn-xs"
-                          aria-label="Delete role"
-                          onclick="document.getElementById('delete-role-{{ .Slug }}').showModal()"
-                        >
-                          {{ template "icon-trash" . }}
-                        </button>
-                      {{ end }}
-                    </div>
-                    {{ if and $.RoleError (or (eq $.RoleDialogAction "edit") (eq $.RoleDialogAction "delete")) (eq $.RoleDialogSlug .Slug) .InUse }}
-                      <p class="error">{{ $.RoleError }}</p>
-                    {{ end }}
-                    {{ if not .InUse }}
-                      <dialog
-                        id="edit-role-{{ .Slug }}"
-                        class="dialog dialog-overflow"
-                      >
-                        <div class="dialog-card">
-                          <header class="dialog-head">
-                            <div>
-                              <h3 class="dialog-title">Edit Role</h3>
-                              <p class="dialog-subtitle">
-                                Change the role name and color
-                              </p>
-                            </div>
-                            <button
-                              type="button"
-                              class="btn btn-ghost btn-icon dialog-close"
-                              onclick="document.getElementById('edit-role-{{ .Slug }}').close()"
-                            >
-                              {{ template "icon-close" . }}
-                            </button>
-                          </header>
-                          <div class="org-admin-dialog-role-pill">
-                            <span
-                              class="pill pill-lg role-pill"
-                              data-role-palette="{{ .Palette }}"
-                            >
-                              {{ .Name }}
-                            </span>
-                          </div>
-                          <form
-                            method="post"
-                            action="/my/organization/roles"
-                            class="input-form"
-                          >
-                            <input
-                              type="hidden"
-                              name="intent"
-                              value="set_role"
-                            />
-                            <input
-                              type="hidden"
-                              name="role_slug"
-                              value="{{ .Slug }}"
-                            />
-                            <div class="form-field">
-                              <label for="edit-role-name-{{ .Slug }}"
-                                >Role name</label
-                              >
-                              <input
-                                id="edit-role-name-{{ .Slug }}"
-                                name="name"
-                                type="text"
-                                {{ if and (eq $.RoleDialogAction "edit") (eq $.RoleDialogSlug .Slug) $.RoleDialogName }}
-                                  value="{{ $.RoleDialogName }}"
-                                {{ else }}
-                                  value="{{ .Name }}"
-                                {{ end }}
-                                required
-                              />
-                            </div>
-                            <div class="form-field">
-                              <label for="edit-role-palette-{{ .Slug }}"
-                                >Role color palette</label
-                              >
-                              <div
-                                class="role-palette-picker"
-                                data-role-palette-picker
-                              >
-                                <div class="role-palette-select-wrap">
-                                  <select
-                                    id="edit-role-palette-{{ .Slug }}"
-                                    name="palette"
-                                    required
-                                    class="role-palette-native-select"
-                                    data-role-palette-select
-                                  >
-                                    {{ template "role-palette-options" (or $.RoleDialogPalette .Palette) }}
-                                  </select>
-                                  <button
-                                    type="button"
-                                    class="roles-picker-toggle role-palette-toggle"
-                                    data-role-palette-toggle
-                                    aria-expanded="false"
-                                  >
-                                    <span data-role-palette-toggle-label></span>
-                                    <span
-                                      class="roles-picker-toggle-icon"
-                                      aria-hidden="true"
-                                    >
-                                      {{ template "icon-chevron-down" . }}
-                                    </span>
-                                  </button>
-                                  <div
-                                    class="roles-picker-menu role-palette-menu"
-                                    data-role-palette-menu
-                                    hidden
-                                  >
-                                    <ul
-                                      class="roles-picker-options"
-                                      data-role-palette-options
-                                    ></ul>
-                                  </div>
-                                </div>
-                                <span
-                                  class="role-palette-preview"
-                                  aria-hidden="true"
-                                  data-role-palette-preview
-                                ></span>
-                              </div>
-                            </div>
-                            {{ if and (eq $.RoleDialogAction "edit") (eq $.RoleDialogSlug .Slug) $.RoleError }}
-                              <p class="error">{{ $.RoleError }}</p>
-                            {{ end }}
-                            <div
-                              class="dialog-actions"
-                            >
-                              <button class="btn btn-primary" type="submit">
-                                Save role
-                              </button>
-                            </div>
-                          </form>
-                        </div>
-                      </dialog>
-                      <dialog
-                        id="delete-role-{{ .Slug }}"
-                        class="dialog"
-                      >
-                        <div class="dialog-card">
-                          <header class="dialog-head">
-                            <div>
-                              <h3
-                                class="dialog-title u-text-danger"
-                              >
-                                Danger zone - Delete role
-                              </h3>
-                              <p class="dialog-subtitle">
-                                This action cannot be undone
-                              </p>
-                            </div>
-                            <button
-                              type="button"
-                              class="btn btn-ghost btn-icon dialog-close"
-                              onclick="document.getElementById('delete-role-{{ .Slug }}').close()"
-                            >
-                              {{ template "icon-close" . }}
-                            </button>
-                          </header>
-                          <div class="org-admin-dialog-role-pill">
-                            <span
-                              class="pill pill-lg role-pill"
-                              data-role-palette="{{ .Palette }}"
-                            >
-                              {{ .Name }}
-                            </span>
-                          </div>
-                          <p>
-                            This will permanently remove the role from your
-                            organization. Confirm only if you want to continue.
-                          </p>
-                          {{ if and (eq $.RoleDialogAction "delete") (eq $.RoleDialogSlug .Slug) $.RoleError }}
-                            <p class="error">{{ $.RoleError }}</p>
-                          {{ end }}
-                          <form
-                            method="post"
-                            action="/my/organization/roles"
-                            class="input-form"
-                          >
-                            <input
-                              type="hidden"
-                              name="intent"
-                              value="delete_role"
-                            />
-                            <input
-                              type="hidden"
-                              name="role_slug"
-                              value="{{ .Slug }}"
-                            />
-                            <div
-                              class="dialog-actions"
-                            >
-                              <button type="submit" class="btn btn-danger">
-                                Delete role
-                              </button>
-                            </div>
-                          </form>
-                        </div>
-                      </dialog>
-                    {{ end }}
-                  </li>
-                {{ end }}
-              </ul>
-            {{ else }}
-              <p class="muted">No organization roles yet</p>
-            {{ end }}
-          </section>
-          <section
-            class="org-admin-panel-section"
-            id="org-admin-panel-members"
-            data-org-admin-panel="members"
-            {{ if ne .ActivePanel "members" }}hidden{{ end }}
-          >
-            <div class="panel-head-actions">
-              <div class="panel-heading">
-                <h2>Users</h2>
-                <p>Members and invites for your organization</p>
-              </div>
-              <button
-                class="btn btn-primary"
-                type="button"
-                onclick="document.getElementById('add-user-dialog').showModal()"
-              >
-                {{ template "icon-plus" . }}
-                Add user
-              </button>
-            </div>
-            {{ if .UsersError }}<p class="error">{{ .UsersError }}</p>{{ end }}
-            {{ if .Users }}
-              <ul class="list-rows">
-                {{ range .Users }}
-                  <li class="list-row">
-                    <div class="list-row-main">
-                      <span class="user-email">
-                        {{ if .IsOrgAdmin }}
-                          {{ template "icon-user-org-admin" . }}
-                        {{ else }}
-                          {{ template "icon-user-member" . }}
-                        {{ end }}
-                        {{ .Email }}
-                        {{ if not .Activated }}
-                          <span
-                            class="pill role-pill pill-accent"
-                            >Pending invite</span
-                          >
-                        {{ end }}
-                      </span>
-                      <div class="user-tags">
-                        {{ range .RoleOptions }}
-                          {{ if and .Selected (not (or (eq .Slug "org-admin") (eq .Slug "org_admin"))) }}
-                            <span
-                              class="pill role-pill"
-                              data-role-palette="{{ .Palette }}"
-                            >
-                              {{ .Name }}
-                            </span>
-                          {{ end }}
-                        {{ end }}
-                      </div>
-                    </div>
-                    <div class="list-row-actions">
-                      <button
-                        type="button"
-                        class="btn btn-ghost btn-icon btn-xs"
-                        aria-label="Edit user"
-                        onclick="document.getElementById('manage-user-{{ .UserID }}').showModal()"
-                      >
-                        {{ template "icon-settings" . }}
-                      </button>
-                      <button
-                        type="button"
-                        class="btn btn-ghost-danger btn-icon btn-xs"
-                        aria-label="Delete user"
-                        onclick="document.getElementById('delete-user-{{ .UserID }}').showModal()"
-                      >
-                        {{ template "icon-trash" . }}
-                      </button>
-                    </div>
-                    <dialog
-                      id="manage-user-{{ .UserID }}"
-                      class="dialog dialog-overflow"
-                    >
-                      <div class="dialog-card">
-                        <header class="dialog-head">
-                          <div>
-                            <h3 class="dialog-title">Manage User</h3>
-                            <p class="dialog-subtitle">{{ .Email }}</p>
-                          </div>
-                          <button
-                            type="button"
-                            class="btn btn-ghost btn-icon dialog-close"
-                            onclick="document.getElementById('manage-user-{{ .UserID }}').close()"
-                          >
-                            {{ template "icon-close" . }}
-                          </button>
-                        </header>
-
-                        <form
-                          method="post"
-                          action="/my/organization/users"
-                          class="input-form"
-                        >
-                          <input
-                            type="hidden"
-                            name="intent"
-                            value="set_roles"
-                          />
-                          <input
-                            type="hidden"
-                            name="userId"
-                            value="{{ .UserID }}"
-                          />
-                          <div class="form-field">
-                            <label>Roles</label>
-                            <div class="roles-picker" data-role-picker>
-                              <button
-                                type="button"
-                                class="roles-picker-toggle"
-                                data-role-picker-toggle
-                                aria-expanded="false"
-                              >
-                                <span data-role-picker-toggle-label
-                                  >Select roles</span
-                                >
-                                <span
-                                  class="roles-picker-toggle-icon"
-                                  aria-hidden="true"
-                                >
-                                  {{ template "icon-chevron-down" . }}
-                                </span>
-                              </button>
-                              <div
-                                class="roles-picker-menu"
-                                data-role-picker-menu
-                                hidden
-                              >
-                                <input
-                                  type="search"
-                                  class="roles-picker-search"
-                                  data-role-picker-search
-                                  placeholder="Search roles..."
-                                />
-                                <ul class="roles-picker-options">
-                                  {{ range .RoleOptions }}
-                                    <li>
-                                      <button
-                                        type="button"
-                                        class="roles-picker-option"
-                                        data-role-picker-option
-                                        data-value="{{ .Slug }}"
-                                        data-label="{{ .Name }} ({{ .Slug }})"
-                                        {{ if .Selected }}
-                                          data-selected="true"
-                                        {{ end }}
-                                      >
-                                        <span>{{ .Name }} ({{ .Slug }})</span>
-                                        <span class="roles-picker-option-check"
-                                          >Selected</span
-                                        >
-                                      </button>
-                                    </li>
-                                  {{ end }}
-                                </ul>
-                                <p
-                                  class="roles-picker-empty"
-                                  data-role-picker-empty
-                                  hidden
-                                >
-                                  No roles match your search
-                                </p>
-                              </div>
-                              <div data-role-picker-hidden-inputs></div>
-                            </div>
-                          </div>
-                          <div
-                            class="dialog-actions"
-                          >
-                            <button class="btn btn-primary" type="submit">
-                              Save roles
-                            </button>
-                          </div>
-                        </form>
-                      </div>
-                    </dialog>
-                    <dialog
-                      id="delete-user-{{ .UserID }}"
-                      class="dialog"
-                    >
-                      <div class="dialog-card">
-                        <header class="dialog-head">
-                          <div>
-                            <h3
-                              class="dialog-title u-text-danger"
-                            >
-                              Danger zone - Delete Account
-                            </h3>
-                            <p class="dialog-subtitle">{{ .Email }}</p>
-                          </div>
-                          <button
-                            type="button"
-                            class="btn btn-ghost btn-icon dialog-close"
-                            onclick="document.getElementById('delete-user-{{ .UserID }}').close()"
-                          >
-                            {{ template "icon-close" . }}
-                          </button>
-                        </header>
-                        <p class="u-m-0 u-mb-5">
-                          This will remove the account from your organization.
-                          Confirm only if you want to permanently delete this
-                          user access.
-                        </p>
-                        <form
-                          method="post"
-                          action="/my/organization/users"
-                          class="input-form"
-                        >
-                          <input
-                            type="hidden"
-                            name="intent"
-                            value="delete_user"
-                          />
-                          <input
-                            type="hidden"
-                            name="userId"
-                            value="{{ .UserID }}"
-                          />
-                          <div
-                            class="dialog-actions"
-                          >
-                            <button type="submit" class="btn btn-danger">
-                              Delete account
-                            </button>
-                          </div>
-                        </form>
-                      </div>
-                    </dialog>
-                  </li>
-                {{ end }}
-              </ul>
-            {{ else }}
-              <p class="muted">No organization users yet</p>
-            {{ end }}
-          </section>
-
-          <dialog
-            id="add-role-dialog"
-            class="dialog dialog-overflow"
-          >
-            <div class="dialog-card">
-              <header class="dialog-head">
-                <div>
-                  <h3 class="dialog-title">Add Role</h3>
-                  <p class="dialog-subtitle">
-                    Create a new role for your organization
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  class="btn btn-ghost btn-icon dialog-close"
-                  onclick="document.getElementById('add-role-dialog').close()"
-                >
-                  {{ template "icon-close" . }}
-                </button>
-              </header>
-
-              <form method="post" action="/my/organization/roles" class="input-form">
-                <input type="hidden" name="intent" value="create_role" />
-                <div class="form-field">
-                  <label for="role-name">Role name</label>
-                  <input
-                    id="role-name"
-                    name="name"
-                    type="text"
-                    value="{{ if and (eq .RoleDialogAction "create") .RoleDialogName }}
-                      {{ .RoleDialogName }}
-                    {{ end }}"
-                    required
-                  />
-                </div>
-                <div class="form-field">
-                  <label for="role-palette">Role color palette</label>
-                  <div class="role-palette-picker" data-role-palette-picker data-role-palette-auto>
-                    <div class="role-palette-select-wrap">
-                      <select
-                        id="role-palette"
-                        name="palette"
-                        required
-                        class="role-palette-native-select"
-                        data-role-palette-select
-                      >
-                        {{ template "role-palette-options" (or .RoleDialogPalette "red") }}
-                      </select>
-                      <button
-                        type="button"
-                        class="roles-picker-toggle role-palette-toggle"
-                        data-role-palette-toggle
-                        aria-expanded="false"
-                      >
-                        <span data-role-palette-toggle-label></span>
-                        <span
-                          class="roles-picker-toggle-icon"
-                          aria-hidden="true"
-                        >
-                          {{ template "icon-chevron-down" . }}
-                        </span>
-                      </button>
-                      <div
-                        class="roles-picker-menu role-palette-menu"
-                        data-role-palette-menu
-                        hidden
-                      >
-                        <ul
-                          class="roles-picker-options"
-                          data-role-palette-options
-                        ></ul>
-                      </div>
-                    </div>
-                    <span
-                      class="role-palette-preview"
-                      aria-hidden="true"
-                      data-role-palette-preview
-                    ></span>
-                  </div>
-                </div>
-                {{ if and .RoleError (eq .RoleDialogAction "create") }}
-                  <p class="error">{{ .RoleError }}</p>
-                {{ end }}
-                <div class="dialog-actions">
-                  <button class="btn btn-primary" type="submit">Create role</button>
-                </div>
-              </form>
-            </div>
-          </dialog>
-
-          <dialog
-            id="add-user-dialog"
-            class="dialog dialog-overflow"
-          >
-            <div class="dialog-card">
-              <header class="dialog-head">
-                <div>
-                  <h3 class="dialog-title">Add User</h3>
-                  <p class="dialog-subtitle">
-                    Invite a new user to your organization
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  class="btn btn-ghost btn-icon dialog-close"
-                  onclick="document.getElementById('add-user-dialog').close()"
-                >
-                  {{ template "icon-close" . }}
-                </button>
-              </header>
-
-              <form method="post" action="/my/organization/users" class="input-form">
-                <input type="hidden" name="intent" value="invite" />
-                <div class="form-field">
-                  <label for="user-email">Email</label>
-                  <input id="user-email" name="email" type="email" required />
-                </div>
-                <div class="form-field">
-                  <label>Roles</label>
-                  <div class="roles-picker" data-role-picker>
-                    <button
-                      type="button"
-                      class="roles-picker-toggle"
-                      data-role-picker-toggle
-                      aria-expanded="false"
-                    >
-                      <span data-role-picker-toggle-label>Select roles</span>
-                      <span
-                        class="roles-picker-toggle-icon"
-                        aria-hidden="true"
-                      >
-                        {{ template "icon-chevron-down" . }}
-                      </span>
-                    </button>
-                    <div class="roles-picker-menu" data-role-picker-menu hidden>
-                      <input
-                        type="search"
-                        class="roles-picker-search"
-                        data-role-picker-search
-                        placeholder="Search roles..."
-                      />
-                      <ul class="roles-picker-options">
-                        {{ range .Roles }}
-                          <li>
-                            <button
-                              type="button"
-                              class="roles-picker-option"
-                              data-role-picker-option
-                              data-value="{{ .Slug }}"
-                              data-label="{{ .Name }} ({{ .Slug }})"
-                            >
-                              <span>{{ .Name }} ({{ .Slug }})</span>
-                              <span class="roles-picker-option-check"
-                                >Selected</span
-                              >
-                            </button>
-                          </li>
-                        {{ end }}
-                      </ul>
-                      <p
-                        class="roles-picker-empty"
-                        data-role-picker-empty
-                        hidden
-                      >
-                        No roles match your search
-                      </p>
-                    </div>
-                    <div data-role-picker-hidden-inputs></div>
-                  </div>
-                </div>
-                {{ if .InviteError }}
-                  <p class="error">{{ .InviteError }}</p>
-                {{ end }}
-                <div class="dialog-actions">
-                  <button class="btn btn-primary" type="submit">Create invite</button>
-                </div>
-              </form>
-            </div>
-          </dialog>
         </section>
-      {{ end }}
-    </div>
+      </div>
+    {{ else }}
+      {{ template "admin_console" (orgAdminConsole .) }}
+    {{ end }}
   </div>
 
 <script>
   (function () {
-    const orgAdminShell = document.querySelector("[data-org-admin-shell]");
-    const orgAdminMobilePanelMedia = window.matchMedia("(max-width: 767px)");
-    const orgAdminPanels = new Set(["profile", "roles", "members"]);
-    const orgAdminPanelPaths = {
-      profile: "/my/organization/profile",
-      roles: "/my/organization/roles",
-      members: "/my/organization/members",
-    };
-    const orgAdminPanelFromPath = (path) => {
-      switch (path) {
-        case "/my/organization/profile":
-          return "profile";
-        case "/my/organization/roles":
-          return "roles";
-        case "/my/organization/members":
-          return "members";
-        default:
-          return null;
-      }
-    };
-    let activeOrgAdminPanel = "profile";
-    const setOrgAdminPanel = (panelName) => {
-      if (!orgAdminShell || !orgAdminPanels.has(panelName)) {
-        return;
-      }
-      activeOrgAdminPanel = panelName;
-      const panels = Array.from(orgAdminShell.querySelectorAll("[data-org-admin-panel]"));
-      panels.forEach((panel) => {
-        const currentName = panel.getAttribute("data-org-admin-panel");
-        panel.hidden = currentName !== panelName;
-      });
-      const navLinks = Array.from(document.querySelectorAll("[data-org-admin-nav]"));
-      navLinks.forEach((link) => {
-        const currentName = link.getAttribute("data-org-admin-nav");
-        const isActive = currentName === panelName;
-        link.classList.toggle("is-active", isActive);
-        if (isActive) {
-          link.setAttribute("aria-current", "page");
-        } else {
-          link.removeAttribute("aria-current");
-        }
-      });
-      orgAdminShell.setAttribute("data-org-admin-ready", "true");
-    };
-    const focusOrgAdminPanel = () => {
-      if (!orgAdminShell || !orgAdminMobilePanelMedia.matches) {
-        return;
-      }
-      window.requestAnimationFrame(() => {
-        const top = window.scrollY + orgAdminShell.getBoundingClientRect().top - 12;
-        window.scrollTo({
-          top: Math.max(0, top),
-          behavior: "smooth",
-        });
-      });
-    };
-
-    if (orgAdminShell) {
-      const preferredPanel = (() => {
-        const pathPanel = orgAdminPanelFromPath(window.location.pathname);
-        if (pathPanel && orgAdminPanels.has(pathPanel)) {
-          return pathPanel;
-        }
-        const defaultPanel = (orgAdminShell.getAttribute("data-org-admin-default-panel") || "").trim();
-        if (orgAdminPanels.has(defaultPanel)) {
-          return defaultPanel;
-        }
-        return "profile";
-      })();
-      Array.from(document.querySelectorAll("[data-org-admin-nav]")).forEach((link) => {
-        link.addEventListener("click", (event) => {
-          event.preventDefault();
-          const panelName = (link.getAttribute("data-org-admin-nav") || "").trim();
-          if (!orgAdminPanels.has(panelName)) {
-            return;
-          }
-          setOrgAdminPanel(panelName);
-          const path = orgAdminPanelPaths[panelName];
-          if (window.location.pathname === path) {
-            window.history.replaceState({ orgAdminPanel: panelName }, "", path);
-          } else {
-            window.history.pushState({ orgAdminPanel: panelName }, "", path);
-          }
-          focusOrgAdminPanel();
-        });
-      });
-      window.addEventListener("popstate", (event) => {
-        const statePanel = event.state && event.state.orgAdminPanel;
-        const panelName =
-          (statePanel && orgAdminPanels.has(statePanel) && statePanel) ||
-          orgAdminPanelFromPath(window.location.pathname) ||
-          preferredPanel;
-        setOrgAdminPanel(panelName);
-        focusOrgAdminPanel();
-      });
-      setOrgAdminPanel(preferredPanel);
-      const preferredPath = orgAdminPanelPaths[preferredPanel];
-      if (preferredPath) {
-        window.history.replaceState({ orgAdminPanel: preferredPanel }, "", preferredPath);
-      }
-    }
-
     const rolePalettePickers = Array.from(document.querySelectorAll("[data-role-palette-picker]"));
     const closeAllPalettePickers = (except) => {
       rolePalettePickers.forEach((picker) => {
@@ -1362,6 +445,586 @@
     });
   })();
 </script>
+{{ end }}
+
+{{ define "org_admin_main" }}
+  {{ if eq .ActivePanel "roles" }}
+    {{ template "org_admin_roles_panel" . }}
+  {{ else if eq .ActivePanel "members" }}
+    {{ template "org_admin_members_panel" . }}
+  {{ else }}
+    {{ template "org_admin_profile_panel" . }}
+  {{ end }}
+{{ end }}
+
+{{ define "org_admin_profile_panel" }}
+  <section class="org-admin-panel-section" id="org-admin-panel-profile">
+    <div class="panel-heading">
+      <h2>Organization profile</h2>
+      <p>Review and update your organization details</p>
+    </div>
+    <div class="org-profile-summary">
+      {{ if .OrganizationLogoURL }}
+        <img
+          src="{{ .OrganizationLogoURL }}"
+          alt="{{ .Organization.Name }} logo"
+          class="org-profile-logo"
+        />
+      {{ else }}
+        <span class="org-profile-logo-placeholder">
+          {{ template "icon-no-org" . }}
+        </span>
+      {{ end }}
+      <div class="org-profile-meta">
+        <p class="org-profile-name">
+          <strong>{{ .Organization.Name }}</strong>
+        </p>
+        <p class="muted org-profile-slug">
+          Slug:
+          {{ .Organization.Slug }}
+        </p>
+      </div>
+    </div>
+    <form
+      method="post"
+      action="/my/organization/users"
+      class="input-form org-profile-form"
+      enctype="multipart/form-data"
+    >
+      <input type="hidden" name="intent" value="update_org" />
+      <div class="form-field">
+        <label for="org-name-profile">Organization name</label>
+        <input
+          id="org-name-profile"
+          name="name"
+          type="text"
+          value="{{ .Organization.Name }}"
+          required
+        />
+      </div>
+      <div class="form-field">
+        <label for="org-logo-profile"
+          >Organization logo (optional)</label
+        >
+        <input
+          id="org-logo-profile"
+          name="logo"
+          type="file"
+          accept=".png,.jpg,.jpeg,.webp,.svg,image/png,image/jpeg,image/webp,image/svg+xml"
+        />
+      </div>
+      {{ if .OrganizationError }}
+        <p class="error">{{ .OrganizationError }}</p>
+      {{ end }}
+      <div class="org-admin-form-actions">
+        <button class="btn btn-primary" type="submit">Save organization</button>
+      </div>
+    </form>
+  </section>
+{{ end }}
+
+{{ define "org_admin_roles_panel" }}
+  <section class="org-admin-panel-section" id="org-admin-panel-roles">
+    <div class="panel-head-actions">
+      <div class="panel-heading">
+        <h2>Roles</h2>
+        <p>Available roles for your organization</p>
+      </div>
+      <button
+        class="btn btn-primary"
+        type="button"
+        onclick="document.getElementById('add-role-dialog').showModal()"
+      >
+        {{ template "icon-plus" . }}
+        Add role
+      </button>
+    </div>
+    {{ if .RoleRows }}
+      <ul class="list-rows">
+        {{ range .RoleRows }}
+          <li class="list-row">
+            <div class="list-row-main">
+              <span
+                class="pill pill-lg role-pill"
+                data-role-palette="{{ .Palette }}"
+              >
+                {{ .Name }}
+              </span>
+            </div>
+            <div class="list-row-actions">
+              {{ if .InUse }}
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-icon btn-xs"
+                  aria-label="Edit role"
+                  title="Role in use"
+                  disabled
+                >
+                  {{ template "icon-settings-muted" . }}
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-ghost-danger btn-icon btn-xs"
+                  aria-label="Delete role"
+                  title="Role in use"
+                  disabled
+                >
+                  {{ template "icon-trash-muted" . }}
+                </button>
+              {{ else }}
+                <span class="muted u-text-xs"
+                  >Not used</span
+                >
+                <button
+                  type="button"
+                  class="btn btn-ghost btn-icon btn-xs"
+                  aria-label="Edit role"
+                  onclick="document.getElementById('edit-role-{{ .Slug }}').showModal()"
+                >
+                  {{ template "icon-settings" . }}
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-ghost-danger btn-icon btn-xs"
+                  aria-label="Delete role"
+                  onclick="document.getElementById('delete-role-{{ .Slug }}').showModal()"
+                >
+                  {{ template "icon-trash" . }}
+                </button>
+              {{ end }}
+            </div>
+            {{ if and $.RoleError (or (eq $.RoleDialogAction "edit") (eq $.RoleDialogAction "delete")) (eq $.RoleDialogSlug .Slug) .InUse }}
+              <p class="error">{{ $.RoleError }}</p>
+            {{ end }}
+            {{ if not .InUse }}
+              <dialog
+                id="edit-role-{{ .Slug }}"
+                class="dialog dialog-overflow"
+              >
+                <div class="dialog-card">
+                  <header class="dialog-head">
+                    <div>
+                      <h3 class="dialog-title">Edit Role</h3>
+                      <p class="dialog-subtitle">
+                        Change the role name and color
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-icon dialog-close"
+                      onclick="document.getElementById('edit-role-{{ .Slug }}').close()"
+                    >
+                      {{ template "icon-close" . }}
+                    </button>
+                  </header>
+                  <div class="org-admin-dialog-role-pill">
+                    <span
+                      class="pill pill-lg role-pill"
+                      data-role-palette="{{ .Palette }}"
+                    >
+                      {{ .Name }}
+                    </span>
+                  </div>
+                  <form
+                    method="post"
+                    action="/my/organization/roles"
+                    class="input-form"
+                  >
+                    <input
+                      type="hidden"
+                      name="intent"
+                      value="set_role"
+                    />
+                    <input
+                      type="hidden"
+                      name="role_slug"
+                      value="{{ .Slug }}"
+                    />
+                    <div class="form-field">
+                      <label for="edit-role-name-{{ .Slug }}"
+                        >Role name</label
+                      >
+                      <input
+                        id="edit-role-name-{{ .Slug }}"
+                        name="name"
+                        type="text"
+                        {{ if and (eq $.RoleDialogAction "edit") (eq $.RoleDialogSlug .Slug) $.RoleDialogName }}
+                          value="{{ $.RoleDialogName }}"
+                        {{ else }}
+                          value="{{ .Name }}"
+                        {{ end }}
+                        required
+                      />
+                    </div>
+                    <div class="form-field">
+                      <label for="edit-role-palette-{{ .Slug }}"
+                        >Role color palette</label
+                      >
+                      <div
+                        class="role-palette-picker"
+                        data-role-palette-picker
+                      >
+                        <div class="role-palette-select-wrap">
+                          <select
+                            id="edit-role-palette-{{ .Slug }}"
+                            name="palette"
+                            required
+                            class="role-palette-native-select"
+                            data-role-palette-select
+                          >
+                            {{ template "role-palette-options" (or $.RoleDialogPalette .Palette) }}
+                          </select>
+                          <button
+                            type="button"
+                            class="roles-picker-toggle role-palette-toggle"
+                            data-role-palette-toggle
+                            aria-expanded="false"
+                          >
+                            <span data-role-palette-toggle-label></span>
+                            <span
+                              class="roles-picker-toggle-icon"
+                              aria-hidden="true"
+                            >
+                              {{ template "icon-chevron-down" . }}
+                            </span>
+                          </button>
+                          <div
+                            class="roles-picker-menu role-palette-menu"
+                            data-role-palette-menu
+                            hidden
+                          >
+                            <ul
+                              class="roles-picker-options"
+                              data-role-palette-options
+                            ></ul>
+                          </div>
+                        </div>
+                        <span
+                          class="role-palette-preview"
+                          aria-hidden="true"
+                          data-role-palette-preview
+                        ></span>
+                      </div>
+                    </div>
+                    {{ if and (eq $.RoleDialogAction "edit") (eq $.RoleDialogSlug .Slug) $.RoleError }}
+                      <p class="error">{{ $.RoleError }}</p>
+                    {{ end }}
+                    <div
+                      class="dialog-actions"
+                    >
+                      <button class="btn btn-primary" type="submit">
+                        Save role
+                      </button>
+                    </div>
+                  </form>
+                </div>
+              </dialog>
+              <dialog
+                id="delete-role-{{ .Slug }}"
+                class="dialog"
+              >
+                <div class="dialog-card">
+                  <header class="dialog-head">
+                    <div>
+                      <h3
+                        class="dialog-title u-text-danger"
+                      >
+                        Danger zone - Delete role
+                      </h3>
+                      <p class="dialog-subtitle">
+                        This action cannot be undone
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-icon dialog-close"
+                      onclick="document.getElementById('delete-role-{{ .Slug }}').close()"
+                    >
+                      {{ template "icon-close" . }}
+                    </button>
+                  </header>
+                  <div class="org-admin-dialog-role-pill">
+                    <span
+                      class="pill pill-lg role-pill"
+                      data-role-palette="{{ .Palette }}"
+                    >
+                      {{ .Name }}
+                    </span>
+                  </div>
+                  <p>
+                    This will permanently remove the role from your
+                    organization. Confirm only if you want to continue.
+                  </p>
+                  {{ if and (eq $.RoleDialogAction "delete") (eq $.RoleDialogSlug .Slug) $.RoleError }}
+                    <p class="error">{{ $.RoleError }}</p>
+                  {{ end }}
+                  <form
+                    method="post"
+                    action="/my/organization/roles"
+                    class="input-form"
+                  >
+                    <input
+                      type="hidden"
+                      name="intent"
+                      value="delete_role"
+                    />
+                    <input
+                      type="hidden"
+                      name="role_slug"
+                      value="{{ .Slug }}"
+                    />
+                    <div
+                      class="dialog-actions"
+                    >
+                      <button type="submit" class="btn btn-danger">
+                        Delete role
+                      </button>
+                    </div>
+                  </form>
+                </div>
+              </dialog>
+            {{ end }}
+          </li>
+        {{ end }}
+      </ul>
+    {{ else }}
+      <p class="muted">No organization roles yet</p>
+    {{ end }}
+  </section>
+{{ end }}
+
+{{ define "org_admin_members_panel" }}
+  <section class="org-admin-panel-section" id="org-admin-panel-members">
+    <div class="panel-head-actions">
+      <div class="panel-heading">
+        <h2>Users</h2>
+        <p>Members and invites for your organization</p>
+      </div>
+      <button
+        class="btn btn-primary"
+        type="button"
+        onclick="document.getElementById('add-user-dialog').showModal()"
+      >
+        {{ template "icon-plus" . }}
+        Add user
+      </button>
+    </div>
+    {{ if .UsersError }}<p class="error">{{ .UsersError }}</p>{{ end }}
+    {{ if .Users }}
+      <ul class="list-rows">
+        {{ range .Users }}
+          <li class="list-row">
+            <div class="list-row-main">
+              <span class="user-email">
+                {{ if .IsOrgAdmin }}
+                  {{ template "icon-user-org-admin" . }}
+                {{ else }}
+                  {{ template "icon-user-member" . }}
+                {{ end }}
+                {{ .Email }}
+                {{ if not .Activated }}
+                  <span
+                    class="pill role-pill pill-accent"
+                    >Pending invite</span
+                  >
+                {{ end }}
+              </span>
+              <div class="user-tags">
+                {{ range .RoleOptions }}
+                  {{ if and .Selected (not (or (eq .Slug "org-admin") (eq .Slug "org_admin"))) }}
+                    <span
+                      class="pill role-pill"
+                      data-role-palette="{{ .Palette }}"
+                    >
+                      {{ .Name }}
+                    </span>
+                  {{ end }}
+                {{ end }}
+              </div>
+            </div>
+            <div class="list-row-actions">
+              <button
+                type="button"
+                class="btn btn-ghost btn-icon btn-xs"
+                aria-label="Edit user"
+                onclick="document.getElementById('manage-user-{{ .UserID }}').showModal()"
+              >
+                {{ template "icon-settings" . }}
+              </button>
+              <button
+                type="button"
+                class="btn btn-ghost-danger btn-icon btn-xs"
+                aria-label="Delete user"
+                onclick="document.getElementById('delete-user-{{ .UserID }}').showModal()"
+              >
+                {{ template "icon-trash" . }}
+              </button>
+            </div>
+            <dialog
+              id="manage-user-{{ .UserID }}"
+              class="dialog dialog-overflow"
+            >
+              <div class="dialog-card">
+                <header class="dialog-head">
+                  <div>
+                    <h3 class="dialog-title">Manage User</h3>
+                    <p class="dialog-subtitle">{{ .Email }}</p>
+                  </div>
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-icon dialog-close"
+                    onclick="document.getElementById('manage-user-{{ .UserID }}').close()"
+                  >
+                    {{ template "icon-close" . }}
+                  </button>
+                </header>
+
+                <form
+                  method="post"
+                  action="/my/organization/users"
+                  class="input-form"
+                >
+                  <input
+                    type="hidden"
+                    name="intent"
+                    value="set_roles"
+                  />
+                  <input
+                    type="hidden"
+                    name="userId"
+                    value="{{ .UserID }}"
+                  />
+                  <div class="form-field">
+                    <label>Roles</label>
+                    <div class="roles-picker" data-role-picker>
+                      <button
+                        type="button"
+                        class="roles-picker-toggle"
+                        data-role-picker-toggle
+                        aria-expanded="false"
+                      >
+                        <span data-role-picker-toggle-label
+                          >Select roles</span
+                        >
+                        <span
+                          class="roles-picker-toggle-icon"
+                          aria-hidden="true"
+                        >
+                          {{ template "icon-chevron-down" . }}
+                        </span>
+                      </button>
+                      <div
+                        class="roles-picker-menu"
+                        data-role-picker-menu
+                        hidden
+                      >
+                        <input
+                          type="search"
+                          class="roles-picker-search"
+                          data-role-picker-search
+                          placeholder="Search roles..."
+                        />
+                        <ul class="roles-picker-options">
+                          {{ range .RoleOptions }}
+                            <li>
+                              <button
+                                type="button"
+                                class="roles-picker-option"
+                                data-role-picker-option
+                                data-value="{{ .Slug }}"
+                                data-label="{{ .Name }} ({{ .Slug }})"
+                                {{ if .Selected }}
+                                  data-selected="true"
+                                {{ end }}
+                              >
+                                <span>{{ .Name }} ({{ .Slug }})</span>
+                                <span class="roles-picker-option-check"
+                                  >Selected</span
+                                >
+                              </button>
+                            </li>
+                          {{ end }}
+                        </ul>
+                        <p
+                          class="roles-picker-empty"
+                          data-role-picker-empty
+                          hidden
+                        >
+                          No roles match your search
+                        </p>
+                      </div>
+                      <div data-role-picker-hidden-inputs></div>
+                    </div>
+                  </div>
+                  <div
+                    class="dialog-actions"
+                  >
+                    <button class="btn btn-primary" type="submit">
+                      Save roles
+                    </button>
+                  </div>
+                </form>
+              </div>
+            </dialog>
+            <dialog
+              id="delete-user-{{ .UserID }}"
+              class="dialog"
+            >
+              <div class="dialog-card">
+                <header class="dialog-head">
+                  <div>
+                    <h3
+                      class="dialog-title u-text-danger"
+                    >
+                      Danger zone - Delete Account
+                    </h3>
+                    <p class="dialog-subtitle">{{ .Email }}</p>
+                  </div>
+                  <button
+                    type="button"
+                    class="btn btn-ghost btn-icon dialog-close"
+                    onclick="document.getElementById('delete-user-{{ .UserID }}').close()"
+                  >
+                    {{ template "icon-close" . }}
+                  </button>
+                </header>
+                <p class="u-m-0 u-mb-5">
+                  This will remove the account from your organization.
+                  Confirm only if you want to permanently delete this
+                  user access.
+                </p>
+                <form
+                  method="post"
+                  action="/my/organization/users"
+                  class="input-form"
+                >
+                  <input
+                    type="hidden"
+                    name="intent"
+                    value="delete_user"
+                  />
+                  <input
+                    type="hidden"
+                    name="userId"
+                    value="{{ .UserID }}"
+                  />
+                  <div
+                    class="dialog-actions"
+                  >
+                    <button type="submit" class="btn btn-danger">
+                      Delete account
+                    </button>
+                  </div>
+                </form>
+              </div>
+            </dialog>
+          </li>
+        {{ end }}
+      </ul>
+    {{ else }}
+      <p class="muted">No organization users yet</p>
+    {{ end }}
+  </section>
 {{ end }}
 
 {{ define "org_admin.html" }}

--- a/server/templates/pages/platform_admin.html
+++ b/server/templates/pages/platform_admin.html
@@ -1,183 +1,142 @@
 {{/* Used on /admin/orgs to render platform administration page */}}
 
 {{ define "platform_admin_body" }}
-
   <div class="stack u-max-w-7xl u-mx-auto">
-    <section class="page-header">
-      {{ template "breadcrumbs" .Breadcrumbs }}
-      <div class="page-header-body">
-        <h1>Platform admin dashboard</h1>
-        {{ if eq .ActivePanel "categories" }}
-          <p>Browse stream discovery categories</p>
-        {{ else }}
-          <p>Create and manage organizations</p>
-        {{ end }}
-      </div>
-    </section>
-
-    <div class="rail-layout rail-layout-ready">
-      <section class="panel panel-sticky">
-        <nav
-          class="sidebar-nav"
-          aria-label="Platform admin sections"
-        >
-          <a
-            href="/admin/orgs"
-            class="sidebar-nav-link{{ if ne .ActivePanel "categories" }} is-active{{ end }}"
-            {{ if ne .ActivePanel "categories" }}aria-current="page"{{ end }}
-          >
-            <span class="sidebar-nav-title">Organizations</span>
-            <span class="sidebar-nav-copy"
-              >Create and manage organizations</span
-            >
-          </a>
-          <a
-            href="/admin/categories"
-            class="sidebar-nav-link{{ if eq .ActivePanel "categories" }} is-active{{ end }}"
-            {{ if eq .ActivePanel "categories" }}aria-current="page"{{ end }}
-          >
-            <span class="sidebar-nav-title">Categories</span>
-            <span class="sidebar-nav-copy"
-              >Browse stream discovery categories</span
-            >
-          </a>
-        </nav>
-      </section>
-
-      <section class="panel rail-layout-main">
-        {{ if eq .ActivePanel "categories" }}
-          {{ template "platform_admin_categories_panel" . }}
-        {{ else }}
-          <div class="panel-head-actions">
-            <div class="panel-heading">
-              <h2>Organizations</h2>
-            </div>
-            <button
-              class="btn btn-primary"
-              type="button"
-              onclick="document.getElementById('create-org-dialog').showModal()"
-            >
-              {{ template "icon-plus" . }}
-              Add organization
-            </button>
-          </div>
-
-          <form
-            method="get"
-            action="/admin/orgs"
-            class="platform-admin-search"
-            id="platform-admin-search"
-          >
-            <input type="hidden" name="page" value="1" />
-            <label
-              class="platform-admin-search-field"
-              for="platform-admin-search-input"
-            >
-              {{ template "icon-search" . }}
-              <input
-                id="platform-admin-search-input"
-                type="search"
-                name="q"
-                value="{{ .SearchQuery }}"
-                placeholder="Search organizations by name"
-                autocomplete="off"
-                hx-get="/admin/orgs"
-                hx-target="#platform-admin-results"
-                hx-select="#platform-admin-results"
-                hx-swap="outerHTML"
-                hx-push-url="true"
-                hx-include="#platform-admin-search"
-                hx-trigger="input changed delay:200ms, search"
-              />
-            </label>
-          </form>
-
-          {{ template "platform_admin_results" . }}
-        {{ end }}
-      </section>
-    </div>
+    {{ template "admin_console" (platformAdminConsole .) }}
   </div>
+{{ end }}
 
-  <dialog id="create-org-dialog" class="dialog">
-    <div class="dialog-card">
-      <header class="dialog-head">
-        <div>
-          <h3 class="dialog-title">New organization</h3>
-          <p class="dialog-subtitle">
-            Add a new organization to the platform
-          </p>
-        </div>
-        <button
-          type="button"
-          class="btn btn-ghost btn-icon dialog-close"
-          onclick="document.getElementById('create-org-dialog').close()"
-        >
-          {{ template "icon-close" . }}
-        </button>
-      </header>
-      <form
-        method="post"
-        action="/admin/orgs"
-        class="input-form"
-        enctype="multipart/form-data"
+{{ define "platform_admin_main" }}
+  {{ if eq .ActivePanel "categories" }}
+    {{ template "platform_admin_categories_panel" . }}
+  {{ else }}
+    <div class="panel-head-actions">
+      <div class="panel-heading">
+        <h2>Organizations</h2>
+      </div>
+      <button
+        class="btn btn-primary"
+        type="button"
+        onclick="document.getElementById('create-org-dialog').showModal()"
       >
-        <input type="hidden" name="intent" value="create_org" />
-        <input type="hidden" name="q" value="{{ .SearchQuery }}" />
-        <input type="hidden" name="page" value="{{ .CurrentPage }}" />
-        <div class="form-field">
-          <label for="org-name">Organization name *</label>
-          <input
-            id="org-name"
-            name="name"
-            type="text"
-            value="{{ if eq .OrganizationDialogAction "create" }}
-              {{ .OrganizationDialogName }}
-            {{ end }}"
-            required
-          />
-        </div>
-        <div class="form-field">
-          <label for="org-logo">Organization logo</label>
-          <input
-            id="org-logo"
-            name="logo"
-            type="file"
-            accept=".png,.jpg,.jpeg,.webp,.svg,image/png,image/jpeg,image/webp,image/svg+xml"
-          />
-        </div>
-        <div class="form-field">
-          <label for="org-admin-email">Organization admin email</label>
-          <input
-            id="org-admin-email"
-            name="invite_email"
-            type="email"
-            value="{{ if eq .OrganizationDialogAction "create" }}
-              {{ .InviteDialogEmail }}
-            {{ end }}"
-          />
-          <small class="muted">
-            Invite the first org admin now, or add more org admins later from
-            the organization invite action.
-          </small>
-        </div>
-        {{ if and .OrganizationError (eq .OrganizationDialogAction "create") }}
-          <p class="error">{{ .OrganizationError }}</p>
-        {{ end }}
-        <div class="dialog-actions">
-          <button class="btn btn-primary" type="submit">Create organization</button>
-        </div>
-      </form>
+        {{ template "icon-plus" . }}
+        Add organization
+      </button>
     </div>
-  </dialog>
 
-<script>
-  (function () {
-    const createDialog = document.getElementById("create-org-dialog");
-    if (createDialog && {{if and .OrganizationError (eq .OrganizationDialogAction "create")}}true{{else}}false{{end}} && !createDialog.open) {
-      createDialog.showModal();
-    }
-  })();
-</script>
+    <form
+      method="get"
+      action="/admin/orgs"
+      class="platform-admin-search"
+      id="platform-admin-search"
+    >
+      <input type="hidden" name="page" value="1" />
+      <label
+        class="platform-admin-search-field"
+        for="platform-admin-search-input"
+      >
+        {{ template "icon-search" . }}
+        <input
+          id="platform-admin-search-input"
+          type="search"
+          name="q"
+          value="{{ .SearchQuery }}"
+          placeholder="Search organizations by name"
+          autocomplete="off"
+          hx-get="/admin/orgs"
+          hx-target="#platform-admin-results"
+          hx-select="#platform-admin-results"
+          hx-swap="outerHTML"
+          hx-push-url="true"
+          hx-include="#platform-admin-search"
+          hx-trigger="input changed delay:200ms, search"
+        />
+      </label>
+    </form>
+
+    {{ template "platform_admin_results" . }}
+
+    <dialog id="create-org-dialog" class="dialog">
+      <div class="dialog-card">
+        <header class="dialog-head">
+          <div>
+            <h3 class="dialog-title">New organization</h3>
+            <p class="dialog-subtitle">
+              Add a new organization to the platform
+            </p>
+          </div>
+          <button
+            type="button"
+            class="btn btn-ghost btn-icon dialog-close"
+            onclick="document.getElementById('create-org-dialog').close()"
+          >
+            {{ template "icon-close" . }}
+          </button>
+        </header>
+        <form
+          method="post"
+          action="/admin/orgs"
+          class="input-form"
+          enctype="multipart/form-data"
+        >
+          <input type="hidden" name="intent" value="create_org" />
+          <input type="hidden" name="q" value="{{ .SearchQuery }}" />
+          <input type="hidden" name="page" value="{{ .CurrentPage }}" />
+          <div class="form-field">
+            <label for="org-name">Organization name *</label>
+            <input
+              id="org-name"
+              name="name"
+              type="text"
+              value="{{ if eq .OrganizationDialogAction "create" }}
+                {{ .OrganizationDialogName }}
+              {{ end }}"
+              required
+            />
+          </div>
+          <div class="form-field">
+            <label for="org-logo">Organization logo</label>
+            <input
+              id="org-logo"
+              name="logo"
+              type="file"
+              accept=".png,.jpg,.jpeg,.webp,.svg,image/png,image/jpeg,image/webp,image/svg+xml"
+            />
+          </div>
+          <div class="form-field">
+            <label for="org-admin-email">Organization admin email</label>
+            <input
+              id="org-admin-email"
+              name="invite_email"
+              type="email"
+              value="{{ if eq .OrganizationDialogAction "create" }}
+                {{ .InviteDialogEmail }}
+              {{ end }}"
+            />
+            <small class="muted">
+              Invite the first org admin now, or add more org admins later from
+              the organization invite action.
+            </small>
+          </div>
+          {{ if and .OrganizationError (eq .OrganizationDialogAction "create") }}
+            <p class="error">{{ .OrganizationError }}</p>
+          {{ end }}
+          <div class="dialog-actions">
+            <button class="btn btn-primary" type="submit">Create organization</button>
+          </div>
+        </form>
+      </div>
+    </dialog>
+
+    <script>
+      (function () {
+        const createDialog = document.getElementById("create-org-dialog");
+        if (createDialog && {{ if and .OrganizationError (eq .OrganizationDialogAction "create") }}true{{ else }}false{{ end }} && !createDialog.open) {
+          createDialog.showModal();
+        }
+      })();
+    </script>
+  {{ end }}
 {{ end }}
 
 {{ define "platform_admin_categories_panel" }}


### PR DESCRIPTION
## Summary
- Add shared `admin_console` shell so platform and org admin soft-nav swap header + sidebar + main via HTMX (`#admin-console`) without full page reloads.
- Platform admin Orgs/Categories and org admin Profile/Roles/Members use the same pattern; org admin drops multi-panel DOM + History JS (one panel per route). Form POSTs stay full-page; orgs search still targets `#platform-admin-results`.
- Fix org soft-nav panel resolution after `/my` path rewrite so Roles/Members actually swap (not profile-only with URL change).

## Test plan
- [ ] Platform admin: soft-nav Orgs ↔ Categories; confirm URL + active nav + main content update without full reload
- [ ] Platform admin: orgs search/pagination still swaps `#platform-admin-results` only
- [ ] Org admin: soft-nav Profile ↔ Roles ↔ Members; confirm panel content and active sidebar update
- [ ] Org admin form POSTs still full-page reload
- [ ] Org setup (`NeedsOrganizationSetup`) has no soft-nav shell
- [ ] `go test ./cmd/server -run 'AdminConsole|OrgAdminSoftNav|PlatformAdmin.*HTMX|ResolveOrgAdminActivePanel'`


Made with [Cursor](https://cursor.com)