### PR TITLE
perf(admin): cut platform orgs Appwrite N+1 load

### DIFF
--- a/docs/superpowers/plans/2026-07-30-platform-admin-orgs-perf.md
+++ b/docs/superpowers/plans/2026-07-30-platform-admin-orgs-perf.md
@@ -1,0 +1,985 @@
+# Platform Admin Orgs Perf Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `GET /admin/orgs` fast by stopping per-member Appwrite user hydration on the org table, then add early org-admin filtering, parallel per-org fetches, and Appwrite-paged team listing.
+
+**Architecture:** Keep full `ListOrganizationMemberships` (hydrates each member via `GetUserByID`) for flows that need label-accurate roles. Add a lite membership list that decodes Appwrite team membership rows only (`userEmail`, `confirm`, membership roles → `IsOrgAdmin`). Platform admin org rows use lite (+ optional team ID to skip `GetOrganizationBySlug`), filter to org-admins before summarizing, and fetch orgs in parallel. Org catalog paging moves from “list all teams then slice in memory” to `teams.List` with `query.Limit` / `query.Offset` / `OrderAsc("name")` and optional `WithListSearch`.
+
+**Tech Stack:** Go `net/http` server, Appwrite Go SDK `v1.0.0` (`teams`, `query`), existing `IdentityStore` / `fakeIdentityStore`, `httptest` Appwrite mocks in `identity_appwrite_test.go`.
+
+## Global Constraints
+
+- Work only in git worktree `.worktrees/investigate/admin-orgs-slow-load` on branch `investigate/admin-orgs-slow-load`.
+- Do **not** add caching.
+- Prefer minimal diffs; do not refactor unrelated identity call sites.
+- Lite membership `IsOrgAdmin` comes from membership roles (`owner` / invite encoding via `decodeInviteMembershipRoles`) — **not** from user labels. Org-admin invites already set `owner` via `encodeInviteMembershipRoles`. Document this in the lite method comment.
+- Full hydrated `ListOrganizationMemberships` behavior must remain unchanged for org-admin member UIs / invite upgrade paths that still call it.
+- TDD: failing test → implement → pass → commit per task.
+- Run Go tests from `server/`: `go test -count=1 ./cmd/server/ -run <Name>`.
+
+---
+
+## File map
+
+| File | Role |
+|------|------|
+| `server/cmd/server/identity.go` | Add `IdentityOrgListOptions`, `IdentityOrgPage`, `ListOrganizationsPage`, `ListOrganizationMembershipsLite` |
+| `server/cmd/server/identity_appwrite.go` | Implement lite membership decode + paged org list; keep hydrated list as-is |
+| `server/cmd/server/identity_mapping.go` | Optional tiny helper if decode is shared; otherwise keep decode next to Appwrite impl |
+| `server/cmd/server/identity_test_helpers_test.go` | Fake impls for new interface methods |
+| `server/cmd/server/identity_appwrite_test.go` | HTTP-count tests for lite list + paged list |
+| `server/cmd/server/main.go` | `platformAdminView`, `platformOrganizations` / page helper, `platformAdminOrganizationRows` |
+| `server/cmd/server/admin_handler_identity_test.go` | Existing platform admin status tests; extend for call amplification / parallel safety |
+| `server/cmd/server/platform_admin_orgs_perf_test.go` | New focused perf-contract tests (call counts, paging) |
+
+---
+
+### Task 1: Lite membership decode + `ListOrganizationMembershipsLite`
+
+**Files:**
+- Modify: `server/cmd/server/identity.go`
+- Modify: `server/cmd/server/identity_appwrite.go` (`ListOrganizationMemberships`, `toIdentityMembership`)
+- Modify: `server/cmd/server/identity_test_helpers_test.go`
+- Modify: `server/cmd/server/identity_appwrite_test.go`
+
+**Interfaces:**
+- Consumes: existing `IdentityMembership`, `decodeInviteMembershipRoles`, `identityMembershipOwnerRole`, `GetOrganizationBySlug`, `teams.ListMemberships`
+- Produces:
+  - `ListOrganizationMembershipsLite(ctx context.Context, orgSlug string) ([]IdentityMembership, error)` on `IdentityStore`
+  - unexported `membershipFromAppwrite(membership *models.Membership, org *IdentityOrg) IdentityMembership` (no `GetUserByID`)
+  - Hydrated `ListOrganizationMemberships` keeps calling user hydration (can call lite decode then optionally hydrate, or keep `toIdentityMembership` but extract shared decode)
+
+- [ ] **Step 1: Write the failing Appwrite HTTP-count test**
+
+Append to `server/cmd/server/identity_appwrite_test.go`:
+
+```go
+func TestAppwriteIdentityListOrganizationMembershipsLiteSkipsUserHydration(t *testing.T) {
+	var userGETs int
+	appwriteAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/teams/acme":
+			_, _ = w.Write([]byte(`{"$id":"acme","name":"Acme Org","prefs":{"schemaVersion":1,"slug":"acme"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/teams/acme/memberships":
+			_, _ = w.Write([]byte(`{"total":2,"memberships":[
+				{"$id":"m1","userId":"user-1","userEmail":"owner@example.com","teamId":"acme","teamName":"Acme Org","confirm":true,"roles":["owner"]},
+				{"$id":"m2","userId":"user-2","userEmail":"member@example.com","teamId":"acme","teamName":"Acme Org","confirm":true,"roles":["member","iapprover"]}
+			]}`))
+		case strings.HasPrefix(r.URL.Path, "/v1/users/"):
+			userGETs++
+			t.Fatalf("lite list must not call users API: %s %s", r.Method, r.URL.Path)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer appwriteAPI.Close()
+
+	identity := NewAppwriteIdentity(appwriteAPI.URL+"/v1", "project-1", "api-key-1", appwriteAPI.Client())
+	memberships, err := identity.ListOrganizationMembershipsLite(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("ListOrganizationMembershipsLite error: %v", err)
+	}
+	if userGETs != 0 {
+		t.Fatalf("userGETs = %d, want 0", userGETs)
+	}
+	if len(memberships) != 2 {
+		t.Fatalf("memberships = %#v", memberships)
+	}
+	if !memberships[0].IsOrgAdmin || memberships[0].Email != "owner@example.com" || !memberships[0].Confirmed {
+		t.Fatalf("memberships[0] = %#v", memberships[0])
+	}
+	if memberships[1].IsOrgAdmin || memberships[1].Email != "member@example.com" {
+		t.Fatalf("memberships[1] = %#v", memberships[1])
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && go test -count=1 ./cmd/server/ -run TestAppwriteIdentityListOrganizationMembershipsLiteSkipsUserHydration -v`
+
+Expected: FAIL — `IdentityStore` / `*appwriteIdentity` missing `ListOrganizationMembershipsLite`
+
+- [ ] **Step 3: Add interface + fake + Appwrite implementation**
+
+In `identity.go`, add to `IdentityStore`:
+
+```go
+ListOrganizationMembershipsLite(ctx context.Context, orgSlug string) ([]IdentityMembership, error)
+```
+
+In `identity_test_helpers_test.go`, add field + method:
+
+```go
+listOrganizationMembershipsLiteFunc func(ctx context.Context, orgSlug string) ([]IdentityMembership, error)
+
+func (f *fakeIdentityStore) ListOrganizationMembershipsLite(ctx context.Context, orgSlug string) ([]IdentityMembership, error) {
+	if f.listOrganizationMembershipsLiteFunc != nil {
+		return f.listOrganizationMembershipsLiteFunc(ctx, orgSlug)
+	}
+	// Default: reuse full list hook so existing fakes keep working when only listOrganizationMembershipsFunc is set.
+	return f.ListOrganizationMemberships(ctx, orgSlug)
+}
+```
+
+In `identity_appwrite.go`, extract non-hydrating decode and implement lite list:
+
+```go
+func membershipFromAppwrite(membership *models.Membership, org *IdentityOrg) IdentityMembership {
+	if membership == nil {
+		return IdentityMembership{}
+	}
+	decodedRoles := decodeInviteMembershipRoles(membership.Roles)
+	identity := IdentityMembership{
+		ID:              strings.TrimSpace(membership.Id),
+		TeamID:          strings.TrimSpace(membership.TeamId),
+		UserID:          strings.TrimSpace(membership.UserId),
+		Email:           strings.TrimSpace(membership.UserEmail),
+		MembershipRoles: append([]string(nil), membership.Roles...),
+		RoleSlugs:       append([]string(nil), decodedRoles.BusinessRoles...),
+		IsOrgAdmin:      decodedRoles.IsOrgAdmin || hasMembershipRole(membership.Roles, identityMembershipOwnerRole),
+		Confirmed:       membership.Confirm,
+	}
+	if org != nil {
+		identity.TeamID = strings.TrimSpace(org.ID)
+	}
+	if invitedAt, err := parseAppwriteTime(membership.Invited); err == nil {
+		identity.InvitedAt = invitedAt
+	}
+	if joinedAt, err := parseAppwriteTime(membership.Joined); err == nil {
+		identity.JoinedAt = joinedAt
+	}
+	return identity
+}
+
+// ListOrganizationMembershipsLite returns memberships decoded from the team membership
+// list only. IsOrgAdmin is derived from membership roles (owner / invite encoding), not
+// user labels. Callers that need label-accurate roles must use ListOrganizationMemberships.
+func (a *appwriteIdentity) ListOrganizationMembershipsLite(ctx context.Context, orgSlug string) ([]IdentityMembership, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	org, err := a.GetOrganizationBySlug(ctx, orgSlug)
+	if err != nil {
+		return nil, err
+	}
+	membershipList, err := teams.New(a.adminClient).ListMemberships(strings.TrimSpace(org.ID))
+	if err != nil {
+		return nil, normalizeIdentityError(err)
+	}
+	memberships := make([]IdentityMembership, 0, len(membershipList.Memberships))
+	for i := range membershipList.Memberships {
+		memberships = append(memberships, membershipFromAppwrite(&membershipList.Memberships[i], org))
+	}
+	return memberships, nil
+}
+```
+
+Refactor `toIdentityMembership` to start from `membershipFromAppwrite` then optionally hydrate (preserve current overwrite behavior):
+
+```go
+func (a *appwriteIdentity) toIdentityMembership(ctx context.Context, membership *models.Membership, org *IdentityOrg) IdentityMembership {
+	identity := membershipFromAppwrite(membership, org)
+	if identity.UserID != "" {
+		if user, err := a.GetUserByID(ctx, identity.UserID); err == nil {
+			identity.Email = user.Email
+			identity.RoleSlugs = decodeIdentityRoleLabels(user.Labels)
+			identity.IsOrgAdmin = user.IsOrgAdmin
+		}
+	}
+	return identity
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && go test -count=1 ./cmd/server/ -run 'TestAppwriteIdentityListOrganizationMembershipsLiteSkipsUserHydration|TestAppwriteIdentityListOrganizationMembershipsPendingMembership' -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/cmd/server/identity.go server/cmd/server/identity_appwrite.go server/cmd/server/identity_test_helpers_test.go server/cmd/server/identity_appwrite_test.go
+git commit -m "$(cat <<'EOF'
+feat(identity): add lite org membership list without user hydration
+
+EOF
+)"
+```
+
+---
+
+### Task 2: Platform admin rows use lite list (biggest win)
+
+**Files:**
+- Modify: `server/cmd/server/main.go` (`platformAdminOrganizationRows`)
+- Create: `server/cmd/server/platform_admin_orgs_perf_test.go`
+- Modify: `server/cmd/server/admin_handler_identity_test.go` only if existing status test needs the lite fake hook
+
+**Interfaces:**
+- Consumes: `IdentityStore.ListOrganizationMembershipsLite`
+- Produces: `platformAdminOrganizationRows` calls lite only (no `ListOrganizationMemberships`)
+
+- [ ] **Step 1: Write failing amplification test**
+
+Create `server/cmd/server/platform_admin_orgs_perf_test.go`:
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+)
+
+func TestPlatformAdminViewDoesNotCallHydratedMembershipList(t *testing.T) {
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "change-me")
+
+	var hydratedCalls atomic.Int64
+	var liteCalls atomic.Int64
+
+	orgs := []IdentityOrg{
+		{ID: "team-1", Slug: "accepted", Name: "Accepted Org"},
+		{ID: "team-2", Slug: "pending", Name: "Pending Org"},
+		{ID: "team-3", Slug: "missing", Name: "Missing Org"},
+	}
+
+	identity := &fakeIdentityStore{
+		listOrganizationsFunc: func(ctx context.Context) ([]IdentityOrg, error) {
+			return orgs, nil
+		},
+		listOrganizationMembershipsFunc: func(ctx context.Context, orgSlug string) ([]IdentityMembership, error) {
+			hydratedCalls.Add(1)
+			t.Fatalf("platform admin view must not call ListOrganizationMemberships (%s)", orgSlug)
+			return nil, nil
+		},
+		listOrganizationMembershipsLiteFunc: func(ctx context.Context, orgSlug string) ([]IdentityMembership, error) {
+			liteCalls.Add(1)
+			switch orgSlug {
+			case "accepted":
+				return []IdentityMembership{
+					{Email: "admin@example.com", Confirmed: true, IsOrgAdmin: true},
+					{Email: "owner@example.com", Confirmed: true, IsOrgAdmin: true},
+				}, nil
+			case "pending":
+				return []IdentityMembership{
+					{Email: "pending-owner@example.com", Confirmed: false, IsOrgAdmin: true},
+				}, nil
+			default:
+				return nil, nil
+			}
+		},
+	}
+
+	server := &Server{identity: identity, authorizer: fakeAuthorizer{}}
+	view := server.platformAdminView(&AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "", PlatformAdminErrors{})
+
+	if hydratedCalls.Load() != 0 {
+		t.Fatalf("hydratedCalls = %d", hydratedCalls.Load())
+	}
+	if liteCalls.Load() != 3 {
+		t.Fatalf("liteCalls = %d, want 3", liteCalls.Load())
+	}
+	if len(view.Organizations) != 3 {
+		t.Fatalf("organizations = %#v", view.Organizations)
+	}
+	if view.Organizations[0].OrgAdminStatus != "At least one org admin accepted" {
+		t.Fatalf("accepted status = %q", view.Organizations[0].OrgAdminStatus)
+	}
+	if view.Organizations[2].OrgAdminStatus != "All org admin invites pending" {
+		t.Fatalf("pending status = %q", view.Organizations[2].OrgAdminStatus)
+	}
+	if view.Organizations[1].OrgAdminStatus != "No org admin" {
+		t.Fatalf("missing status = %q", view.Organizations[1].OrgAdminStatus)
+	}
+	_ = fmt.Sprintf // keep import if needed; remove if unused after edits
+}
+```
+
+(Remove unused `fmt` if the compiler complains — prefer no dead imports.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && go test -count=1 ./cmd/server/ -run TestPlatformAdminViewDoesNotCallHydratedMembershipList -v`
+
+Expected: FAIL with `platform admin view must not call ListOrganizationMemberships` (current code hits hydrated list; fake default lite → hydrated)
+
+- [ ] **Step 3: Switch `platformAdminOrganizationRows` to lite**
+
+In `main.go`, change the membership fetch:
+
+```go
+func platformAdminOrganizationRows(ctx context.Context, organizations []Organization, identity IdentityStore) []PlatformAdminOrganizationRow {
+	rows := make([]PlatformAdminOrganizationRow, 0, len(organizations))
+	for _, organization := range organizations {
+		row := PlatformAdminOrganizationRow{
+			Name:             organization.Name,
+			Slug:             organization.Slug,
+			LogoAttachmentID: organization.LogoAttachmentID,
+		}
+		if identity != nil && strings.TrimSpace(organization.Slug) != "" {
+			memberships, err := identity.ListOrganizationMembershipsLite(ctx, organization.Slug)
+			if err != nil {
+				log.Printf("failed to list organization memberships for %s: %v", organization.Slug, err)
+			} else {
+				row.OrgAdminEmails, row.PendingOrgAdminEmails = summarizePlatformOrgAdminMemberships(memberships)
+			}
+		}
+		row.OrgAdminStatus, row.OrgAdminStatusClassName = platformOrgAdminStatus(row.OrgAdminEmails, row.PendingOrgAdminEmails)
+		rows = append(rows, row)
+	}
+	return rows
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd server && go test -count=1 ./cmd/server/ -run 'TestPlatformAdminViewDoesNotCallHydratedMembershipList|TestPlatformAdminHelpers' -v`
+
+Expected: PASS (include whatever existing test name wraps `platform admin view summarizes org admin status` — currently under `TestPlatformAdminHelpers` / similar in `admin_handler_identity_test.go`)
+
+Also run: `cd server && go test -count=1 ./cmd/server/ -run 'TestPlatformAdmin|TestHandleAdminOrgs' -v` and fix any fakes that relied on hydrated-only hooks (lite defaults to hydrated in fake, so most tests should keep working).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/cmd/server/main.go server/cmd/server/platform_admin_orgs_perf_test.go server/cmd/server/admin_handler_identity_test.go
+git commit -m "$(cat <<'EOF'
+perf(admin): load platform org admin status via lite memberships
+
+EOF
+)"
+```
+
+---
+
+### Task 3: Filter earlier to org-admin memberships only
+
+**Files:**
+- Modify: `server/cmd/server/main.go` (`summarizePlatformOrgAdminMemberships` call site or new helper)
+- Modify: `server/cmd/server/platform_admin_orgs_perf_test.go`
+
+**Interfaces:**
+- Consumes: lite memberships
+- Produces: `filterPlatformOrgAdminMemberships(memberships []IdentityMembership) []IdentityMembership` used before summarize
+
+- [ ] **Step 1: Write failing unit test**
+
+Append to `platform_admin_orgs_perf_test.go`:
+
+```go
+func TestFilterPlatformOrgAdminMembershipsDropsNonAdmins(t *testing.T) {
+	in := []IdentityMembership{
+		{Email: "owner@example.com", IsOrgAdmin: true, Confirmed: true},
+		{Email: "member@example.com", IsOrgAdmin: false, Confirmed: true},
+		{Email: "pending@example.com", IsOrgAdmin: true, Confirmed: false},
+	}
+	got := filterPlatformOrgAdminMemberships(in)
+	if len(got) != 2 {
+		t.Fatalf("got = %#v", got)
+	}
+	if got[0].Email != "owner@example.com" || got[1].Email != "pending@example.com" {
+		t.Fatalf("got = %#v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `cd server && go test -count=1 ./cmd/server/ -run TestFilterPlatformOrgAdminMembershipsDropsNonAdmins -v`
+
+Expected: FAIL — `filterPlatformOrgAdminMemberships` undefined
+
+- [ ] **Step 3: Implement filter + wire into rows**
+
+```go
+func filterPlatformOrgAdminMemberships(memberships []IdentityMembership) []IdentityMembership {
+	out := make([]IdentityMembership, 0, len(memberships))
+	for _, membership := range memberships {
+		if !membership.IsOrgAdmin {
+			continue
+		}
+		out = append(out, membership)
+	}
+	return out
+}
+```
+
+In `platformAdminOrganizationRows`, after lite list succeeds:
+
+```go
+row.OrgAdminEmails, row.PendingOrgAdminEmails = summarizePlatformOrgAdminMemberships(
+	filterPlatformOrgAdminMemberships(memberships),
+)
+```
+
+Keep `summarizePlatformOrgAdminMemberships`’s platform-admin-email skip (`isPlatformAdminMembership`) as-is.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd server && go test -count=1 ./cmd/server/ -run 'TestFilterPlatformOrgAdminMembershipsDropsNonAdmins|TestPlatformAdminViewDoesNotCallHydratedMembershipList' -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/cmd/server/main.go server/cmd/server/platform_admin_orgs_perf_test.go
+git commit -m "$(cat <<'EOF'
+perf(admin): summarize only org-admin memberships on platform org rows
+
+EOF
+)"
+```
+
+---
+
+### Task 4: Parallelize per-org membership fetches
+
+**Files:**
+- Modify: `server/cmd/server/main.go` (`platformAdminOrganizationRows`)
+- Modify: `server/cmd/server/platform_admin_orgs_perf_test.go`
+
+**Interfaces:**
+- Consumes: `ListOrganizationMembershipsLite`, `golang.org/x/sync/errgroup` **or** stdlib `sync.WaitGroup` (prefer stdlib `WaitGroup` + mutex to avoid new dependency debates; `errgroup` is fine if already used in module — check `go.mod`; if absent, use `WaitGroup`)
+- Produces: same row order as input `organizations` slice (stable order)
+
+- [ ] **Step 1: Write failing concurrency-order test**
+
+Append:
+
+```go
+func TestPlatformAdminOrganizationRowsPreservesOrderUnderParallelFetch(t *testing.T) {
+	var calls atomic.Int64
+	identity := &fakeIdentityStore{
+		listOrganizationMembershipsLiteFunc: func(ctx context.Context, orgSlug string) ([]IdentityMembership, error) {
+			n := calls.Add(1)
+			// Stagger later orgs so unordered append would scramble results.
+			if orgSlug == "a" {
+				time.Sleep(30 * time.Millisecond)
+			}
+			_ = n
+			return []IdentityMembership{{Email: orgSlug + "-owner@example.com", IsOrgAdmin: true, Confirmed: true}}, nil
+		},
+	}
+	orgs := []Organization{{Slug: "a", Name: "A"}, {Slug: "b", Name: "B"}, {Slug: "c", Name: "C"}}
+	rows := platformAdminOrganizationRows(context.Background(), orgs, identity)
+	if len(rows) != 3 || rows[0].Slug != "a" || rows[1].Slug != "b" || rows[2].Slug != "c" {
+		t.Fatalf("rows = %#v", rows)
+	}
+	if rows[0].OrgAdminEmails[0] != "a-owner@example.com" || rows[2].OrgAdminEmails[0] != "c-owner@example.com" {
+		t.Fatalf("emails = %#v", rows)
+	}
+}
+```
+
+(Add `"sync/atomic"` / `"time"` imports.)
+
+This test should already pass with sequential code (order-preserving). That is OK — it is a **regression lock** before parallelization. Optionally assert elapsed &lt; sequential lower bound after parallelization in Step 4.
+
+- [ ] **Step 2: Run — expect PASS (baseline lock)**
+
+Run: `cd server && go test -count=1 ./cmd/server/ -run TestPlatformAdminOrganizationRowsPreservesOrderUnderParallelFetch -v`
+
+Expected: PASS
+
+- [ ] **Step 3: Parallelize with stable indexing**
+
+Replace the loop body with pre-sized slice + WaitGroup:
+
+```go
+func platformAdminOrganizationRows(ctx context.Context, organizations []Organization, identity IdentityStore) []PlatformAdminOrganizationRow {
+	rows := make([]PlatformAdminOrganizationRow, len(organizations))
+	var wg sync.WaitGroup
+	for i, organization := range organizations {
+		wg.Add(1)
+		go func(i int, organization Organization) {
+			defer wg.Done()
+			row := PlatformAdminOrganizationRow{
+				Name:             organization.Name,
+				Slug:             organization.Slug,
+				LogoAttachmentID: organization.LogoAttachmentID,
+			}
+			if identity != nil && strings.TrimSpace(organization.Slug) != "" {
+				memberships, err := identity.ListOrganizationMembershipsLite(ctx, organization.Slug)
+				if err != nil {
+					log.Printf("failed to list organization memberships for %s: %v", organization.Slug, err)
+				} else {
+					row.OrgAdminEmails, row.PendingOrgAdminEmails = summarizePlatformOrgAdminMemberships(
+						filterPlatformOrgAdminMemberships(memberships),
+					)
+				}
+			}
+			row.OrgAdminStatus, row.OrgAdminStatusClassName = platformOrgAdminStatus(row.OrgAdminEmails, row.PendingOrgAdminEmails)
+			rows[i] = row
+		}(i, organization)
+	}
+	wg.Wait()
+	return rows
+}
+```
+
+Add `"sync"` to imports in `main.go` if missing.
+
+- [ ] **Step 4: Run tests + optional timing check**
+
+Run: `cd server && go test -count=1 ./cmd/server/ -run 'TestPlatformAdminOrganizationRowsPreservesOrderUnderParallelFetch|TestPlatformAdminViewDoesNotCallHydratedMembershipList' -v`
+
+Expected: PASS
+
+Optional: in the order test, set lite sleep to `20ms` for every org and assert `elapsed < 50ms` so parallelism is proven (3×20ms sequential would be ≥60ms). Only add if stable on CI; skip if flaky.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/cmd/server/main.go server/cmd/server/platform_admin_orgs_perf_test.go
+git commit -m "$(cat <<'EOF'
+perf(admin): fetch platform org memberships in parallel
+
+EOF
+)"
+```
+
+---
+
+### Task 5: Server-side team pagination (+ search)
+
+**Files:**
+- Modify: `server/cmd/server/identity.go`
+- Modify: `server/cmd/server/identity_appwrite.go`
+- Modify: `server/cmd/server/identity_test_helpers_test.go`
+- Modify: `server/cmd/server/identity_appwrite_test.go`
+- Modify: `server/cmd/server/main.go` (`platformAdminView`, replace or narrow `platformOrganizations` usage for this page)
+- Modify: `server/cmd/server/platform_admin_orgs_perf_test.go`
+
+**Interfaces:**
+- Consumes: Appwrite `teams.List` with `WithListQueries([]string{query.Limit(n), query.Offset(o), query.OrderAsc("name")})`, optional `WithListSearch(q)`, `WithListTotal(true)`
+- Produces:
+  - `type IdentityOrgListOptions struct { Search string; Limit int; Offset int }`
+  - `type IdentityOrgPage struct { Organizations []IdentityOrg; Total int }`
+  - `ListOrganizationsPage(ctx context.Context, opts IdentityOrgListOptions) (IdentityOrgPage, error)`
+  - `ListOrganizations` remains for other callers (unchanged behavior in this task)
+
+**Behavior notes:**
+- Empty search: page with limit/offset ordered by name.
+- Non-empty search: pass `WithListSearch(trimmedQuery)` **and** still apply limit/offset. Accept Appwrite full-text search semantics (may differ slightly from previous `strings.Contains` on name). Do **not** fetch all teams to re-filter in memory on this page path.
+- `MatchedOrganizations` / `TotalPages` must use `page.Total`, not `len(page.Organizations)`.
+- Default Appwrite list limit is small; this task is also a correctness fix when org count &gt; 25.
+
+- [ ] **Step 1: Write failing Appwrite paging test**
+
+Append to `identity_appwrite_test.go`:
+
+```go
+func TestAppwriteIdentityListOrganizationsPagePassesLimitOffsetSearch(t *testing.T) {
+	var gotQueries []string
+	var gotSearch string
+	appwriteAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/v1/teams" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		gotSearch = r.URL.Query().Get("search")
+		gotQueries = r.URL.Query()["queries[]"]
+		if len(gotQueries) == 0 {
+			// SDK may encode as queries — accept either form used by sdk-for-go v1.0.0
+			gotQueries = r.URL.Query()["queries"]
+		}
+		_, _ = w.Write([]byte(`{"total":40,"teams":[{"$id":"acme","name":"Acme Org","prefs":{"schemaVersion":1,"slug":"acme"}}]}`))
+	}))
+	defer appwriteAPI.Close()
+
+	identity := NewAppwriteIdentity(appwriteAPI.URL+"/v1", "project-1", "api-key-1", appwriteAPI.Client())
+	page, err := identity.ListOrganizationsPage(context.Background(), IdentityOrgListOptions{
+		Search: "acme",
+		Limit:  12,
+		Offset: 24,
+	})
+	if err != nil {
+		t.Fatalf("ListOrganizationsPage error: %v", err)
+	}
+	if page.Total != 40 || len(page.Organizations) != 1 || page.Organizations[0].Slug != "acme" {
+		t.Fatalf("page = %#v", page)
+	}
+	if gotSearch != "acme" {
+		t.Fatalf("search = %q, want acme", gotSearch)
+	}
+	joined := strings.Join(gotQueries, ",")
+	if !strings.Contains(joined, "12") || !strings.Contains(joined, "24") {
+		t.Fatalf("queries = %#v (raw=%q), want limit 12 and offset 24", gotQueries, joined)
+	}
+}
+```
+
+If the SDK encodes queries as JSON strings in a single param, adjust assertions after observing the failing request dump (`t.Logf("%v", r.URL.RawQuery)`).
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `cd server && go test -count=1 ./cmd/server/ -run TestAppwriteIdentityListOrganizationsPagePassesLimitOffsetSearch -v`
+
+Expected: FAIL — method undefined
+
+- [ ] **Step 3: Implement `ListOrganizationsPage`**
+
+In `identity.go`:
+
+```go
+type IdentityOrgListOptions struct {
+	Search string
+	Limit  int
+	Offset int
+}
+
+type IdentityOrgPage struct {
+	Organizations []IdentityOrg
+	Total         int
+}
+
+// on IdentityStore:
+ListOrganizationsPage(ctx context.Context, opts IdentityOrgListOptions) (IdentityOrgPage, error)
+```
+
+In `identity_appwrite.go`:
+
+```go
+func (a *appwriteIdentity) ListOrganizationsPage(ctx context.Context, opts IdentityOrgListOptions) (IdentityOrgPage, error) {
+	if err := ctx.Err(); err != nil {
+		return IdentityOrgPage{}, err
+	}
+	limit := opts.Limit
+	if limit < 1 {
+		limit = platformAdminOrganizationsPerPage // or local default 12; avoid import cycle — use literal 12 here if const lives in main
+	}
+	offset := opts.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	queries := []string{
+		query.Limit(limit),
+		query.Offset(offset),
+		query.OrderAsc("name"),
+	}
+	options := []teams.ListOption{
+		teams.New(a.adminClient).WithListQueries(queries),
+		teams.New(a.adminClient).WithListTotal(true),
+	}
+	if search := strings.TrimSpace(opts.Search); search != "" {
+		options = append(options, teams.New(a.adminClient).WithListSearch(search))
+	}
+	teamList, err := teams.New(a.adminClient).List(options...)
+	if err != nil {
+		return IdentityOrgPage{}, normalizeIdentityError(err)
+	}
+	if err := ctx.Err(); err != nil {
+		return IdentityOrgPage{}, err
+	}
+	return IdentityOrgPage{
+		Organizations: decodeIdentityOrgs(teamList),
+		Total:         teamList.Total,
+	}, nil
+}
+```
+
+**Const placement:** do **not** reference `platformAdminOrganizationsPerPage` from `identity_appwrite.go` if that creates awkward coupling — use `if limit < 1 { limit = 12 }`.
+
+Fake:
+
+```go
+listOrganizationsPageFunc func(ctx context.Context, opts IdentityOrgListOptions) (IdentityOrgPage, error)
+
+func (f *fakeIdentityStore) ListOrganizationsPage(ctx context.Context, opts IdentityOrgListOptions) (IdentityOrgPage, error) {
+	if f.listOrganizationsPageFunc != nil {
+		return f.listOrganizationsPageFunc(ctx, opts)
+	}
+	orgs, err := f.ListOrganizations(ctx)
+	if err != nil {
+		return IdentityOrgPage{}, err
+	}
+	// In-memory page so existing tests that only stub ListOrganizations still work when platformAdminView switches.
+	filtered := orgs
+	if q := strings.ToLower(strings.TrimSpace(opts.Search)); q != "" {
+		filtered = nil
+		for _, org := range orgs {
+			if strings.Contains(strings.ToLower(org.Name), q) {
+				filtered = append(filtered, org)
+			}
+		}
+	}
+	total := len(filtered)
+	limit := opts.Limit
+	if limit < 1 {
+		limit = 12
+	}
+	offset := opts.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > total {
+		offset = total
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+	return IdentityOrgPage{Organizations: append([]IdentityOrg(nil), filtered[offset:end]...), Total: total}, nil
+}
+```
+
+Add import for `github.com/appwrite/sdk-for-go/query` in `identity_appwrite.go`.
+
+- [ ] **Step 4: Wire `platformAdminView` to paged list**
+
+Replace the list/filter/slice block in `platformAdminView` with:
+
+```go
+limit := platformAdminOrganizationsPerPage
+requestedPage := errs.Page
+if requestedPage < 1 {
+	requestedPage = 1
+}
+offset := (requestedPage - 1) * limit
+
+orgPage, err := s.identity.ListOrganizationsPage(context.Background(), IdentityOrgListOptions{
+	Search: errs.SearchQuery,
+	Limit:  limit,
+	Offset: offset,
+})
+if err != nil {
+	log.Printf("failed to list platform organizations page: %v", err)
+	orgPage = IdentityOrgPage{}
+}
+
+currentPage := normalizePlatformAdminPage(requestedPage, orgPage.Total)
+if currentPage != requestedPage {
+	// Re-fetch if page was clamped (e.g. page=99 when only 2 pages).
+	offset = (currentPage - 1) * limit
+	orgPage, err = s.identity.ListOrganizationsPage(context.Background(), IdentityOrgListOptions{
+		Search: errs.SearchQuery,
+		Limit:  limit,
+		Offset: offset,
+	})
+	if err != nil {
+		log.Printf("failed to list platform organizations page: %v", err)
+		orgPage = IdentityOrgPage{}
+	}
+}
+
+organizations := make([]Organization, 0, len(orgPage.Organizations))
+for _, org := range orgPage.Organizations {
+	organizations = append(organizations, organizationFromIdentityOrg(org))
+}
+
+totalPages := 1
+if orgPage.Total > 0 {
+	totalPages = (orgPage.Total + limit - 1) / limit
+}
+pageNumbers := make([]int, 0, totalPages)
+for page := 1; page <= totalPages; page++ {
+	pageNumbers = append(pageNumbers, page)
+}
+rows := platformAdminOrganizationRows(context.Background(), organizations, s.identity)
+```
+
+Set view fields:
+
+```go
+MatchedOrganizations: orgPage.Total,
+Organizations:        rows,
+CurrentPage:          currentPage,
+TotalPages:           totalPages,
+PageNumbers:          pageNumbers,
+HasPreviousPage:      currentPage > 1,
+HasNextPage:          currentPage < totalPages,
+PreviousPage:         max(currentPage-1, 1),
+NextPage:             min(currentPage+1, totalPages),
+SearchQuery:          errs.SearchQuery,
+```
+
+Leave `platformOrganizations` / `filterPlatformOrganizations` in place for any non-view callers/tests; if `platformAdminView` is the only consumer, do not delete them in this task unless tests force it — YAGNI cleanup can be a tiny follow-up commit inside this task only if unused and tests agree.
+
+Update `TestPlatformAdminViewDoesNotCallHydratedMembershipList` fake: either stub `listOrganizationsPageFunc` **or** rely on fake default that pages `listOrganizationsFunc` (preferred — then existing stub keeps working).
+
+Add paging contract test:
+
+```go
+func TestPlatformAdminViewUsesOrganizationPageTotal(t *testing.T) {
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "change-me")
+	identity := &fakeIdentityStore{
+		listOrganizationsPageFunc: func(ctx context.Context, opts IdentityOrgListOptions) (IdentityOrgPage, error) {
+			if opts.Limit != 12 || opts.Offset != 12 || opts.Search != "ac" {
+				t.Fatalf("opts = %#v", opts)
+			}
+			return IdentityOrgPage{
+				Total: 25,
+				Organizations: []IdentityOrg{
+					{ID: "t13", Slug: "org-13", Name: "Org 13"},
+				},
+			}, nil
+		},
+		listOrganizationMembershipsLiteFunc: func(ctx context.Context, orgSlug string) ([]IdentityMembership, error) {
+			return nil, nil
+		},
+	}
+	server := &Server{identity: identity, authorizer: fakeAuthorizer{}}
+	view := server.platformAdminView(&AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "", PlatformAdminErrors{SearchQuery: "ac", Page: 2})
+	if view.MatchedOrganizations != 25 || view.TotalPages != 3 || view.CurrentPage != 2 || len(view.Organizations) != 1 {
+		t.Fatalf("view paging = matched=%d pages=%d page=%d rows=%d", view.MatchedOrganizations, view.TotalPages, view.CurrentPage, len(view.Organizations))
+	}
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+cd server && go test -count=1 ./cmd/server/ -run 'TestAppwriteIdentityListOrganizationsPagePassesLimitOffsetSearch|TestPlatformAdminViewUsesOrganizationPageTotal|TestPlatformAdminViewDoesNotCallHydratedMembershipList|TestPlatformAdmin' -v
+```
+
+Expected: PASS
+
+Then broader identity compile check:
+
+```bash
+cd server && go test -count=1 ./cmd/server/ -count=1 2>&1 | tail -30
+```
+
+If full package is too slow, at minimum ensure all files compile: `go test -count=1 ./cmd/server/ -run TestDoesNotExist` should compile and print `ok` with no tests.
+
+Fix any `publicCatalogIdentity` / other embedders only if they re-implement the whole interface (they embed `fakeIdentityStore` and should pick up new methods automatically).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/cmd/server/identity.go server/cmd/server/identity_appwrite.go server/cmd/server/identity_test_helpers_test.go server/cmd/server/identity_appwrite_test.go server/cmd/server/main.go server/cmd/server/platform_admin_orgs_perf_test.go
+git commit -m "$(cat <<'EOF'
+perf(admin): page platform organizations via Appwrite teams.List
+
+EOF
+)"
+```
+
+---
+
+### Task 6: End-to-end amplification regression (Appwrite mock)
+
+**Files:**
+- Modify: `server/cmd/server/platform_admin_orgs_perf_test.go`
+
+**Interfaces:**
+- Consumes: real `NewAppwriteIdentity` + `platformAdminView` after Tasks 1–5
+- Produces: hard ceiling on HTTP calls for 12 orgs × 8 members
+
+- [ ] **Step 1: Write failing ceiling test (if current code still hot) / lock test**
+
+```go
+func TestPlatformAdminViewAppwriteCallCeiling(t *testing.T) {
+	const orgCount = 12
+	const membersPerOrg = 8
+	var totalRequests atomic.Int64
+	var userRequests atomic.Int64
+
+	appwriteAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		totalRequests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+		switch {
+		case path == "/v1/teams":
+			teamsPayload := make([]map[string]any, 0, orgCount)
+			for i := 0; i < orgCount; i++ {
+				id := fmt.Sprintf("org-%d", i)
+				teamsPayload = append(teamsPayload, map[string]any{
+					"$id": id, "name": fmt.Sprintf("Org %d", i),
+					"prefs": map[string]any{"schemaVersion": 1, "slug": id},
+				})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"total": orgCount, "teams": teamsPayload})
+		case strings.HasSuffix(path, "/memberships") && strings.HasPrefix(path, "/v1/teams/"):
+			teamID := strings.TrimSuffix(strings.TrimPrefix(path, "/v1/teams/"), "/memberships")
+			teamID = strings.TrimSuffix(teamID, "/")
+			memberships := make([]map[string]any, 0, membersPerOrg)
+			for m := 0; m < membersPerOrg; m++ {
+				memberships = append(memberships, map[string]any{
+					"$id": fmt.Sprintf("%s-m-%d", teamID, m),
+					"userId": fmt.Sprintf("%s-u-%d", teamID, m),
+					"userEmail": fmt.Sprintf("u%d@%s.example", m, teamID),
+					"teamId": teamID, "teamName": teamID, "confirm": true,
+					"roles": []string{"member"},
+				})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"total": membersPerOrg, "memberships": memberships})
+		case strings.HasPrefix(path, "/v1/teams/"):
+			teamID := strings.TrimPrefix(path, "/v1/teams/")
+			_ = json.NewEncoder(w).Encode(map[string]any{"$id": teamID, "name": teamID, "prefs": map[string]any{"schemaVersion": 1, "slug": teamID}})
+		case strings.HasPrefix(path, "/v1/users/"):
+			userRequests.Add(1)
+			t.Fatalf("unexpected user hydration: %s", path)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, path)
+		}
+	}))
+	defer appwriteAPI.Close()
+
+	identity := NewAppwriteIdentity(appwriteAPI.URL+"/v1", "project-1", "api-key-1", appwriteAPI.Client())
+	server := &Server{identity: identity, authorizer: fakeAuthorizer{}}
+	_ = server.platformAdminView(&AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "", PlatformAdminErrors{})
+
+	// 1 list page + ≤12 get team + 12 list memberships = ≤25 (no user calls)
+	if userRequests.Load() != 0 {
+		t.Fatalf("userRequests = %d", userRequests.Load())
+	}
+	if total := totalRequests.Load(); total > 25 {
+		t.Fatalf("totalRequests = %d, want ≤ 25", total)
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect PASS after Tasks 1–5**
+
+Run: `cd server && go test -count=1 ./cmd/server/ -run TestPlatformAdminViewAppwriteCallCeiling -v`
+
+Expected: PASS (`totalRequests ≤ 25`, `userRequests = 0`). Pre-fix baseline was **313** with user hydration.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/cmd/server/platform_admin_orgs_perf_test.go
+git commit -m "$(cat <<'EOF'
+test(admin): lock platform orgs Appwrite call ceiling
+
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+1. **Spec coverage**
+   - Biggest win / lite list: Tasks 1–2
+   - Further (1) lightweight API: Task 1
+   - Further (2) filter earlier: Task 3
+   - Further (3) parallelize: Task 4
+   - Further (5) server-side pagination: Task 5
+   - Cache explicitly omitted
+   - Call-ceiling proof: Task 6
+
+2. **Placeholder scan:** none intentional; Appwrite query encoding assertion in Task 5 may need one adjustment after observing `RawQuery` — that is an allowed empirical tweak, not a TBD.
+
+3. **Type consistency:** `IdentityOrgListOptions` / `IdentityOrgPage` / `ListOrganizationsPage` / `ListOrganizationMembershipsLite` names are stable across tasks; fake defaults preserve older tests.
+
+---
+
+## Out of scope
+
+- Caching org-admin summaries
+- Speeding org-admin **members** page (`ListOrganizationUsers` still hydrates users)
+- Changing invite / label reconciliation semantics for hydrated memberships
+- Deleting unused `platformOrganizations` helpers unless proven dead in Task 5

--- a/server/cmd/server/identity.go
+++ b/server/cmd/server/identity.go
@@ -28,6 +28,7 @@ type IdentityStore interface {
 	AddOrganizationUserByIDAsAdmin(ctx context.Context, orgSlug, userID string, roleSlugs []string, isOrgAdmin bool) (IdentityMembership, error)
 	InviteOrganizationUser(ctx context.Context, sessionSecret, orgSlug, email, redirectURL string, roleSlugs []string, isOrgAdmin bool) (IdentityMembership, error)
 	ListOrganizations(ctx context.Context) ([]IdentityOrg, error)
+	ListOrganizationsPage(ctx context.Context, opts IdentityOrgListOptions) (IdentityOrgPage, error)
 	ListOrganizationMemberships(ctx context.Context, orgSlug string) ([]IdentityMembership, error)
 	ListOrganizationMembershipsLite(ctx context.Context, orgSlug string) ([]IdentityMembership, error)
 	ListOrganizationUsers(ctx context.Context, orgSlug string) ([]IdentityUser, error)
@@ -64,6 +65,17 @@ type IdentityOrg struct {
 	Name       string
 	LogoFileID string
 	Roles      []IdentityRole
+}
+
+type IdentityOrgListOptions struct {
+	Search string
+	Limit  int
+	Offset int
+}
+
+type IdentityOrgPage struct {
+	Organizations []IdentityOrg
+	Total         int
 }
 
 type IdentityRole struct {

--- a/server/cmd/server/identity.go
+++ b/server/cmd/server/identity.go
@@ -30,7 +30,10 @@ type IdentityStore interface {
 	ListOrganizations(ctx context.Context) ([]IdentityOrg, error)
 	ListOrganizationsPage(ctx context.Context, opts IdentityOrgListOptions) (IdentityOrgPage, error)
 	ListOrganizationMemberships(ctx context.Context, orgSlug string) ([]IdentityMembership, error)
-	ListOrganizationMembershipsLite(ctx context.Context, orgSlug string) ([]IdentityMembership, error)
+	// ListOrganizationMembershipsLite lists memberships without user hydration.
+	// Prefer org.ID (Appwrite team ID) when known — e.g. from ListOrganizationsPage —
+	// so slug≠team-ID orgs still resolve without an unpaged ListOrganizations fallback.
+	ListOrganizationMembershipsLite(ctx context.Context, org IdentityOrg) ([]IdentityMembership, error)
 	ListOrganizationUsers(ctx context.Context, orgSlug string) ([]IdentityUser, error)
 	GetOrganizationBySlug(ctx context.Context, slug string) (*IdentityOrg, error)
 	UpdateOrganization(ctx context.Context, sessionSecret, currentSlug, name, logoFileID string, roles []IdentityRole) (IdentityOrg, error)

--- a/server/cmd/server/identity.go
+++ b/server/cmd/server/identity.go
@@ -29,6 +29,7 @@ type IdentityStore interface {
 	InviteOrganizationUser(ctx context.Context, sessionSecret, orgSlug, email, redirectURL string, roleSlugs []string, isOrgAdmin bool) (IdentityMembership, error)
 	ListOrganizations(ctx context.Context) ([]IdentityOrg, error)
 	ListOrganizationMemberships(ctx context.Context, orgSlug string) ([]IdentityMembership, error)
+	ListOrganizationMembershipsLite(ctx context.Context, orgSlug string) ([]IdentityMembership, error)
 	ListOrganizationUsers(ctx context.Context, orgSlug string) ([]IdentityUser, error)
 	GetOrganizationBySlug(ctx context.Context, slug string) (*IdentityOrg, error)
 	UpdateOrganization(ctx context.Context, sessionSecret, currentSlug, name, logoFileID string, roles []IdentityRole) (IdentityOrg, error)

--- a/server/cmd/server/identity_appwrite.go
+++ b/server/cmd/server/identity_appwrite.go
@@ -507,21 +507,34 @@ func (a *appwriteIdentity) ListOrganizationMemberships(ctx context.Context, orgS
 // ListOrganizationMembershipsLite returns memberships decoded from the team membership
 // list only. IsOrgAdmin is derived from membership roles (owner / invite encoding), not
 // user labels. Callers that need label-accurate roles must use ListOrganizationMemberships.
-func (a *appwriteIdentity) ListOrganizationMembershipsLite(ctx context.Context, orgSlug string) ([]IdentityMembership, error) {
+//
+// When org.ID is set it is used as the Appwrite team ID directly (no slug lookup). That
+// matters for paged platform-admin catalogs where slug may differ from team ID and
+// GetOrganizationBySlug's ListOrganizations fallback is not exhaustive.
+func (a *appwriteIdentity) ListOrganizationMembershipsLite(ctx context.Context, org IdentityOrg) ([]IdentityMembership, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	org, err := a.GetOrganizationBySlug(ctx, orgSlug)
-	if err != nil {
-		return nil, err
+	resolved := org
+	teamID := strings.TrimSpace(org.ID)
+	if teamID == "" {
+		found, err := a.GetOrganizationBySlug(ctx, org.Slug)
+		if err != nil {
+			return nil, err
+		}
+		resolved = *found
+		teamID = strings.TrimSpace(resolved.ID)
 	}
-	membershipList, err := teams.New(a.adminClient).ListMemberships(strings.TrimSpace(org.ID))
+	if teamID == "" {
+		return nil, ErrIdentityNotFound
+	}
+	membershipList, err := teams.New(a.adminClient).ListMemberships(teamID)
 	if err != nil {
 		return nil, normalizeIdentityError(err)
 	}
 	memberships := make([]IdentityMembership, 0, len(membershipList.Memberships))
 	for i := range membershipList.Memberships {
-		memberships = append(memberships, membershipFromAppwrite(&membershipList.Memberships[i], org))
+		memberships = append(memberships, membershipFromAppwrite(&membershipList.Memberships[i], &resolved))
 	}
 	return memberships, nil
 }

--- a/server/cmd/server/identity_appwrite.go
+++ b/server/cmd/server/identity_appwrite.go
@@ -466,6 +466,28 @@ func (a *appwriteIdentity) ListOrganizationMemberships(ctx context.Context, orgS
 	return memberships, nil
 }
 
+// ListOrganizationMembershipsLite returns memberships decoded from the team membership
+// list only. IsOrgAdmin is derived from membership roles (owner / invite encoding), not
+// user labels. Callers that need label-accurate roles must use ListOrganizationMemberships.
+func (a *appwriteIdentity) ListOrganizationMembershipsLite(ctx context.Context, orgSlug string) ([]IdentityMembership, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	org, err := a.GetOrganizationBySlug(ctx, orgSlug)
+	if err != nil {
+		return nil, err
+	}
+	membershipList, err := teams.New(a.adminClient).ListMemberships(strings.TrimSpace(org.ID))
+	if err != nil {
+		return nil, normalizeIdentityError(err)
+	}
+	memberships := make([]IdentityMembership, 0, len(membershipList.Memberships))
+	for i := range membershipList.Memberships {
+		memberships = append(memberships, membershipFromAppwrite(&membershipList.Memberships[i], org))
+	}
+	return memberships, nil
+}
+
 func (a *appwriteIdentity) GetOrganizationBySlug(ctx context.Context, slug string) (*IdentityOrg, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -886,7 +908,7 @@ func (a *appwriteIdentity) getOrganizationByTeamID(ctx context.Context, teamID s
 	return &org, nil
 }
 
-func (a *appwriteIdentity) toIdentityMembership(ctx context.Context, membership *models.Membership, org *IdentityOrg) IdentityMembership {
+func membershipFromAppwrite(membership *models.Membership, org *IdentityOrg) IdentityMembership {
 	if membership == nil {
 		return IdentityMembership{}
 	}
@@ -910,6 +932,11 @@ func (a *appwriteIdentity) toIdentityMembership(ctx context.Context, membership 
 	if joinedAt, err := parseAppwriteTime(membership.Joined); err == nil {
 		identity.JoinedAt = joinedAt
 	}
+	return identity
+}
+
+func (a *appwriteIdentity) toIdentityMembership(ctx context.Context, membership *models.Membership, org *IdentityOrg) IdentityMembership {
+	identity := membershipFromAppwrite(membership, org)
 	if identity.UserID != "" {
 		if user, err := a.GetUserByID(ctx, identity.UserID); err == nil {
 			identity.Email = user.Email

--- a/server/cmd/server/identity_appwrite.go
+++ b/server/cmd/server/identity_appwrite.go
@@ -18,6 +18,7 @@ import (
 	appwritefile "github.com/appwrite/sdk-for-go/file"
 	"github.com/appwrite/sdk-for-go/id"
 	"github.com/appwrite/sdk-for-go/models"
+	"github.com/appwrite/sdk-for-go/query"
 	"github.com/appwrite/sdk-for-go/storage"
 	"github.com/appwrite/sdk-for-go/teams"
 	"github.com/appwrite/sdk-for-go/users"
@@ -401,6 +402,43 @@ func (a *appwriteIdentity) ListOrganizations(ctx context.Context) ([]IdentityOrg
 		return nil, err
 	}
 	return decodeIdentityOrgs(teamList), nil
+}
+
+func (a *appwriteIdentity) ListOrganizationsPage(ctx context.Context, opts IdentityOrgListOptions) (IdentityOrgPage, error) {
+	if err := ctx.Err(); err != nil {
+		return IdentityOrgPage{}, err
+	}
+	limit := opts.Limit
+	if limit < 1 {
+		limit = 12
+	}
+	offset := opts.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	queries := []string{
+		query.Limit(limit),
+		query.Offset(offset),
+		query.OrderAsc("name"),
+	}
+	options := []teams.ListOption{
+		teams.New(a.adminClient).WithListQueries(queries),
+		teams.New(a.adminClient).WithListTotal(true),
+	}
+	if search := strings.TrimSpace(opts.Search); search != "" {
+		options = append(options, teams.New(a.adminClient).WithListSearch(search))
+	}
+	teamList, err := teams.New(a.adminClient).List(options...)
+	if err != nil {
+		return IdentityOrgPage{}, normalizeIdentityError(err)
+	}
+	if err := ctx.Err(); err != nil {
+		return IdentityOrgPage{}, err
+	}
+	return IdentityOrgPage{
+		Organizations: decodeIdentityOrgs(teamList),
+		Total:         teamList.Total,
+	}, nil
 }
 
 func (a *appwriteIdentity) ListOrganizationUsers(ctx context.Context, orgSlug string) ([]IdentityUser, error) {

--- a/server/cmd/server/identity_appwrite_test.go
+++ b/server/cmd/server/identity_appwrite_test.go
@@ -2034,3 +2034,42 @@ func TestIdentityAppwriteNilAndErrorBranches(t *testing.T) {
 		t.Fatal("expected missing secret error")
 	}
 }
+
+func TestAppwriteIdentityListOrganizationsPagePassesLimitOffsetSearch(t *testing.T) {
+	var gotQueries []string
+	var gotSearch string
+	appwriteAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/v1/teams" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		gotSearch = r.URL.Query().Get("search")
+		gotQueries = r.URL.Query()["queries[]"]
+		if len(gotQueries) == 0 {
+			// SDK may encode as queries — accept either form used by sdk-for-go v1.0.0
+			gotQueries = r.URL.Query()["queries"]
+		}
+		_, _ = w.Write([]byte(`{"total":40,"teams":[{"$id":"acme","name":"Acme Org","prefs":{"schemaVersion":1,"slug":"acme"}}]}`))
+	}))
+	defer appwriteAPI.Close()
+
+	identity := NewAppwriteIdentity(appwriteAPI.URL+"/v1", "project-1", "api-key-1", appwriteAPI.Client())
+	page, err := identity.ListOrganizationsPage(context.Background(), IdentityOrgListOptions{
+		Search: "acme",
+		Limit:  12,
+		Offset: 24,
+	})
+	if err != nil {
+		t.Fatalf("ListOrganizationsPage error: %v", err)
+	}
+	if page.Total != 40 || len(page.Organizations) != 1 || page.Organizations[0].Slug != "acme" {
+		t.Fatalf("page = %#v", page)
+	}
+	if gotSearch != "acme" {
+		t.Fatalf("search = %q, want acme", gotSearch)
+	}
+	joined := strings.Join(gotQueries, ",")
+	if !strings.Contains(joined, "12") || !strings.Contains(joined, "24") {
+		t.Fatalf("queries = %#v (raw=%q), want limit 12 and offset 24", gotQueries, joined)
+	}
+}

--- a/server/cmd/server/identity_appwrite_test.go
+++ b/server/cmd/server/identity_appwrite_test.go
@@ -792,6 +792,46 @@ func TestAppwriteIdentityListOrganizationMembershipsPendingMembership(t *testing
 	}
 }
 
+func TestAppwriteIdentityListOrganizationMembershipsLiteSkipsUserHydration(t *testing.T) {
+	var userGETs int
+	appwriteAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/teams/acme":
+			_, _ = w.Write([]byte(`{"$id":"acme","name":"Acme Org","prefs":{"schemaVersion":1,"slug":"acme"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/teams/acme/memberships":
+			_, _ = w.Write([]byte(`{"total":2,"memberships":[
+				{"$id":"m1","userId":"user-1","userEmail":"owner@example.com","teamId":"acme","teamName":"Acme Org","confirm":true,"roles":["owner"]},
+				{"$id":"m2","userId":"user-2","userEmail":"member@example.com","teamId":"acme","teamName":"Acme Org","confirm":true,"roles":["member","iapprover"]}
+			]}`))
+		case strings.HasPrefix(r.URL.Path, "/v1/users/"):
+			userGETs++
+			t.Fatalf("lite list must not call users API: %s %s", r.Method, r.URL.Path)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer appwriteAPI.Close()
+
+	identity := NewAppwriteIdentity(appwriteAPI.URL+"/v1", "project-1", "api-key-1", appwriteAPI.Client())
+	memberships, err := identity.ListOrganizationMembershipsLite(context.Background(), "acme")
+	if err != nil {
+		t.Fatalf("ListOrganizationMembershipsLite error: %v", err)
+	}
+	if userGETs != 0 {
+		t.Fatalf("userGETs = %d, want 0", userGETs)
+	}
+	if len(memberships) != 2 {
+		t.Fatalf("memberships = %#v", memberships)
+	}
+	if !memberships[0].IsOrgAdmin || memberships[0].Email != "owner@example.com" || !memberships[0].Confirmed {
+		t.Fatalf("memberships[0] = %#v", memberships[0])
+	}
+	if memberships[1].IsOrgAdmin || memberships[1].Email != "member@example.com" {
+		t.Fatalf("memberships[1] = %#v", memberships[1])
+	}
+}
+
 func TestAppwriteIdentityCreateAccountAndRecovery(t *testing.T) {
 	var createPath string
 	var createBody map[string]interface{}

--- a/server/cmd/server/identity_appwrite_test.go
+++ b/server/cmd/server/identity_appwrite_test.go
@@ -797,13 +797,13 @@ func TestAppwriteIdentityListOrganizationMembershipsLiteSkipsUserHydration(t *te
 	appwriteAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/teams/acme":
-			_, _ = w.Write([]byte(`{"$id":"acme","name":"Acme Org","prefs":{"schemaVersion":1,"slug":"acme"}}`))
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/teams/acme/memberships":
 			_, _ = w.Write([]byte(`{"total":2,"memberships":[
 				{"$id":"m1","userId":"user-1","userEmail":"owner@example.com","teamId":"acme","teamName":"Acme Org","confirm":true,"roles":["owner"]},
 				{"$id":"m2","userId":"user-2","userEmail":"member@example.com","teamId":"acme","teamName":"Acme Org","confirm":true,"roles":["member","iapprover"]}
 			]}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/teams/acme":
+			t.Fatalf("lite list with team ID must not GET team by slug: %s", r.URL.Path)
 		case strings.HasPrefix(r.URL.Path, "/v1/users/"):
 			userGETs++
 			t.Fatalf("lite list must not call users API: %s %s", r.Method, r.URL.Path)
@@ -814,7 +814,7 @@ func TestAppwriteIdentityListOrganizationMembershipsLiteSkipsUserHydration(t *te
 	defer appwriteAPI.Close()
 
 	identity := NewAppwriteIdentity(appwriteAPI.URL+"/v1", "project-1", "api-key-1", appwriteAPI.Client())
-	memberships, err := identity.ListOrganizationMembershipsLite(context.Background(), "acme")
+	memberships, err := identity.ListOrganizationMembershipsLite(context.Background(), IdentityOrg{ID: "acme", Slug: "acme", Name: "Acme Org"})
 	if err != nil {
 		t.Fatalf("ListOrganizationMembershipsLite error: %v", err)
 	}
@@ -829,6 +829,38 @@ func TestAppwriteIdentityListOrganizationMembershipsLiteSkipsUserHydration(t *te
 	}
 	if memberships[1].IsOrgAdmin || memberships[1].Email != "member@example.com" {
 		t.Fatalf("memberships[1] = %#v", memberships[1])
+	}
+}
+
+func TestAppwriteIdentityListOrganizationMembershipsLiteUsesTeamIDWhenSlugDiffers(t *testing.T) {
+	appwriteAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/teams/hashed-team-id/memberships":
+			_, _ = w.Write([]byte(`{"total":1,"memberships":[
+				{"$id":"m1","userId":"user-1","userEmail":"owner@example.com","teamId":"hashed-team-id","teamName":"Renamed Org","confirm":true,"roles":["owner"]}
+			]}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/teams/renamed-org-slug":
+			t.Fatalf("must not look up by slug when team ID is provided")
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/teams":
+			t.Fatalf("must not fall back to ListOrganizations when team ID is provided")
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer appwriteAPI.Close()
+
+	identity := NewAppwriteIdentity(appwriteAPI.URL+"/v1", "project-1", "api-key-1", appwriteAPI.Client())
+	memberships, err := identity.ListOrganizationMembershipsLite(context.Background(), IdentityOrg{
+		ID:   "hashed-team-id",
+		Slug: "renamed-org-slug",
+		Name: "Renamed Org",
+	})
+	if err != nil {
+		t.Fatalf("ListOrganizationMembershipsLite error: %v", err)
+	}
+	if len(memberships) != 1 || memberships[0].Email != "owner@example.com" || !memberships[0].IsOrgAdmin {
+		t.Fatalf("memberships = %#v", memberships)
 	}
 }
 

--- a/server/cmd/server/identity_test_helpers_test.go
+++ b/server/cmd/server/identity_test_helpers_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"sort"
 	"strings"
 	"time"
 )
@@ -24,6 +25,7 @@ type fakeIdentityStore struct {
 	addOrganizationUserByIDAsAdminFunc      func(ctx context.Context, orgSlug, userID string, roleSlugs []string, isOrgAdmin bool) (IdentityMembership, error)
 	inviteOrganizationUserFunc              func(ctx context.Context, sessionSecret, orgSlug, email, redirectURL string, roleSlugs []string, isOrgAdmin bool) (IdentityMembership, error)
 	listOrganizationsFunc                   func(ctx context.Context) ([]IdentityOrg, error)
+	listOrganizationsPageFunc               func(ctx context.Context, opts IdentityOrgListOptions) (IdentityOrgPage, error)
 	listOrganizationMembershipsFunc         func(ctx context.Context, orgSlug string) ([]IdentityMembership, error)
 	listOrganizationMembershipsLiteFunc     func(ctx context.Context, orgSlug string) ([]IdentityMembership, error)
 	listOrganizationUsersFunc               func(ctx context.Context, orgSlug string) ([]IdentityUser, error)
@@ -158,6 +160,48 @@ func (f *fakeIdentityStore) ListOrganizations(ctx context.Context) ([]IdentityOr
 		return f.listOrganizationsFunc(ctx)
 	}
 	return nil, nil
+}
+
+func (f *fakeIdentityStore) ListOrganizationsPage(ctx context.Context, opts IdentityOrgListOptions) (IdentityOrgPage, error) {
+	if f.listOrganizationsPageFunc != nil {
+		return f.listOrganizationsPageFunc(ctx, opts)
+	}
+	orgs, err := f.ListOrganizations(ctx)
+	if err != nil {
+		return IdentityOrgPage{}, err
+	}
+	filtered := append([]IdentityOrg(nil), orgs...)
+	if q := strings.ToLower(strings.TrimSpace(opts.Search)); q != "" {
+		filtered = nil
+		for _, org := range orgs {
+			if strings.Contains(strings.ToLower(org.Name), q) {
+				filtered = append(filtered, org)
+			}
+		}
+	}
+	sort.Slice(filtered, func(i, j int) bool {
+		if filtered[i].Name != filtered[j].Name {
+			return filtered[i].Name < filtered[j].Name
+		}
+		return filtered[i].Slug < filtered[j].Slug
+	})
+	total := len(filtered)
+	limit := opts.Limit
+	if limit < 1 {
+		limit = 12
+	}
+	offset := opts.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > total {
+		offset = total
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+	return IdentityOrgPage{Organizations: append([]IdentityOrg(nil), filtered[offset:end]...), Total: total}, nil
 }
 
 func (f *fakeIdentityStore) ListOrganizationMemberships(ctx context.Context, orgSlug string) ([]IdentityMembership, error) {

--- a/server/cmd/server/identity_test_helpers_test.go
+++ b/server/cmd/server/identity_test_helpers_test.go
@@ -25,6 +25,7 @@ type fakeIdentityStore struct {
 	inviteOrganizationUserFunc              func(ctx context.Context, sessionSecret, orgSlug, email, redirectURL string, roleSlugs []string, isOrgAdmin bool) (IdentityMembership, error)
 	listOrganizationsFunc                   func(ctx context.Context) ([]IdentityOrg, error)
 	listOrganizationMembershipsFunc         func(ctx context.Context, orgSlug string) ([]IdentityMembership, error)
+	listOrganizationMembershipsLiteFunc     func(ctx context.Context, orgSlug string) ([]IdentityMembership, error)
 	listOrganizationUsersFunc               func(ctx context.Context, orgSlug string) ([]IdentityUser, error)
 	getOrganizationBySlugFunc               func(ctx context.Context, slug string) (*IdentityOrg, error)
 	updateOrganizationFunc                  func(ctx context.Context, sessionSecret, currentSlug, name, logoFileID string, roles []IdentityRole) (IdentityOrg, error)
@@ -164,6 +165,14 @@ func (f *fakeIdentityStore) ListOrganizationMemberships(ctx context.Context, org
 		return f.listOrganizationMembershipsFunc(ctx, orgSlug)
 	}
 	return nil, nil
+}
+
+func (f *fakeIdentityStore) ListOrganizationMembershipsLite(ctx context.Context, orgSlug string) ([]IdentityMembership, error) {
+	if f.listOrganizationMembershipsLiteFunc != nil {
+		return f.listOrganizationMembershipsLiteFunc(ctx, orgSlug)
+	}
+	// Default: reuse full list hook so existing fakes keep working when only listOrganizationMembershipsFunc is set.
+	return f.ListOrganizationMemberships(ctx, orgSlug)
 }
 
 func (f *fakeIdentityStore) ListOrganizationUsers(ctx context.Context, orgSlug string) ([]IdentityUser, error) {

--- a/server/cmd/server/identity_test_helpers_test.go
+++ b/server/cmd/server/identity_test_helpers_test.go
@@ -27,7 +27,7 @@ type fakeIdentityStore struct {
 	listOrganizationsFunc                   func(ctx context.Context) ([]IdentityOrg, error)
 	listOrganizationsPageFunc               func(ctx context.Context, opts IdentityOrgListOptions) (IdentityOrgPage, error)
 	listOrganizationMembershipsFunc         func(ctx context.Context, orgSlug string) ([]IdentityMembership, error)
-	listOrganizationMembershipsLiteFunc     func(ctx context.Context, orgSlug string) ([]IdentityMembership, error)
+	listOrganizationMembershipsLiteFunc     func(ctx context.Context, org IdentityOrg) ([]IdentityMembership, error)
 	listOrganizationUsersFunc               func(ctx context.Context, orgSlug string) ([]IdentityUser, error)
 	getOrganizationBySlugFunc               func(ctx context.Context, slug string) (*IdentityOrg, error)
 	updateOrganizationFunc                  func(ctx context.Context, sessionSecret, currentSlug, name, logoFileID string, roles []IdentityRole) (IdentityOrg, error)
@@ -211,12 +211,12 @@ func (f *fakeIdentityStore) ListOrganizationMemberships(ctx context.Context, org
 	return nil, nil
 }
 
-func (f *fakeIdentityStore) ListOrganizationMembershipsLite(ctx context.Context, orgSlug string) ([]IdentityMembership, error) {
+func (f *fakeIdentityStore) ListOrganizationMembershipsLite(ctx context.Context, org IdentityOrg) ([]IdentityMembership, error) {
 	if f.listOrganizationMembershipsLiteFunc != nil {
-		return f.listOrganizationMembershipsLiteFunc(ctx, orgSlug)
+		return f.listOrganizationMembershipsLiteFunc(ctx, org)
 	}
 	// Default: reuse full list hook so existing fakes keep working when only listOrganizationMembershipsFunc is set.
-	return f.ListOrganizationMemberships(ctx, orgSlug)
+	return f.ListOrganizationMemberships(ctx, org.Slug)
 }
 
 func (f *fakeIdentityStore) ListOrganizationUsers(ctx context.Context, orgSlug string) ([]IdentityUser, error) {

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -3275,26 +3275,32 @@ func redirectPlatformAdminWithMessage(w http.ResponseWriter, r *http.Request, qu
 var errPlatformAdminInviteCrossOrg = errors.New("platform admin invite email belongs to another organization")
 
 func platformAdminOrganizationRows(ctx context.Context, organizations []Organization, identity IdentityStore) []PlatformAdminOrganizationRow {
-	rows := make([]PlatformAdminOrganizationRow, 0, len(organizations))
-	for _, organization := range organizations {
-		row := PlatformAdminOrganizationRow{
-			Name:             organization.Name,
-			Slug:             organization.Slug,
-			LogoAttachmentID: organization.LogoAttachmentID,
-		}
-		if identity != nil && strings.TrimSpace(organization.Slug) != "" {
-			memberships, err := identity.ListOrganizationMembershipsLite(ctx, organization.Slug)
-			if err != nil {
-				log.Printf("failed to list organization memberships for %s: %v", organization.Slug, err)
-			} else {
-				row.OrgAdminEmails, row.PendingOrgAdminEmails = summarizePlatformOrgAdminMemberships(
-					filterPlatformOrgAdminMemberships(memberships),
-				)
+	rows := make([]PlatformAdminOrganizationRow, len(organizations))
+	var wg sync.WaitGroup
+	for i, organization := range organizations {
+		wg.Add(1)
+		go func(i int, organization Organization) {
+			defer wg.Done()
+			row := PlatformAdminOrganizationRow{
+				Name:             organization.Name,
+				Slug:             organization.Slug,
+				LogoAttachmentID: organization.LogoAttachmentID,
 			}
-		}
-		row.OrgAdminStatus, row.OrgAdminStatusClassName = platformOrgAdminStatus(row.OrgAdminEmails, row.PendingOrgAdminEmails)
-		rows = append(rows, row)
+			if identity != nil && strings.TrimSpace(organization.Slug) != "" {
+				memberships, err := identity.ListOrganizationMembershipsLite(ctx, organization.Slug)
+				if err != nil {
+					log.Printf("failed to list organization memberships for %s: %v", organization.Slug, err)
+				} else {
+					row.OrgAdminEmails, row.PendingOrgAdminEmails = summarizePlatformOrgAdminMemberships(
+						filterPlatformOrgAdminMemberships(memberships),
+					)
+				}
+			}
+			row.OrgAdminStatus, row.OrgAdminStatusClassName = platformOrgAdminStatus(row.OrgAdminEmails, row.PendingOrgAdminEmails)
+			rows[i] = row
+		}(i, organization)
 	}
+	wg.Wait()
 	return rows
 }
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -3274,20 +3274,20 @@ func redirectPlatformAdminWithMessage(w http.ResponseWriter, r *http.Request, qu
 
 var errPlatformAdminInviteCrossOrg = errors.New("platform admin invite email belongs to another organization")
 
-func platformAdminOrganizationRows(ctx context.Context, organizations []Organization, identity IdentityStore) []PlatformAdminOrganizationRow {
+func platformAdminOrganizationRows(ctx context.Context, organizations []IdentityOrg, identity IdentityStore) []PlatformAdminOrganizationRow {
 	rows := make([]PlatformAdminOrganizationRow, len(organizations))
 	var wg sync.WaitGroup
 	for i, organization := range organizations {
 		wg.Add(1)
-		go func(i int, organization Organization) {
+		go func(i int, organization IdentityOrg) {
 			defer wg.Done()
 			row := PlatformAdminOrganizationRow{
 				Name:             organization.Name,
 				Slug:             organization.Slug,
-				LogoAttachmentID: organization.LogoAttachmentID,
+				LogoAttachmentID: strings.TrimSpace(organization.LogoFileID),
 			}
-			if identity != nil && strings.TrimSpace(organization.Slug) != "" {
-				memberships, err := identity.ListOrganizationMembershipsLite(ctx, organization.Slug)
+			if identity != nil && (strings.TrimSpace(organization.ID) != "" || strings.TrimSpace(organization.Slug) != "") {
+				memberships, err := identity.ListOrganizationMembershipsLite(ctx, organization)
 				if err != nil {
 					log.Printf("failed to list organization memberships for %s: %v", organization.Slug, err)
 				} else {
@@ -3439,11 +3439,6 @@ func (s *Server) platformAdminView(user *AccountUser, confirmation string, errs 
 		}
 	}
 
-	organizations := make([]Organization, 0, len(orgPage.Organizations))
-	for _, org := range orgPage.Organizations {
-		organizations = append(organizations, organizationFromIdentityOrg(org))
-	}
-
 	totalPages := 1
 	if orgPage.Total > 0 {
 		totalPages = (orgPage.Total + limit - 1) / limit
@@ -3452,7 +3447,7 @@ func (s *Server) platformAdminView(user *AccountUser, confirmation string, errs 
 	for page := 1; page <= totalPages; page++ {
 		pageNumbers = append(pageNumbers, page)
 	}
-	rows := platformAdminOrganizationRows(context.Background(), organizations, s.identity)
+	rows := platformAdminOrganizationRows(context.Background(), orgPage.Organizations, s.identity)
 	view := PlatformAdminView{
 		PageBase:                 s.pageBaseForUser(user, "platform_admin_body", "", ""),
 		ActivePanel:              "orgs",

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -3283,7 +3283,7 @@ func platformAdminOrganizationRows(ctx context.Context, organizations []Organiza
 			LogoAttachmentID: organization.LogoAttachmentID,
 		}
 		if identity != nil && strings.TrimSpace(organization.Slug) != "" {
-			memberships, err := identity.ListOrganizationMemberships(ctx, organization.Slug)
+			memberships, err := identity.ListOrganizationMembershipsLite(ctx, organization.Slug)
 			if err != nil {
 				log.Printf("failed to list organization memberships for %s: %v", organization.Slug, err)
 			} else {

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -3287,13 +3287,26 @@ func platformAdminOrganizationRows(ctx context.Context, organizations []Organiza
 			if err != nil {
 				log.Printf("failed to list organization memberships for %s: %v", organization.Slug, err)
 			} else {
-				row.OrgAdminEmails, row.PendingOrgAdminEmails = summarizePlatformOrgAdminMemberships(memberships)
+				row.OrgAdminEmails, row.PendingOrgAdminEmails = summarizePlatformOrgAdminMemberships(
+					filterPlatformOrgAdminMemberships(memberships),
+				)
 			}
 		}
 		row.OrgAdminStatus, row.OrgAdminStatusClassName = platformOrgAdminStatus(row.OrgAdminEmails, row.PendingOrgAdminEmails)
 		rows = append(rows, row)
 	}
 	return rows
+}
+
+func filterPlatformOrgAdminMemberships(memberships []IdentityMembership) []IdentityMembership {
+	out := make([]IdentityMembership, 0, len(memberships))
+	for _, membership := range memberships {
+		if !membership.IsOrgAdmin {
+			continue
+		}
+		out = append(out, membership)
+	}
+	return out
 }
 
 func summarizePlatformOrgAdminMemberships(memberships []IdentityMembership) ([]string, []string) {

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -3403,26 +3403,56 @@ func (s *Server) platformAdminView(user *AccountUser, confirmation string, errs 
 	errs.InviteEmail = strings.TrimSpace(errs.InviteEmail)
 	errs.SearchQuery = strings.TrimSpace(errs.SearchQuery)
 
-	organizations := s.platformOrganizations(context.Background())
-	filteredOrganizations := filterPlatformOrganizations(organizations, errs.SearchQuery)
-	currentPage := normalizePlatformAdminPage(errs.Page, len(filteredOrganizations))
-	start := (currentPage - 1) * platformAdminOrganizationsPerPage
-	end := min(start+platformAdminOrganizationsPerPage, len(filteredOrganizations))
-	pagedOrganizations := filteredOrganizations
-	if start < len(filteredOrganizations) {
-		pagedOrganizations = filteredOrganizations[start:end]
-	} else if len(filteredOrganizations) > 0 {
-		pagedOrganizations = filteredOrganizations[:0]
+	limit := platformAdminOrganizationsPerPage
+	requestedPage := errs.Page
+	if requestedPage < 1 {
+		requestedPage = 1
 	}
+	offset := (requestedPage - 1) * limit
+
+	orgPage := IdentityOrgPage{}
+	if s.identity != nil {
+		var err error
+		orgPage, err = s.identity.ListOrganizationsPage(context.Background(), IdentityOrgListOptions{
+			Search: errs.SearchQuery,
+			Limit:  limit,
+			Offset: offset,
+		})
+		if err != nil {
+			log.Printf("failed to list platform organizations page: %v", err)
+			orgPage = IdentityOrgPage{}
+		}
+	}
+
+	currentPage := normalizePlatformAdminPage(requestedPage, orgPage.Total)
+	if currentPage != requestedPage && s.identity != nil {
+		offset = (currentPage - 1) * limit
+		var err error
+		orgPage, err = s.identity.ListOrganizationsPage(context.Background(), IdentityOrgListOptions{
+			Search: errs.SearchQuery,
+			Limit:  limit,
+			Offset: offset,
+		})
+		if err != nil {
+			log.Printf("failed to list platform organizations page: %v", err)
+			orgPage = IdentityOrgPage{}
+		}
+	}
+
+	organizations := make([]Organization, 0, len(orgPage.Organizations))
+	for _, org := range orgPage.Organizations {
+		organizations = append(organizations, organizationFromIdentityOrg(org))
+	}
+
 	totalPages := 1
-	if len(filteredOrganizations) > 0 {
-		totalPages = (len(filteredOrganizations) + platformAdminOrganizationsPerPage - 1) / platformAdminOrganizationsPerPage
+	if orgPage.Total > 0 {
+		totalPages = (orgPage.Total + limit - 1) / limit
 	}
 	pageNumbers := make([]int, 0, totalPages)
 	for page := 1; page <= totalPages; page++ {
 		pageNumbers = append(pageNumbers, page)
 	}
-	rows := platformAdminOrganizationRows(context.Background(), pagedOrganizations, s.identity)
+	rows := platformAdminOrganizationRows(context.Background(), organizations, s.identity)
 	view := PlatformAdminView{
 		PageBase:                 s.pageBaseForUser(user, "platform_admin_body", "", ""),
 		ActivePanel:              "orgs",
@@ -3435,7 +3465,7 @@ func (s *Server) platformAdminView(user *AccountUser, confirmation string, errs 
 		HasNextPage:              currentPage < totalPages,
 		PreviousPage:             max(currentPage-1, 1),
 		NextPage:                 min(currentPage+1, totalPages),
-		MatchedOrganizations:     len(filteredOrganizations),
+		MatchedOrganizations:     orgPage.Total,
 		Organizations:            rows,
 		Confirmation:             strings.TrimSpace(confirmation),
 		OrganizationError:        errs.Organization,

--- a/server/cmd/server/platform_admin_orgs_perf_test.go
+++ b/server/cmd/server/platform_admin_orgs_perf_test.go
@@ -107,3 +107,29 @@ func TestFilterPlatformOrgAdminMembershipsDropsNonAdmins(t *testing.T) {
 		t.Fatalf("got = %#v", got)
 	}
 }
+
+func TestPlatformAdminViewUsesOrganizationPageTotal(t *testing.T) {
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "change-me")
+	identity := &fakeIdentityStore{
+		listOrganizationsPageFunc: func(ctx context.Context, opts IdentityOrgListOptions) (IdentityOrgPage, error) {
+			if opts.Limit != 12 || opts.Offset != 12 || opts.Search != "ac" {
+				t.Fatalf("opts = %#v", opts)
+			}
+			return IdentityOrgPage{
+				Total: 25,
+				Organizations: []IdentityOrg{
+					{ID: "t13", Slug: "org-13", Name: "Org 13"},
+				},
+			}, nil
+		},
+		listOrganizationMembershipsLiteFunc: func(ctx context.Context, orgSlug string) ([]IdentityMembership, error) {
+			return nil, nil
+		},
+	}
+	server := &Server{identity: identity, authorizer: fakeAuthorizer{}}
+	view := server.platformAdminView(&AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "", PlatformAdminErrors{SearchQuery: "ac", Page: 2})
+	if view.MatchedOrganizations != 25 || view.TotalPages != 3 || view.CurrentPage != 2 || len(view.Organizations) != 1 {
+		t.Fatalf("view paging = matched=%d pages=%d page=%d rows=%d", view.MatchedOrganizations, view.TotalPages, view.CurrentPage, len(view.Organizations))
+	}
+}

--- a/server/cmd/server/platform_admin_orgs_perf_test.go
+++ b/server/cmd/server/platform_admin_orgs_perf_test.go
@@ -34,9 +34,9 @@ func TestPlatformAdminViewDoesNotCallHydratedMembershipList(t *testing.T) {
 			t.Fatalf("platform admin view must not call ListOrganizationMemberships (%s)", orgSlug)
 			return nil, nil
 		},
-		listOrganizationMembershipsLiteFunc: func(ctx context.Context, orgSlug string) ([]IdentityMembership, error) {
+		listOrganizationMembershipsLiteFunc: func(ctx context.Context, org IdentityOrg) ([]IdentityMembership, error) {
 			liteCalls.Add(1)
-			switch orgSlug {
+			switch org.Slug {
 			case "accepted":
 				return []IdentityMembership{
 					{Email: "admin@example.com", Confirmed: true, IsOrgAdmin: true},
@@ -78,17 +78,17 @@ func TestPlatformAdminViewDoesNotCallHydratedMembershipList(t *testing.T) {
 func TestPlatformAdminOrganizationRowsPreservesOrderUnderParallelFetch(t *testing.T) {
 	var calls atomic.Int64
 	identity := &fakeIdentityStore{
-		listOrganizationMembershipsLiteFunc: func(ctx context.Context, orgSlug string) ([]IdentityMembership, error) {
+		listOrganizationMembershipsLiteFunc: func(ctx context.Context, org IdentityOrg) ([]IdentityMembership, error) {
 			n := calls.Add(1)
-			// Stagger later orgs so unordered append would scramble results.
-			if orgSlug == "a" {
+			// Stagger org "a" so unordered append would scramble results.
+			if org.Slug == "a" {
 				time.Sleep(30 * time.Millisecond)
 			}
 			_ = n
-			return []IdentityMembership{{Email: orgSlug + "-owner@example.com", IsOrgAdmin: true, Confirmed: true}}, nil
+			return []IdentityMembership{{Email: org.Slug + "-owner@example.com", IsOrgAdmin: true, Confirmed: true}}, nil
 		},
 	}
-	orgs := []Organization{{Slug: "a", Name: "A"}, {Slug: "b", Name: "B"}, {Slug: "c", Name: "C"}}
+	orgs := []IdentityOrg{{Slug: "a", Name: "A"}, {Slug: "b", Name: "B"}, {Slug: "c", Name: "C"}}
 	rows := platformAdminOrganizationRows(context.Background(), orgs, identity)
 	if len(rows) != 3 || rows[0].Slug != "a" || rows[1].Slug != "b" || rows[2].Slug != "c" {
 		t.Fatalf("rows = %#v", rows)
@@ -149,8 +149,7 @@ func TestPlatformAdminViewAppwriteCallCeiling(t *testing.T) {
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"total": membersPerOrg, "memberships": memberships})
 		case strings.HasPrefix(path, "/v1/teams/"):
-			teamID := strings.TrimPrefix(path, "/v1/teams/")
-			_ = json.NewEncoder(w).Encode(map[string]any{"$id": teamID, "name": teamID, "prefs": map[string]any{"schemaVersion": 1, "slug": teamID}})
+			t.Fatalf("unexpected team GET (lite path should use paged team ID): %s", path)
 		case strings.HasPrefix(path, "/v1/users/"):
 			userRequests.Add(1)
 			t.Fatalf("unexpected user hydration: %s", path)
@@ -164,12 +163,12 @@ func TestPlatformAdminViewAppwriteCallCeiling(t *testing.T) {
 	server := &Server{identity: identity, authorizer: fakeAuthorizer{}}
 	_ = server.platformAdminView(&AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "", PlatformAdminErrors{})
 
-	// 1 list page + ≤12 get team + 12 list memberships = ≤25 (no user calls)
+	// 1 list page + 12 list memberships by team ID = 13 (no slug GETs, no user calls)
 	if userRequests.Load() != 0 {
 		t.Fatalf("userRequests = %d", userRequests.Load())
 	}
-	if total := totalRequests.Load(); total > 25 {
-		t.Fatalf("totalRequests = %d, want ≤ 25", total)
+	if total := totalRequests.Load(); total > 13 {
+		t.Fatalf("totalRequests = %d, want ≤ 13", total)
 	}
 }
 
@@ -188,7 +187,7 @@ func TestPlatformAdminViewUsesOrganizationPageTotal(t *testing.T) {
 				},
 			}, nil
 		},
-		listOrganizationMembershipsLiteFunc: func(ctx context.Context, orgSlug string) ([]IdentityMembership, error) {
+		listOrganizationMembershipsLiteFunc: func(ctx context.Context, org IdentityOrg) ([]IdentityMembership, error) {
 			return nil, nil
 		},
 	}
@@ -196,5 +195,49 @@ func TestPlatformAdminViewUsesOrganizationPageTotal(t *testing.T) {
 	view := server.platformAdminView(&AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "", PlatformAdminErrors{SearchQuery: "ac", Page: 2})
 	if view.MatchedOrganizations != 25 || view.TotalPages != 3 || view.CurrentPage != 2 || len(view.Organizations) != 1 {
 		t.Fatalf("view paging = matched=%d pages=%d page=%d rows=%d", view.MatchedOrganizations, view.TotalPages, view.CurrentPage, len(view.Organizations))
+	}
+}
+
+func TestPlatformAdminViewPassesPagedTeamIDToLiteMemberships(t *testing.T) {
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "change-me")
+
+	var seenTeamID string
+	identity := &fakeIdentityStore{
+		listOrganizationsPageFunc: func(ctx context.Context, opts IdentityOrgListOptions) (IdentityOrgPage, error) {
+			return IdentityOrgPage{
+				Total: 1,
+				Organizations: []IdentityOrg{
+					{ID: "hashed-team-id", Slug: "renamed-org-slug", Name: "Renamed Org", LogoFileID: "logo-1"},
+				},
+			}, nil
+		},
+		getOrganizationBySlugFunc: func(ctx context.Context, slug string) (*IdentityOrg, error) {
+			t.Fatalf("must not resolve by slug when paged team ID is known (%s)", slug)
+			return nil, ErrIdentityNotFound
+		},
+		listOrganizationMembershipsLiteFunc: func(ctx context.Context, org IdentityOrg) ([]IdentityMembership, error) {
+			seenTeamID = org.ID
+			if org.ID != "hashed-team-id" || org.Slug != "renamed-org-slug" {
+				t.Fatalf("org = %#v", org)
+			}
+			return []IdentityMembership{
+				{Email: "owner@example.com", Confirmed: true, IsOrgAdmin: true},
+			}, nil
+		},
+	}
+	server := &Server{identity: identity, authorizer: fakeAuthorizer{}}
+	view := server.platformAdminView(&AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "", PlatformAdminErrors{})
+	if seenTeamID != "hashed-team-id" {
+		t.Fatalf("seenTeamID = %q", seenTeamID)
+	}
+	if len(view.Organizations) != 1 || view.Organizations[0].Slug != "renamed-org-slug" {
+		t.Fatalf("rows = %#v", view.Organizations)
+	}
+	if view.Organizations[0].OrgAdminStatus != "At least one org admin accepted" {
+		t.Fatalf("status = %q", view.Organizations[0].OrgAdminStatus)
+	}
+	if view.Organizations[0].LogoAttachmentID != "logo-1" {
+		t.Fatalf("logo = %q", view.Organizations[0].LogoAttachmentID)
 	}
 }

--- a/server/cmd/server/platform_admin_orgs_perf_test.go
+++ b/server/cmd/server/platform_admin_orgs_perf_test.go
@@ -2,6 +2,11 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -105,6 +110,66 @@ func TestFilterPlatformOrgAdminMembershipsDropsNonAdmins(t *testing.T) {
 	}
 	if got[0].Email != "owner@example.com" || got[1].Email != "pending@example.com" {
 		t.Fatalf("got = %#v", got)
+	}
+}
+
+func TestPlatformAdminViewAppwriteCallCeiling(t *testing.T) {
+	const orgCount = 12
+	const membersPerOrg = 8
+	var totalRequests atomic.Int64
+	var userRequests atomic.Int64
+
+	appwriteAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		totalRequests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+		switch {
+		case path == "/v1/teams":
+			teamsPayload := make([]map[string]any, 0, orgCount)
+			for i := 0; i < orgCount; i++ {
+				id := fmt.Sprintf("org-%d", i)
+				teamsPayload = append(teamsPayload, map[string]any{
+					"$id": id, "name": fmt.Sprintf("Org %d", i),
+					"prefs": map[string]any{"schemaVersion": 1, "slug": id},
+				})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"total": orgCount, "teams": teamsPayload})
+		case strings.HasSuffix(path, "/memberships") && strings.HasPrefix(path, "/v1/teams/"):
+			teamID := strings.TrimSuffix(strings.TrimPrefix(path, "/v1/teams/"), "/memberships")
+			teamID = strings.TrimSuffix(teamID, "/")
+			memberships := make([]map[string]any, 0, membersPerOrg)
+			for m := 0; m < membersPerOrg; m++ {
+				memberships = append(memberships, map[string]any{
+					"$id": fmt.Sprintf("%s-m-%d", teamID, m),
+					"userId": fmt.Sprintf("%s-u-%d", teamID, m),
+					"userEmail": fmt.Sprintf("u%d@%s.example", m, teamID),
+					"teamId": teamID, "teamName": teamID, "confirm": true,
+					"roles": []string{"member"},
+				})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"total": membersPerOrg, "memberships": memberships})
+		case strings.HasPrefix(path, "/v1/teams/"):
+			teamID := strings.TrimPrefix(path, "/v1/teams/")
+			_ = json.NewEncoder(w).Encode(map[string]any{"$id": teamID, "name": teamID, "prefs": map[string]any{"schemaVersion": 1, "slug": teamID}})
+		case strings.HasPrefix(path, "/v1/users/"):
+			userRequests.Add(1)
+			t.Fatalf("unexpected user hydration: %s", path)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, path)
+		}
+	}))
+	defer appwriteAPI.Close()
+
+	identity := NewAppwriteIdentity(appwriteAPI.URL+"/v1", "project-1", "api-key-1", appwriteAPI.Client())
+	server := &Server{identity: identity, authorizer: fakeAuthorizer{}}
+	_ = server.platformAdminView(&AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "", PlatformAdminErrors{})
+
+	// 1 list page + ≤12 get team + 12 list memberships = ≤25 (no user calls)
+	if userRequests.Load() != 0 {
+		t.Fatalf("userRequests = %d", userRequests.Load())
+	}
+	if total := totalRequests.Load(); total > 25 {
+		t.Fatalf("totalRequests = %d, want ≤ 25", total)
 	}
 }
 

--- a/server/cmd/server/platform_admin_orgs_perf_test.go
+++ b/server/cmd/server/platform_admin_orgs_perf_test.go
@@ -68,3 +68,18 @@ func TestPlatformAdminViewDoesNotCallHydratedMembershipList(t *testing.T) {
 		t.Fatalf("missing status = %q", view.Organizations[1].OrgAdminStatus)
 	}
 }
+
+func TestFilterPlatformOrgAdminMembershipsDropsNonAdmins(t *testing.T) {
+	in := []IdentityMembership{
+		{Email: "owner@example.com", IsOrgAdmin: true, Confirmed: true},
+		{Email: "member@example.com", IsOrgAdmin: false, Confirmed: true},
+		{Email: "pending@example.com", IsOrgAdmin: true, Confirmed: false},
+	}
+	got := filterPlatformOrgAdminMemberships(in)
+	if len(got) != 2 {
+		t.Fatalf("got = %#v", got)
+	}
+	if got[0].Email != "owner@example.com" || got[1].Email != "pending@example.com" {
+		t.Fatalf("got = %#v", got)
+	}
+}

--- a/server/cmd/server/platform_admin_orgs_perf_test.go
+++ b/server/cmd/server/platform_admin_orgs_perf_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+)
+
+func TestPlatformAdminViewDoesNotCallHydratedMembershipList(t *testing.T) {
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "change-me")
+
+	var hydratedCalls atomic.Int64
+	var liteCalls atomic.Int64
+
+	orgs := []IdentityOrg{
+		{ID: "team-1", Slug: "accepted", Name: "Accepted Org"},
+		{ID: "team-2", Slug: "pending", Name: "Pending Org"},
+		{ID: "team-3", Slug: "missing", Name: "Missing Org"},
+	}
+
+	identity := &fakeIdentityStore{
+		listOrganizationsFunc: func(ctx context.Context) ([]IdentityOrg, error) {
+			return orgs, nil
+		},
+		listOrganizationMembershipsFunc: func(ctx context.Context, orgSlug string) ([]IdentityMembership, error) {
+			hydratedCalls.Add(1)
+			t.Fatalf("platform admin view must not call ListOrganizationMemberships (%s)", orgSlug)
+			return nil, nil
+		},
+		listOrganizationMembershipsLiteFunc: func(ctx context.Context, orgSlug string) ([]IdentityMembership, error) {
+			liteCalls.Add(1)
+			switch orgSlug {
+			case "accepted":
+				return []IdentityMembership{
+					{Email: "admin@example.com", Confirmed: true, IsOrgAdmin: true},
+					{Email: "owner@example.com", Confirmed: true, IsOrgAdmin: true},
+				}, nil
+			case "pending":
+				return []IdentityMembership{
+					{Email: "pending-owner@example.com", Confirmed: false, IsOrgAdmin: true},
+				}, nil
+			default:
+				return nil, nil
+			}
+		},
+	}
+
+	server := &Server{identity: identity, authorizer: fakeAuthorizer{}}
+	view := server.platformAdminView(&AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "", PlatformAdminErrors{})
+
+	if hydratedCalls.Load() != 0 {
+		t.Fatalf("hydratedCalls = %d", hydratedCalls.Load())
+	}
+	if liteCalls.Load() != 3 {
+		t.Fatalf("liteCalls = %d, want 3", liteCalls.Load())
+	}
+	if len(view.Organizations) != 3 {
+		t.Fatalf("organizations = %#v", view.Organizations)
+	}
+	if view.Organizations[0].OrgAdminStatus != "At least one org admin accepted" {
+		t.Fatalf("accepted status = %q", view.Organizations[0].OrgAdminStatus)
+	}
+	if view.Organizations[2].OrgAdminStatus != "All org admin invites pending" {
+		t.Fatalf("pending status = %q", view.Organizations[2].OrgAdminStatus)
+	}
+	if view.Organizations[1].OrgAdminStatus != "No org admin" {
+		t.Fatalf("missing status = %q", view.Organizations[1].OrgAdminStatus)
+	}
+}

--- a/server/cmd/server/platform_admin_orgs_perf_test.go
+++ b/server/cmd/server/platform_admin_orgs_perf_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestPlatformAdminViewDoesNotCallHydratedMembershipList(t *testing.T) {
@@ -66,6 +67,29 @@ func TestPlatformAdminViewDoesNotCallHydratedMembershipList(t *testing.T) {
 	}
 	if view.Organizations[1].OrgAdminStatus != "No org admin" {
 		t.Fatalf("missing status = %q", view.Organizations[1].OrgAdminStatus)
+	}
+}
+
+func TestPlatformAdminOrganizationRowsPreservesOrderUnderParallelFetch(t *testing.T) {
+	var calls atomic.Int64
+	identity := &fakeIdentityStore{
+		listOrganizationMembershipsLiteFunc: func(ctx context.Context, orgSlug string) ([]IdentityMembership, error) {
+			n := calls.Add(1)
+			// Stagger later orgs so unordered append would scramble results.
+			if orgSlug == "a" {
+				time.Sleep(30 * time.Millisecond)
+			}
+			_ = n
+			return []IdentityMembership{{Email: orgSlug + "-owner@example.com", IsOrgAdmin: true, Confirmed: true}}, nil
+		},
+	}
+	orgs := []Organization{{Slug: "a", Name: "A"}, {Slug: "b", Name: "B"}, {Slug: "c", Name: "C"}}
+	rows := platformAdminOrganizationRows(context.Background(), orgs, identity)
+	if len(rows) != 3 || rows[0].Slug != "a" || rows[1].Slug != "b" || rows[2].Slug != "c" {
+		t.Fatalf("rows = %#v", rows)
+	}
+	if rows[0].OrgAdminEmails[0] != "a-owner@example.com" || rows[2].OrgAdminEmails[0] != "c-owner@example.com" {
+		t.Fatalf("emails = %#v", rows)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `ListOrganizationMembershipsLite` (membership roles only — no per-member `GetUserByID` hydration) and wire `/admin/orgs` rows to it
- Filter to org-admin memberships early, fetch per-org memberships in parallel, and page teams via Appwrite `ListOrganizationsPage` (limit/offset/search) instead of list-all-then-slice
- Lock regression: 12 orgs × 8 members stays ≤25 Appwrite HTTP calls with 0 `/v1/users` hydrations (was ~313)

## Test plan
- [ ] `cd server && go test -count=1 ./cmd/server/ -run 'TestPlatformAdmin|TestAppwriteIdentityListOrganizationMembershipsLite|TestAppwriteIdentityListOrganizationsPage|TestFilterPlatformOrgAdmin'`
- [ ] Log in as platform admin, open `/admin/orgs` — page should load quickly with org-admin status chips still correct
- [ ] Search + pagination still work; create/invite org admin still works
- [ ] Note: org search now uses Appwrite `WithListSearch` (may differ slightly from previous substring-on-name filter)


Made with [Cursor](https://cursor.com)