### PR TITLE
feat: redesign /my home as accessible streams catalog

### DIFF
--- a/docs/superpowers/plans/2026-07-31-my-home-catalog.md
+++ b/docs/superpowers/plans/2026-07-31-my-home-catalog.md
@@ -1,0 +1,685 @@
+# `/my` accessible streams catalog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace authenticated `/my` stream picker with a taxonomy-grouped catalog of accessible streams using public result headers + `public_stream_card` (optional management menu), header Create CTA, and a shared empty-state component.
+
+**Architecture:** Pure access filter + grouping builders feed a rewritten `home_picker_body`. Cards reuse `buildPublicStreamCardView` with `Href` overridden to `streamPath(key)+"/"`. Management actions live in a shell around the public card. Empty state is extracted as CSS-only `empty-state` and shared with public stream runs empty.
+
+**Tech Stack:** Go `net/http` + `html/template`, existing taxonomy/public-home CSS classes, Vite CSS modules, Go unit tests (`go test`).
+
+**Spec:** `docs/superpowers/specs/2026-07-31-my-home-catalog-design.md`
+
+## Global Constraints
+
+- Access: platform admin → all catalog streams; org admin (`userIsOrgAdmin`) → streams whose `organizations` include user’s `OrgSlug`; else org + matching workflow role for that org.
+- No sidebar / no HTMX listing on `/my`; stack non-empty taxonomy groups then Uncategorized.
+- Card click → `/my/streams/:key/` (`streamPath(key)+"/"`); public `/` cards stay on `/streams/:key`.
+- No `publicHomeStreamCardLimit` on `/my`.
+- Create stream only in `page-header-actions` when `canViewFormataBuilder`; not inside empty state.
+- Empty: CSS-only `empty-state` extracted from `public-stream-runs-empty`; `/my` uses home-specific title/hint.
+- Follow `docs/css.md` + `.agents/skills/attesta-ui-components`.
+- Work in worktree `.worktrees/feat/my-home-catalog` on branch `feat/my-home-catalog`.
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `server/cmd/server/my_home_access.go` | `userCanAccessStream(user, cfg) bool` |
+| `server/cmd/server/my_home_access_test.go` | Access matrix unit tests |
+| `server/cmd/server/my_home.go` | Grouping + home catalog builders; wire helpers used by `handleHome` |
+| `server/cmd/server/my_home_test.go` | Grouping / builder unit tests |
+| `server/cmd/server/components.go` | `ManagedPublicStreamCardView`, `MyHomeStreamGroupView`; extend home page view fields if needed |
+| `server/cmd/server/main.go` | Update `HomeWorkflowPickerView` / `handleHome`; optionally thin `workflowOptions` if still needed elsewhere |
+| `server/cmd/server/home_handler_test.go` | Rewrite picker stubs/assertions for new `/my` markup + access |
+| `server/templates/pages/home.html` | New `home_picker_body` |
+| `server/templates/components/public_home_stream_group.html` | Shared group: category/subcategory headers + card grid |
+| `server/templates/components/public_home_stream_results.html` | Call shared group for single leaf (keep id wrapper + empty CTA for `/`) |
+| `server/templates/components/managed_public_stream_card.html` | Shell: menu + dialogs + `public_stream_card` |
+| `server/templates/components/public_stream_card.html` | Unchanged core (called from shell / public home) |
+| `server/templates/pages/public_stream.html` | Switch runs empty to `empty-state` classes |
+| `web/src/styles/components/empty-state.css` | CSS-only empty-state contract |
+| `web/src/styles/pages/public-stream.css` | Remove duplicated empty rules (or thin aliases if needed briefly) |
+| `web/src/styles/components/public-stream-card.css` | Shell/menu positioning for managed cards |
+| `web/src/styles/pages/home.css` | Light catalog stack spacing if needed |
+| `web/src/styles/components.css` | Import `empty-state.css` |
+
+---
+
+### Task 1: Access filter
+
+**Files:**
+- Create: `server/cmd/server/my_home_access.go`
+- Create: `server/cmd/server/my_home_access_test.go`
+
+**Interfaces:**
+- Produces: `func userCanAccessStream(user *AccountUser, cfg RuntimeConfig) bool`
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+package main
+
+import "testing"
+
+func TestUserCanAccessStream(t *testing.T) {
+	cfg := RuntimeConfig{
+		Organizations: []WorkflowOrganization{{Slug: "acme", Name: "Acme"}},
+		Roles: []WorkflowRole{
+			{OrgSlug: "acme", Slug: "operator", Name: "Operator"},
+			{OrgSlug: "other", Slug: "reviewer", Name: "Reviewer"},
+		},
+	}
+	otherOrgCfg := RuntimeConfig{
+		Organizations: []WorkflowOrganization{{Slug: "other", Name: "Other"}},
+		Roles:         []WorkflowRole{{OrgSlug: "other", Slug: "reviewer", Name: "Reviewer"}},
+	}
+
+	cases := []struct {
+		name string
+		user *AccountUser
+		cfg  RuntimeConfig
+		want bool
+	}{
+		{
+			name: "platform admin sees all",
+			user: &AccountUser{IsPlatformAdmin: true},
+			cfg:  otherOrgCfg,
+			want: true,
+		},
+		{
+			name: "org admin sees org streams without workflow role",
+			user: &AccountUser{OrgSlug: "acme", RoleSlugs: []string{"org-admin"}},
+			cfg:  cfg,
+			want: true,
+		},
+		{
+			name: "org admin does not see other org streams",
+			user: &AccountUser{OrgSlug: "acme", RoleSlugs: []string{"org-admin"}},
+			cfg:  otherOrgCfg,
+			want: false,
+		},
+		{
+			name: "role member matching org+role",
+			user: &AccountUser{OrgSlug: "acme", RoleSlugs: []string{"operator"}},
+			cfg:  cfg,
+			want: true,
+		},
+		{
+			name: "role member wrong role",
+			user: &AccountUser{OrgSlug: "acme", RoleSlugs: []string{"reviewer"}},
+			cfg:  cfg,
+			want: false,
+		},
+		{
+			name: "outsider",
+			user: &AccountUser{OrgSlug: "stranger", RoleSlugs: []string{"operator"}},
+			cfg:  cfg,
+			want: false,
+		},
+		{
+			name: "nil user",
+			user: nil,
+			cfg:  cfg,
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := userCanAccessStream(tc.user, tc.cfg); got != tc.want {
+				t.Fatalf("userCanAccessStream = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && go test ./cmd/server/ -run TestUserCanAccessStream -count=1`
+
+Expected: FAIL (`userCanAccessStream` undefined)
+
+- [ ] **Step 3: Implement**
+
+```go
+package main
+
+import "strings"
+
+func userCanAccessStream(user *AccountUser, cfg RuntimeConfig) bool {
+	if user == nil {
+		return false
+	}
+	if user.IsPlatformAdmin {
+		return true
+	}
+	org := strings.TrimSpace(user.OrgSlug)
+	if org == "" {
+		return false
+	}
+	participates := false
+	for _, o := range cfg.Organizations {
+		if strings.TrimSpace(o.Slug) == org {
+			participates = true
+			break
+		}
+	}
+	if !participates {
+		return false
+	}
+	if userIsOrgAdmin(user) {
+		return true
+	}
+	for _, role := range cfg.Roles {
+		if strings.TrimSpace(role.OrgSlug) != org {
+			continue
+		}
+		if containsRole(user.RoleSlugs, strings.TrimSpace(role.Slug)) {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `cd server && go test ./cmd/server/ -run TestUserCanAccessStream -count=1`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/cmd/server/my_home_access.go server/cmd/server/my_home_access_test.go
+git commit -m "feat(my): add stream access filter for /my catalog"
+```
+
+---
+
+### Task 2: Grouping builder + view types
+
+**Files:**
+- Modify: `server/cmd/server/components.go`
+- Create: `server/cmd/server/my_home.go`
+- Create: `server/cmd/server/my_home_test.go`
+
+**Interfaces:**
+- Consumes: `userCanAccessStream`, `TaxonomyCategoryNode`, `RuntimeConfig.Workflow.CategorySlug/SubCategorySlug`, `IsCategorized()`
+- Produces:
+  - `ManagedPublicStreamCardView` (embeds card + management fields)
+  - `MyHomeStreamGroupView`
+  - `func buildMyHomeStreamGroups(categories []TaxonomyCategoryNode, cardsByKey map[string]ManagedPublicStreamCardView, catalog map[string]RuntimeConfig, accessibleKeys []string) []MyHomeStreamGroupView`
+
+Add to `components.go`:
+
+```go
+// ManagedPublicStreamCardView wraps a public stream card with optional /my management actions.
+type ManagedPublicStreamCardView struct {
+	Card              PublicStreamCardView
+	Key               string
+	CanClone          bool
+	CanEdit           bool
+	EditAction        string
+	EditRequiresPurge bool
+	CanDelete         bool
+	DeleteAction      string
+}
+
+// MyHomeStreamGroupView is one taxonomy (or Uncategorized) block on /my.
+type MyHomeStreamGroupView struct {
+	CategoryName           string
+	CategoryIconURL        string
+	SubCategoryName        string
+	SubCategoryIconURL     string
+	SubCategoryDescription string
+	Uncategorized          bool
+	Streams                []ManagedPublicStreamCardView
+}
+```
+
+Grouping algorithm in `my_home.go`:
+1. Index accessible keys → cards.
+2. Walk taxonomy categories/subs in order; for each leaf, collect keys where `cfg.Workflow` matches both slugs; if any, append group with taxonomy names/icons/description.
+3. Collect remaining accessible keys (uncategorized or unknown path) → final group with `Uncategorized: true`, `CategoryName: "Uncategorized"`.
+4. Within each group, preserve `accessibleKeys` order (caller passes `sortedWorkflowKeys` filtered).
+
+- [ ] **Step 1: Write failing grouping tests**
+
+```go
+func TestBuildMyHomeStreamGroupsOrdersTaxonomyAndUncategorized(t *testing.T) {
+	categories := []TaxonomyCategoryNode{
+		{
+			Slug: "supply-chain", Name: "Supply Chain", IconURL: "/c.svg", SortOrder: 1,
+			SubCategories: []TaxonomySubCategoryNode{
+				{Slug: "procurement", Name: "Procurement", Description: "PO", IconURL: "/s.svg", SortOrder: 1},
+				{Slug: "order-fulfillment", Name: "Order Fulfillment", SortOrder: 2},
+			},
+		},
+	}
+	catalog := map[string]RuntimeConfig{
+		"a": {Workflow: WorkflowDef{Name: "A", CategorySlug: "supply-chain", SubCategorySlug: "order-fulfillment"}},
+		"b": {Workflow: WorkflowDef{Name: "B", CategorySlug: "supply-chain", SubCategorySlug: "procurement"}},
+		"c": {Workflow: WorkflowDef{Name: "C"}}, // uncategorized
+	}
+	cards := map[string]ManagedPublicStreamCardView{
+		"a": {Key: "a", Card: PublicStreamCardView{Name: "A"}},
+		"b": {Key: "b", Card: PublicStreamCardView{Name: "B"}},
+		"c": {Key: "c", Card: PublicStreamCardView{Name: "C"}},
+	}
+	groups := buildMyHomeStreamGroups(categories, cards, catalog, []string{"a", "b", "c"})
+	if len(groups) != 3 {
+		t.Fatalf("len(groups)=%d want 3", len(groups))
+	}
+	if groups[0].SubCategoryName != "Procurement" || groups[0].Streams[0].Key != "b" {
+		t.Fatalf("first group = %+v", groups[0])
+	}
+	if groups[1].SubCategoryName != "Order Fulfillment" || groups[1].Streams[0].Key != "a" {
+		t.Fatalf("second group = %+v", groups[1])
+	}
+	if !groups[2].Uncategorized || groups[2].CategoryName != "Uncategorized" || groups[2].Streams[0].Key != "c" {
+		t.Fatalf("uncategorized = %+v", groups[2])
+	}
+}
+
+func TestBuildMyHomeStreamGroupsSkipsEmptyLeaves(t *testing.T) {
+	categories := []TaxonomyCategoryNode{{
+		Slug: "supply-chain", Name: "Supply Chain",
+		SubCategories: []TaxonomySubCategoryNode{
+			{Slug: "procurement", Name: "Procurement"},
+			{Slug: "order-fulfillment", Name: "Order Fulfillment"},
+		},
+	}}
+	catalog := map[string]RuntimeConfig{
+		"b": {Workflow: WorkflowDef{CategorySlug: "supply-chain", SubCategorySlug: "procurement"}},
+	}
+	cards := map[string]ManagedPublicStreamCardView{"b": {Key: "b"}}
+	groups := buildMyHomeStreamGroups(categories, cards, catalog, []string{"b"})
+	if len(groups) != 1 || groups[0].SubCategoryName != "Procurement" {
+		t.Fatalf("got %+v", groups)
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `cd server && go test ./cmd/server/ -run TestBuildMyHomeStreamGroups -count=1`
+
+- [ ] **Step 3: Implement types + `buildMyHomeStreamGroups`**
+
+- [ ] **Step 4: Run — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/cmd/server/components.go server/cmd/server/my_home.go server/cmd/server/my_home_test.go
+git commit -m "feat(my): group accessible streams by taxonomy for /my"
+```
+
+---
+
+### Task 3: Extract CSS-only `empty-state`
+
+**Files:**
+- Create: `web/src/styles/components/empty-state.css`
+- Modify: `web/src/styles/components.css`
+- Modify: `web/src/styles/pages/public-stream.css` (remove `.public-stream-runs-empty*` rules)
+- Modify: `server/templates/pages/public_stream.html` (markup classes)
+
+**Interfaces:**
+- Produces CSS-only contract (no Go DTO):
+
+```
+div.empty-state
+  (icon svg)
+  p.empty-state-title
+  p.empty-state-hint
+```
+
+- [ ] **Step 1: Add `empty-state.css` with markup-tree header** (copy visual rules from `.public-stream-runs-empty*`, rename to `.empty-state*`)
+
+```css
+/*
+ * Empty state — centered dashed placeholder (CSS-only).
+ *
+ * div.empty-state
+ *   (optional .icon-svg)
+ *   p.empty-state-title
+ *   p.empty-state-hint
+ */
+```
+
+Import in `components.css` after `toast.css` (or near other chrome primitives).
+
+- [ ] **Step 2: Update public stream template**
+
+Replace:
+
+```html
+<div class="public-stream-runs-empty">
+  {{ template "icon-layers-2" . }}
+  <p class="public-stream-runs-empty-title">No completed runs yet</p>
+  <p class="public-stream-runs-empty-hint">
+    Finished runs with a DPP will appear here.
+  </p>
+</div>
+```
+
+with:
+
+```html
+<div class="empty-state">
+  {{ template "icon-layers-2" . }}
+  <p class="empty-state-title">No completed runs yet</p>
+  <p class="empty-state-hint">
+    Finished runs with a DPP will appear here.
+  </p>
+</div>
+```
+
+Delete old CSS rules from `public-stream.css`; update the file’s tree comment.
+
+- [ ] **Step 3: Grep for leftover `public-stream-runs-empty`**
+
+Run: `rg public-stream-runs-empty web server`
+
+Expected: no matches (or only plan/spec mentions)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/styles/components/empty-state.css web/src/styles/components.css web/src/styles/pages/public-stream.css server/templates/pages/public_stream.html
+git commit -m "refactor(ui): extract shared empty-state CSS component"
+```
+
+---
+
+### Task 4: Managed public stream card shell
+
+**Files:**
+- Create: `server/templates/components/managed_public_stream_card.html`
+- Modify: `web/src/styles/components/public-stream-card.css` (shell + menu)
+- Create or modify: `server/cmd/server/public_stream_card_test.go` (add managed shell tests) — or `managed_public_stream_card_test.go`
+
+**Interfaces:**
+- Consumes: `ManagedPublicStreamCardView`
+- Produces: template define `managed_public_stream_card`
+
+Shell structure (menu/dialogs outside the card link):
+
+```html
+{{ define "managed_public_stream_card" }}
+<div class="public-stream-card-shell">
+  {{ if .CanClone }}
+    <details class="public-stream-card-menu">
+      <!-- same menu items as stream_card: Clone / Edit / Delete -->
+    </details>
+  {{ end }}
+  {{ template "public_stream_card" .Card }}
+  <!-- edit-purge + delete dialogs copied from stream_card, keyed by .Key -->
+</div>
+{{ end }}
+```
+
+Show the ellipsis when `CanClone || CanEdit || CanDelete` (today’s card gated menu on `CanClone`; preserve that behavior: menu when `CanClone`, disabled edit/delete items as today).
+
+CSS: `.public-stream-card-shell { position: relative; }` absolute menu top-right; ensure `details` summary does not sit inside the `<a>`.
+
+- [ ] **Step 1: Failing template test**
+
+```go
+func TestManagedPublicStreamCardRendersMenuAndMyHref(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+	var out bytes.Buffer
+	view := ManagedPublicStreamCardView{
+		Key:      "wf-a",
+		CanClone: true,
+		CanEdit:  true,
+		EditAction: "/my/organization/formata-builder?stream=wf-a",
+		CanDelete: true,
+		DeleteAction: "/my/streams/wf-a/delete",
+		Card: PublicStreamCardView{
+			Name: "Alpha",
+			Href: "/my/streams/wf-a/",
+		},
+	}
+	if err := tmpl.ExecuteTemplate(&out, "managed_public_stream_card", view); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := out.String()
+	for _, want := range []string{
+		`href="/my/streams/wf-a/"`,
+		`class="public-stream-card-shell"`,
+		"Clone",
+		`id="delete-workflow-wf-a"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("missing %q in %s", want, body)
+		}
+	}
+}
+
+func TestManagedPublicStreamCardHidesMenuWithoutClone(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+	var out bytes.Buffer
+	view := ManagedPublicStreamCardView{
+		Key:  "wf-a",
+		Card: PublicStreamCardView{Name: "Alpha", Href: "/my/streams/wf-a/"},
+	}
+	if err := tmpl.ExecuteTemplate(&out, "managed_public_stream_card", view); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if strings.Contains(out.String(), "public-stream-card-menu") {
+		t.Fatalf("menu should be absent: %s", out.String())
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (undefined template)
+
+- [ ] **Step 3: Implement template + CSS**
+
+- [ ] **Step 4: Run — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/templates/components/managed_public_stream_card.html web/src/styles/components/public-stream-card.css server/cmd/server/managed_public_stream_card_test.go
+git commit -m "feat(ui): add managed public stream card shell for /my"
+```
+
+---
+
+### Task 5: Shared group partial + rewrite `/my` body
+
+**Files:**
+- Create: `server/templates/components/public_home_stream_group.html`
+- Modify: `server/templates/components/public_home_stream_results.html`
+- Modify: `server/templates/pages/home.html`
+- Modify: `web/src/styles/pages/home.css` (optional stack gap)
+- Modify: `server/cmd/server/main.go` types for home view fields (`Groups`, `ShowCreateStream`)
+- Modify: `server/cmd/server/test_helpers_test.go` stubs if stub layouts break
+
+**Interfaces:**
+- `public_home_stream_group` accepts either:
+  - public results fields (`PublicHomeStreamResultsView` subset), **or**
+  - `MyHomeStreamGroupView` with `Streams` as `[]ManagedPublicStreamCardView`
+
+Prefer **two thin defines** to avoid type friction:
+
+1. `public_home_stream_group` — headers + `range .Streams` calling `public_stream_card` (for `/`)
+2. `my_home_stream_group` — same headers; `range .Streams` calling `managed_public_stream_card`; if `.Uncategorized`, only category header “Uncategorized” (no subcategory header)
+
+Refactor `public_home_stream_results` to keep `#public-home-stream-results` wrapper, empty CTA for `/`, and call `public_home_stream_group` for the headers+grid when streams present.
+
+`home_picker_body`:
+
+```html
+{{ define "home_picker_body" }}
+<section class="stack u-max-w-7xl u-mx-auto my-home">
+  <section class="page-header">
+    <div class="page-header-head">
+      <div class="page-header-body">
+        <h1>Choose a stream</h1>
+        <p>Select a stream to start or continue process tracking</p>
+      </div>
+      {{ if .ShowCreateStream }}
+      <div class="page-header-actions">
+        <a class="btn btn-primary" href="/my/organization/formata-builder">
+          {{ template "icon-plus" . }} Create a stream
+        </a>
+      </div>
+      {{ end }}
+    </div>
+  </section>
+  {{ if .Confirmation }}<p class="confirmation">{{ .Confirmation }}</p>{{ end }}
+  {{ template "error_banner.html" . }}
+  {{ if .Groups }}
+    <div class="my-home-catalog">
+      {{ range .Groups }}
+        {{ template "my_home_stream_group" . }}
+      {{ end }}
+    </div>
+  {{ else }}
+    <div class="empty-state">
+      {{ template "icon-layers-2" . }}
+      <p class="empty-state-title">No streams available</p>
+      <p class="empty-state-hint">Streams for your organization and roles will appear here.</p>
+    </div>
+  {{ end }}
+</section>
+{{ end }}
+```
+
+Update `HomeWorkflowPickerView` / `WorkflowPickerView`:
+
+```go
+type HomeWorkflowPickerView struct {
+	PageBase
+	Groups          []MyHomeStreamGroupView
+	ShowCreateStream bool
+	Error           string
+	Confirmation    string
+}
+```
+
+Remove `/my` dependency on `Workflows` / `ShowCreateStreamCard` once tests are updated (Task 6–7). Keep `WorkflowPickerView` only if still used elsewhere; otherwise delete dead fields carefully.
+
+- [ ] **Step 1: Template unit test for `my_home_stream_group` headers + empty home body**
+
+- [ ] **Step 2: Implement templates; keep public home tests green**
+
+Run: `cd server && go test ./cmd/server/ -run 'TestHandlePublicHome|TestPublicHome|TestBuildPublicHome' -count=1`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/templates/pages/home.html server/templates/components/public_home_stream_group.html server/templates/components/public_home_stream_results.html server/templates/components/my_home_stream_group.html web/src/styles/pages/home.css server/cmd/server/main.go
+git commit -m "feat(my): render taxonomy-grouped catalog markup on /my"
+```
+
+---
+
+### Task 6: Wire `handleHome` builder
+
+**Files:**
+- Modify: `server/cmd/server/my_home.go` (add `buildMyHomeCatalog` on `*Server`)
+- Modify: `server/cmd/server/main.go` (`handleHome`)
+
+**Interfaces:**
+- Produces: `func (s *Server) buildMyHomeCatalog(ctx context.Context, user *AccountUser) ([]MyHomeStreamGroupView, error)`
+- Management flags: reuse the same rules as `workflowOptions` (Formata `canViewFormataBuilder` → `CanClone`; Cerbos edit/delete; `EditAction`/`DeleteAction` paths). Prefer extracting a small `streamManagementFlags(...)` helper from `workflowOptions` to avoid drift; if extract is large, duplicate the permission block once with a comment pointing at `workflowOptions`.
+
+Builder steps:
+1. `catalog, err := s.workflowCatalog()`
+2. `categories, err := loadTaxonomyTree(ctx, s.store)`
+3. `logoURLs := organizationLogoURLMap(ctx, s.identity)`
+4. Filter `sortedWorkflowKeys` with `userCanAccessStream`
+5. For each key: `buildPublicStreamCardView` then `card.Href = streamPath(key) + "/"`; attach management flags into `ManagedPublicStreamCardView`
+6. `return buildMyHomeStreamGroups(...)`
+
+`handleHome`:
+
+```go
+groups, err := s.buildMyHomeCatalog(r.Context(), user)
+// ...
+showCreate, authErr := s.canViewFormataBuilder(r.Context(), user)
+view := HomeWorkflowPickerView{
+  PageBase: s.pageBaseForUser(user, "home_picker_body", "", ""),
+  Groups: groups,
+  ShowCreateStream: showCreate && authErr == nil && showCreate,
+  Error: homePickerMessage(r, "error"),
+  Confirmation: homePickerMessage(r, "confirmation"),
+}
+```
+
+(Use the same error-log pattern as today when Cerbos check fails for create.)
+
+- [ ] **Step 1: Failing handler test** (auth user with role sees only matching stream; href `/my/streams/.../`; create in header)
+
+Use real `parseTestTemplates` + seeded taxonomy + categorized YAML (patterns from `public_home_test.go` / `home_handler_test.go`).
+
+- [ ] **Step 2: Implement builder + wire handler**
+
+- [ ] **Step 3: Run focused tests — PASS**
+
+Run: `cd server && go test ./cmd/server/ -run 'TestUserCanAccessStream|TestBuildMyHomeStreamGroups|TestHandleHome' -count=1`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/cmd/server/my_home.go server/cmd/server/main.go server/cmd/server/home_handler_test.go
+git commit -m "feat(my): wire accessible catalog into handleHome"
+```
+
+---
+
+### Task 7: Update legacy home picker tests + cleanup
+
+**Files:**
+- Modify: `server/cmd/server/home_handler_test.go` (replace `homePickerTemplates` stubs and assertions that expect `PICK N` / `stream-card` / create-card CTA)
+- Modify: any other tests referencing `WorkflowPickerView.Workflows` on `/my`
+- Delete unused `stream_card_create` usage from `/my` only; keep `stream_card.html` if still referenced; delete create define only if unused
+
+Checklist of tests to rewrite (from current file):
+- `TestHandleHomeRendersWorkflowPicker` → assert groups/empty via stub or real templates
+- `TestHandleHomePickerCreateStreamCardVisibility` → assert header Create link / absence (`ShowCreateStream`), not `stream-card-cta`
+- `TestHandleHomePickerRendersWorkflowCardsAndScopedLinks` → `/my/streams/.../` on public card href
+- `TestHandleHomePickerDeleteButtonVisibility` → managed menu/delete dialog
+- Count/turn-indicator tests: either drop turn indicator (not on public card) **or** keep out of scope — **do not** reintroduce turn bell unless spec asks (spec does not). Update tests to drop `HasUserTurn` expectations on `/my`.
+- Update `homePickerTemplates()` stub to print groups/keys if still used for fast tests
+
+- [ ] **Step 1: Fix failing suite under `TestHandleHome*`**
+
+Run: `cd server && go test ./cmd/server/ -run 'TestHandleHome|TestManagedPublic|TestUserCanAccess|TestBuildMyHome' -count=1`
+
+- [ ] **Step 2: Broader regression**
+
+Run: `cd server && go test ./cmd/server/ -count=1`
+
+Expected: PASS except known pre-existing OpenAPI docs 404 failures (`TestHandleDocsRoutes`, `TestServeOpenAPIFileRewritesServerToRequestOrigin`) — do not “fix” those in this plan.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/cmd/server/home_handler_test.go server/templates/components/stream_card.html
+git commit -m "test(my): align /my home tests with accessible catalog"
+```
+
+---
+
+## Self-review (plan vs spec)
+
+| Spec requirement | Task |
+|------------------|------|
+| Access rules (platform / org admin / role) | Task 1 + 6 |
+| No sidebar; stacked category/subcategory headers | Tasks 2, 5 |
+| Uncategorized group | Task 2 |
+| `public_stream_card` + management menu | Task 4 |
+| Href `/my/streams/:key/` | Tasks 4, 6 |
+| Create in page-header-actions | Task 5–6 |
+| Empty-state extraction + `/my` empty | Tasks 3, 5 |
+| No 6-card cap | Task 2/6 (no limit applied) |
+| Tests: access, grouping, markup | Tasks 1, 2, 4, 6, 7 |
+| Public `/` unchanged aside from shared group/empty extract | Tasks 3, 5 |
+
+No TBD placeholders. Types consistent: `ManagedPublicStreamCardView`, `MyHomeStreamGroupView`, `userCanAccessStream`, `buildMyHomeStreamGroups`, `buildMyHomeCatalog`.

--- a/docs/superpowers/plans/2026-07-31-my-home-category-sidebar-anchors.md
+++ b/docs/superpowers/plans/2026-07-31-my-home-category-sidebar-anchors.md
@@ -1,0 +1,1045 @@
+# `/my` category sidebar anchors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract a shared thin-full `category_sidebar` component, use it on public `/` (HTMX leaves unchanged) and on `/my` (accessible-only anchor leaves + section ids), with a CSS-only `nav-drawer` for mobile.
+
+**Architecture:** Rename today’s public-home sidebar DTOs into `CategorySidebar*` views. One template dispatches leaf markup on `Href` vs `PartialURL`. `/my` derives the sidebar from existing catalog groups, wraps each group in `section#AnchorID`, and docks the same sidebar DOM node in a two-column grid (desktop) or popover drawer (mobile).
+
+**Tech Stack:** Go `net/http` + `html/template`, Vite CSS modules, Popover API (no app JS), Go unit/template tests.
+
+**Spec:** `docs/superpowers/specs/2026-07-31-my-home-category-sidebar-anchors-design.md`
+
+## Global Constraints
+
+- `/my` leaves are anchors only (`href="#cat-…"`); category rows stay `<details>`/`<summary>` (not links).
+- `/my` sidebar lists only categories/subcategories with ≥1 accessible stream; Uncategorized = synthetic category with one leaf → `#cat-uncategorized`.
+- `/my` layout: two columns inside `u-max-w-7xl` / `.my-home`; same page background — no public-home full-bleed split band.
+- Desktop (`md`+): sidebar docked; hamburger hidden. Mobile: hamburger + left `nav-drawer`. **One** sidebar DOM instance.
+- No scroll-spy. No new JS modules for drawer open/close.
+- Public `/` HTMX filter semantics, URLs, and selection resolution unchanged.
+- Follow `docs/css.md` + `.agents/skills/attesta-ui-components`.
+- Work in `.worktrees/feat/my-home-catalog` on branch `feat/my-home-catalog`.
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `server/cmd/server/components.go` | `CategorySidebarView`, `CategorySidebarCategoryView`, `CategorySidebarLeafView`; extend `MyHomeStreamGroupView` with slugs/`AnchorID`; optionally `ShowCategoryHeader` |
+| `server/templates/components/category_sidebar.html` | Shared sidebar template |
+| `web/src/styles/components/category-sidebar.css` | `.category-sidebar-*` tree styles (moved from public-home) |
+| `web/src/styles/components/nav-drawer.css` | CSS-only drawer shell contract |
+| `web/src/styles/components.css` | Import new component CSS |
+| `server/cmd/server/public_home.go` | `buildPublicHomeCategories` → returns `CategorySidebarView` (HTMX leaves) |
+| `server/templates/pages/public_home.html` | Call `category_sidebar` |
+| `web/src/styles/pages/public-home.css` | Keep split-band layout; drop moved tree rules; target `.category-sidebar` |
+| `server/cmd/server/my_home.go` | Fill `AnchorID`/slugs on groups; `buildMyHomeCategorySidebar(groups)` |
+| `server/templates/components/my_home_stream_group.html` | Wrap leaf block in `<section id="{{ .AnchorID }}">` |
+| `server/templates/pages/home.html` | Grid + nav-drawer markup + sidebar |
+| `web/src/styles/pages/home.css` | `/my` grid, scroll-margin, desktop popover override, transparent sidebar band |
+| `server/cmd/server/main.go` | `HomeWorkflowPickerView.Sidebar`; `handleHome` fills it |
+| `server/cmd/server/category_sidebar_test.go` | Template leaf-mode tests |
+| `server/cmd/server/my_home_test.go` / `my_home_stream_group_test.go` / `home_handler_test.go` / `public_home_test.go` | Update assertions |
+
+---
+
+### Task 1: `CategorySidebar*` types + template leaf dispatch
+
+**Files:**
+- Modify: `server/cmd/server/components.go`
+- Create: `server/templates/components/category_sidebar.html`
+- Create: `server/cmd/server/category_sidebar_test.go`
+
+**Interfaces:**
+- Produces:
+  - `type CategorySidebarLeafView struct { Slug, Name string; Active bool; Href, PartialURL, PushURL string }`
+  - `type CategorySidebarCategoryView struct { Slug, Name, IconURL string; Expanded bool; SubCategories []CategorySidebarLeafView }`
+  - `type CategorySidebarView struct { Title string; Categories []CategorySidebarCategoryView }`
+- Consumes: none
+
+- [ ] **Step 1: Write failing template tests**
+
+```go
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCategorySidebarTemplateHTMXLeaf(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+	var out bytes.Buffer
+	view := CategorySidebarView{
+		Title: "Stream Categories",
+		Categories: []CategorySidebarCategoryView{{
+			Slug: "supply-chain", Name: "Supply Chain", IconURL: "/c.svg", Expanded: true,
+			SubCategories: []CategorySidebarLeafView{{
+				Slug: "procurement", Name: "Procurement", Active: true,
+				PartialURL: "/streams/public?category=supply-chain&subCategory=procurement",
+				PushURL:    "/?category=supply-chain&subCategory=procurement",
+			}},
+		}},
+	}
+	if err := tmpl.ExecuteTemplate(&out, "category_sidebar", view); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := out.String()
+	for _, want := range []string{
+		`class="category-sidebar"`,
+		`class="category-sidebar-title">Stream Categories<`,
+		`hx-get="/streams/public?category=supply-chain&amp;subCategory=procurement"`,
+		`hx-push-url="/?category=supply-chain&amp;subCategory=procurement"`,
+		`is-active`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("missing %q in %s", want, body)
+		}
+	}
+	if strings.Contains(body, `href="#`) {
+		t.Fatalf("HTMX leaf must not use href anchor, got %s", body)
+	}
+}
+
+func TestCategorySidebarTemplateAnchorLeaf(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+	var out bytes.Buffer
+	view := CategorySidebarView{
+		Title: "Stream Categories",
+		Categories: []CategorySidebarCategoryView{{
+			Slug: "supply-chain", Name: "Supply Chain", Expanded: true,
+			SubCategories: []CategorySidebarLeafView{{
+				Slug: "procurement", Name: "Procurement",
+				Href: "#cat-supply-chain--procurement",
+			}},
+		}},
+	}
+	if err := tmpl.ExecuteTemplate(&out, "category_sidebar", view); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := out.String()
+	if !strings.Contains(body, `href="#cat-supply-chain--procurement"`) {
+		t.Fatalf("missing anchor href, got %s", body)
+	}
+	if strings.Contains(body, "hx-get=") || strings.Contains(body, "<button") {
+		t.Fatalf("anchor leaf must not render HTMX button, got %s", body)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests — expect FAIL** (types/template missing)
+
+```bash
+cd server && go test ./cmd/server/ -run 'TestCategorySidebarTemplate' -count=1
+```
+
+Expected: FAIL (undefined types and/or missing template).
+
+- [ ] **Step 3: Add types in `components.go`**
+
+Replace `PublicHomeSubCategoryView` / `PublicHomeCategoryView` with:
+
+```go
+// CategorySidebarLeafView is one subcategory row in category_sidebar.
+// If Href is set, render an anchor; otherwise render an HTMX button using PartialURL/PushURL.
+type CategorySidebarLeafView struct {
+	Slug       string
+	Name       string
+	Active     bool
+	Href       string // /my anchors, e.g. #cat-supply-chain--procurement
+	PartialURL string // public home HTMX get
+	PushURL    string // public home hx-push-url
+}
+
+// CategorySidebarCategoryView is one accordion category in category_sidebar.
+type CategorySidebarCategoryView struct {
+	Slug          string
+	Name          string
+	IconURL       string
+	Expanded      bool
+	SubCategories []CategorySidebarLeafView
+}
+
+// CategorySidebarView is the root for templates/components/category_sidebar.html.
+type CategorySidebarView struct {
+	Title      string
+	Categories []CategorySidebarCategoryView
+}
+```
+
+Prefer a clean rename in the same commit as Task 2 if compile breaks mid-way; do not leave permanent aliases.
+
+- [ ] **Step 4: Add `category_sidebar.html`**
+
+```html
+{{ define "category_sidebar" }}
+<aside class="category-sidebar" aria-label="Stream categories" data-landing-category-sidebar>
+  <div class="category-sidebar-header">
+    {{ template "icon-layout-grid" . }}
+    <p class="category-sidebar-title">{{ .Title }}</p>
+  </div>
+  <div class="category-sidebar-list">
+    {{ range .Categories }}
+      <details class="category-sidebar-category" {{ if .Expanded }}open{{ end }} data-category-slug="{{ .Slug }}">
+        <summary class="category-sidebar-category-summary">
+          <span class="category-sidebar-category-label">
+            {{ if .IconURL }}
+              <img class="category-sidebar-category-icon" src="{{ .IconURL }}" alt="" width="20" height="20" />
+            {{ end }}
+            <span>{{ .Name }}</span>
+          </span>
+          <span class="category-sidebar-category-chevron" aria-hidden="true">
+            {{ template "icon-chevron-right" }}
+          </span>
+        </summary>
+        <div class="category-sidebar-subcategories">
+          {{ range .SubCategories }}
+            {{ if .Href }}
+              <a
+                class="category-sidebar-subcategory{{ if .Active }} is-active{{ end }}"
+                href="{{ .Href }}"
+                data-subcategory-slug="{{ .Slug }}"
+              >{{ .Name }}</a>
+            {{ else }}
+              <button
+                type="button"
+                class="category-sidebar-subcategory{{ if .Active }} is-active{{ end }}"
+                data-subcategory-slug="{{ .Slug }}"
+                hx-get="{{ .PartialURL }}"
+                hx-target="#public-home-stream-results"
+                hx-swap="outerHTML"
+                hx-push-url="{{ .PushURL }}"
+              >{{ .Name }}</button>
+            {{ end }}
+          {{ end }}
+        </div>
+      </details>
+    {{ else }}
+      <p class="category-sidebar-empty">No categories yet.</p>
+    {{ end }}
+  </div>
+</aside>
+{{ end }}
+```
+
+Keep `data-landing-category-sidebar` on the aside for any existing selectors that look for it.
+
+- [ ] **Step 5: Run tests — expect PASS**
+
+```bash
+cd server && go test ./cmd/server/ -run 'TestCategorySidebarTemplate' -count=1
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/cmd/server/components.go server/templates/components/category_sidebar.html server/cmd/server/category_sidebar_test.go
+git commit -m "$(cat <<'EOF'
+feat(ui): add category_sidebar template with HTMX/anchor leaves
+
+EOF
+)"
+```
+
+---
+
+### Task 2: Wire public home to shared sidebar
+
+**Files:**
+- Modify: `server/cmd/server/public_home.go`
+- Modify: `server/cmd/server/main.go` (public home view field type)
+- Modify: `server/templates/pages/public_home.html`
+- Modify: `server/cmd/server/public_home_test.go`
+- Modify: `server/cmd/server/home_handler_test.go` (public home assertions that mention old class names)
+
+**Interfaces:**
+- Consumes: `CategorySidebarView` / leaf types from Task 1
+- Produces: `func buildPublicHomeCategories(categories []TaxonomyCategoryNode, selectedCat, selectedSub string) CategorySidebarView`
+
+- [ ] **Step 1: Update failing public tests** to expect `CategorySidebarView` and `class="category-sidebar"`. Keep PartialURL/PushURL behavior assertions.
+
+```go
+got := buildPublicHomeCategories(cats, "supply-chain", "order-fulfillment")
+if got.Title != "Stream Categories" {
+	t.Fatalf("title=%q", got.Title)
+}
+if got.Categories[0].SubCategories[1].PartialURL != wantPartial {
+	t.Fatalf("PartialURL=%q", got.Categories[0].SubCategories[1].PartialURL)
+}
+```
+
+Markup wants:
+
+```go
+`class="category-sidebar"`,
+`hx-get="/streams/public?category=supply-chain&amp;subCategory=procurement"`,
+```
+
+Remove asserts on `public-home-category-sidebar` class strings.
+
+- [ ] **Step 2: Run targeted tests — expect FAIL** on type/class mismatches
+
+```bash
+cd server && go test ./cmd/server/ -run 'TestBuildPublicHomeCategories|TestHandlePublicHomeRenders|TestHandlePublicHomeQuery' -count=1
+```
+
+- [ ] **Step 3: Change builder**
+
+```go
+func buildPublicHomeCategories(categories []TaxonomyCategoryNode, selectedCat, selectedSub string) CategorySidebarView {
+	out := make([]CategorySidebarCategoryView, 0, len(categories))
+	for _, cat := range categories {
+		subs := make([]CategorySidebarLeafView, 0, len(cat.SubCategories))
+		for _, sub := range cat.SubCategories {
+			query := url.Values{
+				"category":    {cat.Slug},
+				"subCategory": {sub.Slug},
+			}
+			encoded := query.Encode()
+			subs = append(subs, CategorySidebarLeafView{
+				Slug:       sub.Slug,
+				Name:       sub.Name,
+				Active:     cat.Slug == selectedCat && sub.Slug == selectedSub,
+				PartialURL: "/streams/public?" + encoded,
+				PushURL:    publicHomePath(cat.Slug, sub.Slug),
+			})
+		}
+		out = append(out, CategorySidebarCategoryView{
+			Slug:          cat.Slug,
+			Name:          cat.Name,
+			IconURL:       cat.IconURL,
+			Expanded:      cat.Slug == selectedCat,
+			SubCategories: subs,
+		})
+	}
+	return CategorySidebarView{
+		Title:      "Stream Categories",
+		Categories: out,
+	}
+}
+```
+
+Update the public home page view field to `Sidebar CategorySidebarView` and set `Sidebar: buildPublicHomeCategories(...)`.
+
+- [ ] **Step 4: Replace inline aside in `public_home.html`**
+
+Inside `.public-home-streams-split`, replace the whole `<aside class="public-home-category-sidebar" …>…</aside>` block with:
+
+```html
+{{ template "category_sidebar" .Sidebar }}
+```
+
+- [ ] **Step 5: Run public home tests — expect PASS**
+
+```bash
+cd server && go test ./cmd/server/ -run 'TestBuildPublicHomeCategories|TestHandlePublicHome|TestHandlePublicStreamsPartial' -count=1
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/cmd/server/public_home.go server/cmd/server/main.go server/templates/pages/public_home.html server/cmd/server/public_home_test.go server/cmd/server/home_handler_test.go
+git commit -m "$(cat <<'EOF'
+refactor: use category_sidebar on public home
+
+EOF
+)"
+```
+
+---
+
+### Task 3: Migrate category sidebar CSS
+
+**Files:**
+- Create: `web/src/styles/components/category-sidebar.css`
+- Modify: `web/src/styles/components.css`
+- Modify: `web/src/styles/pages/public-home.css`
+
+**Interfaces:**
+- Produces: `.category-sidebar*` selectors (visual parity with former `.public-home-category*`)
+- Consumes: public-home split layout still positions the aside
+
+- [ ] **Step 1: Create `category-sidebar.css`**
+
+Copy rules from `public-home.css` covering `.public-home-category-sidebar` through `.public-home-subcategory.is-active::before` (approx. lines 133–281). Rename:
+
+| Old | New |
+|-----|-----|
+| `.public-home-category-sidebar` | `.category-sidebar` |
+| `.public-home-category-sidebar-header` | `.category-sidebar-header` |
+| `.public-home-category-sidebar-title` | `.category-sidebar-title` |
+| `.public-home-category-sidebar-list` | `.category-sidebar-list` |
+| `.public-home-category-sidebar-empty` | `.category-sidebar-empty` |
+| `.public-home-category` | `.category-sidebar-category` |
+| `.public-home-category-summary` | `.category-sidebar-category-summary` |
+| `.public-home-category-label` | `.category-sidebar-category-label` |
+| `.public-home-category-icon` | `.category-sidebar-category-icon` |
+| `.public-home-category-chevron` | `.category-sidebar-category-chevron` |
+| `.public-home-subcategories` | `.category-sidebar-subcategories` |
+| `.public-home-subcategory` | `.category-sidebar-subcategory` |
+
+Add a markup-tree header matching `category_sidebar.html`. Style `a.category-sidebar-subcategory` like the button (no underline; inherit color).
+
+- [ ] **Step 2: Import from `components.css`**
+
+```css
+@import url("./components/category-sidebar.css");
+```
+
+Place near other full components (after `public-stream-card.css` is fine).
+
+- [ ] **Step 3: Delete moved rules from `public-home.css`**; update split-layout selectors that referenced `.public-home-category-sidebar` to `.category-sidebar` (including `@media (--md-up)` grid-column rules). Update the file header comment tree.
+
+- [ ] **Step 4: Lint + smoke public tests**
+
+```bash
+task css:lint
+cd server && go test ./cmd/server/ -run 'TestHandlePublicHomeRenders|TestCategorySidebarTemplate' -count=1
+```
+
+Expected: css lint OK; tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/styles/components/category-sidebar.css web/src/styles/components.css web/src/styles/pages/public-home.css
+git commit -m "$(cat <<'EOF'
+style: extract category-sidebar component CSS
+
+EOF
+)"
+```
+
+---
+
+### Task 4: Catalog section anchors on `/my`
+
+**Files:**
+- Modify: `server/cmd/server/components.go` (`MyHomeStreamGroupView`)
+- Modify: `server/cmd/server/my_home.go`
+- Modify: `server/templates/components/my_home_stream_group.html`
+- Modify: `server/cmd/server/my_home_test.go`
+- Modify: `server/cmd/server/my_home_stream_group_test.go`
+
+**Interfaces:**
+- Produces:
+  - `MyHomeStreamGroupView` fields: `CategorySlug`, `SubCategorySlug`, `AnchorID string`, `ShowCategoryHeader bool`
+  - `func myHomeAnchorID(categorySlug, subCategorySlug string, uncategorized bool) string`
+- Consumes: existing `buildMyHomeStreamGroups`
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+func TestMyHomeAnchorID(t *testing.T) {
+	if got := myHomeAnchorID("supply-chain", "procurement", false); got != "cat-supply-chain--procurement" {
+		t.Fatalf("got %q", got)
+	}
+	if got := myHomeAnchorID("", "", true); got != "cat-uncategorized" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestBuildMyHomeStreamGroupsSetsAnchorIDs(t *testing.T) {
+	// reuse taxonomy fixtures from TestBuildMyHomeStreamGroupsOrdersTaxonomyAndUncategorized
+	groups := buildMyHomeStreamGroups(categories, cards, catalog, []string{"a", "b", "c"})
+	if groups[0].AnchorID != "cat-supply-chain--procurement" || groups[0].CategorySlug != "supply-chain" {
+		t.Fatalf("first=%+v", groups[0])
+	}
+	if !groups[0].ShowCategoryHeader || groups[0].CategoryName != "Supply Chain" {
+		t.Fatalf("first header=%+v", groups[0])
+	}
+	if groups[1].AnchorID != "cat-supply-chain--order-fulfillment" || groups[1].ShowCategoryHeader {
+		t.Fatalf("second=%+v", groups[1])
+	}
+	if groups[1].CategoryName != "Supply Chain" {
+		t.Fatalf("second must retain CategoryName for sidebar builder, got %+v", groups[1])
+	}
+	if groups[2].AnchorID != "cat-uncategorized" || !groups[2].Uncategorized {
+		t.Fatalf("uncat=%+v", groups[2])
+	}
+}
+```
+
+Extend `TestMyHomeStreamGroupTemplateRendersCategoryHeaders` to pass `ShowCategoryHeader: true`, `AnchorID: "cat-supply-chain--procurement"`, and assert `id="cat-supply-chain--procurement"`.
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+cd server && go test ./cmd/server/ -run 'TestMyHomeAnchorID|TestBuildMyHomeStreamGroupsSetsAnchorIDs|TestMyHomeStreamGroupTemplate' -count=1
+```
+
+- [ ] **Step 3: Implement**
+
+```go
+func myHomeAnchorID(categorySlug, subCategorySlug string, uncategorized bool) string {
+	if uncategorized {
+		return "cat-uncategorized"
+	}
+	return "cat-" + strings.TrimSpace(categorySlug) + "--" + strings.TrimSpace(subCategorySlug)
+}
+```
+
+Extend `MyHomeStreamGroupView`:
+
+```go
+type MyHomeStreamGroupView struct {
+	CategoryName           string
+	CategoryIconURL        string
+	CategorySlug           string
+	SubCategorySlug        string
+	SubCategoryName        string
+	SubCategoryIconURL     string
+	SubCategoryDescription string
+	AnchorID               string
+	ShowCategoryHeader     bool
+	Uncategorized          bool
+	Streams                []ManagedPublicStreamCardView
+}
+```
+
+In `buildMyHomeStreamGroups`, for each taxonomy group always set:
+
+```go
+group := MyHomeStreamGroupView{
+	CategoryName:           category.Name,
+	CategoryIconURL:        category.IconURL,
+	CategorySlug:           category.Slug,
+	SubCategorySlug:        sub.Slug,
+	SubCategoryName:        sub.Name,
+	SubCategoryIconURL:     sub.IconURL,
+	SubCategoryDescription: sub.Description,
+	AnchorID:               myHomeAnchorID(category.Slug, sub.Slug, false),
+	ShowCategoryHeader:     !categoryHeaderEmitted,
+	Streams:                streams,
+}
+categoryHeaderEmitted = true
+```
+
+Uncategorized:
+
+```go
+groups = append(groups, MyHomeStreamGroupView{
+	CategoryName:       "Uncategorized",
+	AnchorID:           myHomeAnchorID("", "", true),
+	ShowCategoryHeader: true,
+	Uncategorized:      true,
+	Streams:            uncategorized,
+})
+```
+
+Template — use `ShowCategoryHeader` and wrap leaf content:
+
+```html
+{{ define "my_home_stream_group" }}
+  {{ if .Uncategorized }}
+  <section class="my-home-catalog-section" id="{{ .AnchorID }}">
+    {{ if .ShowCategoryHeader }}
+    <header class="public-home-results-category-header">
+      <h2 class="public-home-results-category-name">{{ .CategoryName }}</h2>
+    </header>
+    {{ end }}
+    {{ if .Streams }}
+    <div class="public-home-stream-grid">
+      {{ range .Streams }}
+        {{ template "managed_public_stream_card" . }}
+      {{ end }}
+    </div>
+    {{ end }}
+  </section>
+  {{ else }}
+  {{ if .ShowCategoryHeader }}
+  <header class="public-home-results-category-header">
+    {{ if .CategoryIconURL }}
+    <img class="public-home-results-category-icon" src="{{ .CategoryIconURL }}" alt="" width="24" height="24" />
+    {{ end }}
+    <h2 class="public-home-results-category-name">{{ .CategoryName }}</h2>
+  </header>
+  {{ end }}
+  <section class="my-home-catalog-section" id="{{ .AnchorID }}">
+    {{ if .SubCategoryName }}
+    <header class="public-home-results-subcategory-header">
+      …existing subcategory markup…
+    </header>
+    {{ end }}
+    {{ if .Streams }}
+    <div class="public-home-stream-grid">
+      {{ range .Streams }}
+        {{ template "managed_public_stream_card" . }}
+      {{ end }}
+    </div>
+    {{ end }}
+  </section>
+  {{ end }}
+{{ end }}
+```
+
+Update any template tests that used `CategoryName` alone to set `ShowCategoryHeader: true`.
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+cd server && go test ./cmd/server/ -run 'TestMyHomeAnchorID|TestBuildMyHomeStreamGroups|TestMyHomeStreamGroupTemplate' -count=1
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/cmd/server/components.go server/cmd/server/my_home.go server/templates/components/my_home_stream_group.html server/cmd/server/my_home_test.go server/cmd/server/my_home_stream_group_test.go
+git commit -m "$(cat <<'EOF'
+feat(my): add stable catalog section anchor ids
+
+EOF
+)"
+```
+
+---
+
+### Task 5: Build `/my` sidebar from groups
+
+**Files:**
+- Modify: `server/cmd/server/my_home.go`
+- Modify: `server/cmd/server/my_home_test.go`
+- Modify: `server/cmd/server/main.go` (`HomeWorkflowPickerView`, `handleHome`)
+
+**Interfaces:**
+- Produces: `func buildMyHomeCategorySidebar(groups []MyHomeStreamGroupView) CategorySidebarView`
+- Consumes: groups with `CategorySlug`, `SubCategorySlug`, `AnchorID`, `CategoryName`, `CategoryIconURL`, `Uncategorized`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+func TestBuildMyHomeCategorySidebarFromGroups(t *testing.T) {
+	groups := []MyHomeStreamGroupView{
+		{CategorySlug: "supply-chain", CategoryName: "Supply Chain", CategoryIconURL: "/c.svg", SubCategorySlug: "procurement", SubCategoryName: "Procurement", AnchorID: "cat-supply-chain--procurement", ShowCategoryHeader: true},
+		{CategorySlug: "supply-chain", CategoryName: "Supply Chain", CategoryIconURL: "/c.svg", SubCategorySlug: "order-fulfillment", SubCategoryName: "Order Fulfillment", AnchorID: "cat-supply-chain--order-fulfillment"},
+		{Uncategorized: true, CategoryName: "Uncategorized", AnchorID: "cat-uncategorized", ShowCategoryHeader: true},
+	}
+	got := buildMyHomeCategorySidebar(groups)
+	if got.Title != "Stream Categories" || len(got.Categories) != 2 {
+		t.Fatalf("got=%+v", got)
+	}
+	if !got.Categories[0].Expanded || got.Categories[0].Name != "Supply Chain" || len(got.Categories[0].SubCategories) != 2 {
+		t.Fatalf("cat0=%+v", got.Categories[0])
+	}
+	if got.Categories[0].SubCategories[0].Href != "#cat-supply-chain--procurement" {
+		t.Fatalf("href0=%q", got.Categories[0].SubCategories[0].Href)
+	}
+	if got.Categories[1].Name != "Uncategorized" || got.Categories[1].SubCategories[0].Href != "#cat-uncategorized" {
+		t.Fatalf("uncat=%+v", got.Categories[1])
+	}
+	if got.Categories[0].SubCategories[0].PartialURL != "" {
+		t.Fatalf("my leaves must not set PartialURL")
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+cd server && go test ./cmd/server/ -run TestBuildMyHomeCategorySidebarFromGroups -count=1
+```
+
+- [ ] **Step 3: Implement builder**
+
+```go
+func buildMyHomeCategorySidebar(groups []MyHomeStreamGroupView) CategorySidebarView {
+	var cats []CategorySidebarCategoryView
+	var current *CategorySidebarCategoryView
+
+	flush := func() {
+		if current != nil {
+			cats = append(cats, *current)
+			current = nil
+		}
+	}
+
+	for _, g := range groups {
+		if g.Uncategorized {
+			flush()
+			cats = append(cats, CategorySidebarCategoryView{
+				Slug:     "uncategorized",
+				Name:     "Uncategorized",
+				Expanded: true,
+				SubCategories: []CategorySidebarLeafView{{
+					Slug: "uncategorized",
+					Name: "Uncategorized",
+					Href: "#" + g.AnchorID,
+				}},
+			})
+			continue
+		}
+		if current == nil || current.Slug != g.CategorySlug {
+			flush()
+			current = &CategorySidebarCategoryView{
+				Slug:     g.CategorySlug,
+				Name:     g.CategoryName,
+				IconURL:  g.CategoryIconURL,
+				Expanded: true,
+			}
+		}
+		current.SubCategories = append(current.SubCategories, CategorySidebarLeafView{
+			Slug: g.SubCategorySlug,
+			Name: g.SubCategoryName,
+			Href: "#" + g.AnchorID,
+		})
+	}
+	flush()
+	return CategorySidebarView{Title: "Stream Categories", Categories: cats}
+}
+```
+
+- [ ] **Step 4: Wire `handleHome`**
+
+```go
+type HomeWorkflowPickerView struct {
+	PageBase
+	Groups           []MyHomeStreamGroupView
+	Sidebar          CategorySidebarView
+	ShowCreateStream bool
+	Error            string
+	Confirmation     string
+}
+```
+
+```go
+view := HomeWorkflowPickerView{
+	PageBase:         s.pageBaseForUser(user, "home_picker_body", "", ""),
+	Groups:           groups,
+	Sidebar:          buildMyHomeCategorySidebar(groups),
+	ShowCreateStream: showCreateStream && authErr == nil,
+	Error:            homePickerMessage(r, "error"),
+	Confirmation:     homePickerMessage(r, "confirmation"),
+}
+```
+
+- [ ] **Step 5: Run — expect PASS**
+
+```bash
+cd server && go test ./cmd/server/ -run 'TestBuildMyHomeCategorySidebarFromGroups|TestBuildMyHomeStreamGroups' -count=1
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/cmd/server/my_home.go server/cmd/server/my_home_test.go server/cmd/server/main.go
+git commit -m "$(cat <<'EOF'
+feat(my): build category sidebar from accessible catalog groups
+
+EOF
+)"
+```
+
+---
+
+### Task 6: `nav-drawer` + `/my` page layout
+
+**Files:**
+- Create: `web/src/styles/components/nav-drawer.css`
+- Modify: `web/src/styles/components.css`
+- Modify: `web/src/styles/pages/home.css`
+- Modify: `server/templates/pages/home.html`
+- Modify: `server/cmd/server/my_home_stream_group_test.go`
+- Modify: `server/cmd/server/home_handler_test.go`
+
+**Interfaces:**
+- Produces: CSS-only `nav-drawer` markup contract; `/my` two-column layout
+- Consumes: `CategorySidebarView` on home picker view; `category_sidebar` template
+
+- [ ] **Step 1: Write failing page markup tests**
+
+```go
+func TestHomePickerBodyRendersSidebarAndDrawerTrigger(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+	var out bytes.Buffer
+	view := HomeWorkflowPickerView{
+		PageBase: PageBase{Body: "home_picker_body"},
+		Groups: []MyHomeStreamGroupView{{
+			CategoryName: "Supply Chain", SubCategoryName: "Procurement",
+			AnchorID: "cat-supply-chain--procurement", ShowCategoryHeader: true,
+			Streams: []ManagedPublicStreamCardView{{Card: PublicStreamCardView{Name: "A"}}},
+		}},
+		Sidebar: CategorySidebarView{
+			Title: "Stream Categories",
+			Categories: []CategorySidebarCategoryView{{
+				Name: "Supply Chain", Expanded: true,
+				SubCategories: []CategorySidebarLeafView{{Name: "Procurement", Href: "#cat-supply-chain--procurement"}},
+			}},
+		},
+	}
+	if err := tmpl.ExecuteTemplate(&out, "home_picker_body", view); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := out.String()
+	for _, want := range []string{
+		`class="nav-drawer-trigger"`,
+		`popovertarget="my-home-category-sidebar"`,
+		`id="my-home-category-sidebar"`,
+		`class="category-sidebar"`,
+		`href="#cat-supply-chain--procurement"`,
+		`id="cat-supply-chain--procurement"`,
+		`class="my-home-catalog"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("missing %q in %s", want, body)
+		}
+	}
+}
+```
+
+Update `TestHomePickerBodyTemplateRendersEmptyState` to assert absence of `nav-drawer-trigger` and `category-sidebar`.
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+cd server && go test ./cmd/server/ -run 'TestHomePickerBodyRendersSidebarAndDrawerTrigger|TestHomePickerBodyTemplateRendersEmptyState' -count=1
+```
+
+- [ ] **Step 3: Add `nav-drawer.css`**
+
+```css
+/*
+ * Nav drawer — left slide-in shell (CSS-only).
+ *
+ * button.nav-drawer-trigger[popovertarget="…"]
+ * div.nav-drawer-panel[popover][id="…"]   (hosts page content, e.g. category_sidebar)
+ *
+ * Desktop: page CSS forces .nav-drawer-panel into normal flow and hides the trigger.
+ * Do not use :target to open — hashes are reserved for in-page section anchors.
+ */
+
+.nav-drawer-panel {
+  margin: 0;
+  border: 0;
+  padding: 0;
+  background: var(--background);
+  color: var(--foreground);
+  width: min(18rem, 92vw);
+  height: 100dvh;
+  max-height: 100dvh;
+  overflow: auto;
+}
+
+.nav-drawer-panel:popover-open {
+  position: fixed;
+  inset: 0 auto 0 0;
+}
+```
+
+Import in `components.css`. Keep YAGNI — UA popover backdrop is enough.
+
+- [ ] **Step 4: Rewrite `home_picker_body` layout**
+
+```html
+{{ define "home_picker_body" }}
+<section class="stack u-max-w-7xl u-mx-auto my-home">
+  <section class="page-header">
+    <div class="page-header-head">
+      <div class="page-header-body">
+        <h1>Choose a stream</h1>
+        <p>Select a stream to start or continue process tracking</p>
+      </div>
+      {{ if or .Groups .ShowCreateStream }}
+      <div class="page-header-actions">
+        {{ if .Groups }}
+        <button
+          type="button"
+          class="btn btn-ghost btn-icon nav-drawer-trigger"
+          popovertarget="my-home-category-sidebar"
+          aria-label="Open stream categories"
+          title="Stream categories"
+        >
+          {{ template "icon-layout-grid" . }}
+        </button>
+        {{ end }}
+        {{ if .ShowCreateStream }}
+        <a class="btn btn-primary" href="/my/organization/formata-builder">
+          {{ template "icon-plus" . }} Create a stream
+        </a>
+        {{ end }}
+      </div>
+      {{ end }}
+    </div>
+  </section>
+  {{ if .Confirmation }}
+    <p class="confirmation">{{ .Confirmation }}</p>
+  {{ end }}
+  {{ template "error_banner.html" . }}
+  {{ if .Groups }}
+    <div class="my-home-body">
+      <div
+        id="my-home-category-sidebar"
+        class="nav-drawer-panel my-home-sidebar"
+        popover
+      >
+        {{ template "category_sidebar" .Sidebar }}
+      </div>
+      <div class="my-home-catalog">
+        {{ range .Groups }}
+          {{ template "my_home_stream_group" . }}
+        {{ end }}
+      </div>
+    </div>
+  {{ else }}
+    <div class="empty-state">
+      {{ template "icon-layers-2" . }}
+      <p class="empty-state-title">No streams available</p>
+      <p class="empty-state-hint">Streams for your organization and roles will appear here.</p>
+    </div>
+  {{ end }}
+</section>
+{{ end }}
+```
+
+- [ ] **Step 5: Update `home.css`**
+
+```css
+.my-home-catalog {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+  min-width: 0;
+}
+
+.my-home-catalog-section {
+  scroll-margin-top: 44px;
+}
+
+.my-home-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.my-home .nav-drawer-trigger {
+  display: inline-flex;
+}
+
+@media (--md-up) {
+  .my-home-body {
+    display: grid;
+    grid-template-columns: 18rem minmax(0, 1fr);
+    gap: var(--space-8);
+    align-items: start;
+  }
+
+  .my-home .nav-drawer-trigger {
+    display: none;
+  }
+
+  .my-home .nav-drawer-panel.my-home-sidebar {
+    display: block;
+    position: static;
+    inset: auto;
+    width: auto;
+    height: auto;
+    max-height: none;
+    overflow: visible;
+    background: transparent;
+  }
+
+  .my-home .category-sidebar {
+    background: transparent;
+    border-bottom: 0;
+    padding: 0;
+  }
+}
+```
+
+If forcing a closed popover into flow fails in a target browser, fall back to a checkbox `nav-drawer` with the same class names (no app JS).
+
+- [ ] **Step 6: Run tests + css lint**
+
+```bash
+cd server && go test ./cmd/server/ -run 'TestHomePickerBody|TestMyHomeStreamGroup|TestBuildMyHome|TestCategorySidebar|TestHandleHome' -count=1
+task css:lint
+```
+
+Expected: PASS
+
+- [ ] **Step 7: Manual check** on worktree host-dev: `/my` desktop two-column same bg; mobile hamburger opens left panel; leaf jumps to section; empty catalog has no trigger.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/src/styles/components/nav-drawer.css web/src/styles/components.css web/src/styles/pages/home.css server/templates/pages/home.html server/cmd/server/my_home_stream_group_test.go server/cmd/server/home_handler_test.go
+git commit -m "$(cat <<'EOF'
+feat(my): dock category sidebar with mobile nav-drawer
+
+EOF
+)"
+```
+
+---
+
+### Task 7: Handler regression sweep
+
+**Files:**
+- Modify: `server/cmd/server/home_handler_test.go`
+- Any remaining stale references under `server/` / `web/`
+
+**Interfaces:**
+- Consumes: all prior tasks
+
+- [ ] **Step 1: Grep for stale names**
+
+```bash
+rg -n 'PublicHomeCategoryView|PublicHomeSubCategoryView|public-home-category-sidebar|public-home-subcategory"' server web --glob '*.{go,html,css}'
+```
+
+Expected: no stale Go types; aside uses `.category-sidebar*`; results headers (`.public-home-results-*`) remain.
+
+- [ ] **Step 2: Add handler assertions** on an existing `/my` catalog test:
+
+```go
+if !strings.Contains(body, `href="#cat-`) {
+	t.Fatalf("expected sidebar anchor hrefs, got %s", body)
+}
+if !strings.Contains(body, `id="cat-`) {
+	t.Fatalf("expected catalog section ids, got %s", body)
+}
+```
+
+- [ ] **Step 3: Run broader package slice**
+
+```bash
+cd server && go test ./cmd/server/ -run 'TestHandleHome|TestHandlePublicHome|TestCategorySidebar|TestBuildMyHome|TestHomePicker|TestMyHome' -count=1
+task css:lint
+```
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/cmd/server
+git commit -m "$(cat <<'EOF'
+test: cover /my category sidebar anchors and public rename
+
+EOF
+)"
+```
+
+---
+
+## Spec coverage self-check
+
+| Spec requirement | Task |
+|------------------|------|
+| Shared thin-full `category_sidebar` | 1–3 |
+| HTMX vs Href leaf dispatch | 1 |
+| Public `/` migration, behavior unchanged | 2–3 |
+| `/my` accessible-only sidebar | 5 |
+| Uncategorized synthetic category + leaf | 5 |
+| Section ids `cat-…` / `cat-uncategorized` | 4 |
+| `ShowCategoryHeader` + always-populated category name for sidebar | 4 |
+| Two-col inside max-width, same bg | 6 |
+| Desktop docked / mobile hamburger drawer | 6 |
+| One DOM instance | 6 |
+| No scroll-spy / no app JS | 6 (Popover) |
+| Empty: no sidebar/trigger | 6 |
+| Tests listed in spec | 1, 4–7 |

--- a/docs/superpowers/specs/2026-07-31-my-home-catalog-design.md
+++ b/docs/superpowers/specs/2026-07-31-my-home-catalog-design.md
@@ -1,0 +1,105 @@
+# `/my` home: accessible streams catalog
+
+Date: 2026-07-31  
+Scope: Authenticated `/my` stream home (`handleHome`, `home_picker_body` / `pages/home.html`), public stream card + optional management shell, CSS-only empty-state extraction, access filtering + taxonomy grouping builders/tests.  
+Out of scope: Public `/` sidebar/filter behavior, public stream page content redesign, platform admin taxonomy CRUD, changing Cerbos policy semantics for edit/delete (reuse existing checks), SSE/HTMX for the `/my` listing.
+
+Related: `docs/superpowers/specs/2026-07-30-public-home-category-sidebar-design.md` (public home filters; `/my` does **not** reuse the sidebar).
+
+## Goal
+
+Replace the authenticated `/my` “Choose a stream” grid (`stream_card` + create card) with a catalog that:
+
+- Shows **only streams the user may access** (with admin exceptions below)
+- Groups them under the same **category / subcategory result headers** used on the public home results panel
+- Reuses **`public_stream_card`** visuals, with optional clone/edit/delete actions
+- Puts **Create a stream** in the page header actions (not a grid card)
+- Uses a shared **empty-state** component when the user has zero accessible streams
+
+## Decisions
+
+1. **Approach:** Stack reused results groups (no sidebar, no HTMX filter on `/my`).
+2. **Card visual:** `public_stream_card`; management menu when permitted (shell/wrapper so the menu does not navigate).
+3. **Card click:** `/my/streams/:key/`.
+4. **Uncategorized:** Final group with an “Uncategorized” header for accessible streams lacking taxonomy.
+5. **Create:** `page-header-actions` → Formata builder when `canViewFormataBuilder`; not inside the empty block.
+6. **Empty:** Extract public stream runs empty pattern into a CSS-only component; `/my` and public stream runs share it.
+7. **Card cap:** Public home’s `publicHomeStreamCardLimit` does **not** apply on `/my`.
+
+## Access rules
+
+Include a catalog stream on `/my` when **any** of:
+
+| Actor | Streams shown |
+|-------|----------------|
+| Platform admin (`user.IsPlatformAdmin`) | **All** runtime catalog streams |
+| Org admin (`userIsOrgAdmin`) for their org | All streams whose `organizations` include the user’s `OrgSlug` (workflow role not required) |
+| Everyone else | User’s `OrgSlug` is a participating org **and** at least one of their `RoleSlugs` is listed on that stream’s `roles` for that org |
+
+Catalog source: same runtime workflow catalog as today’s picker.  
+Store/taxonomy/catalog load failures → HTTP 500. Zero accessible streams → HTTP 200 + empty state.
+
+## Layout
+
+```
+[ page-header ]
+  title + short subtitle
+  [Create a stream]     ← page-header-actions (permission-gated)
+  confirmation / error  ← existing query flash
+
+[ catalog stack ]       ← no sidebar, no landing hero
+  for each taxonomy path with ≥1 accessible stream (taxonomy sortOrder):
+    category header     (.public-home-results-category-header)
+    subcategory header  (.public-home-results-subcategory-header)
+    public_stream_card grid
+  if any uncategorized accessible streams:
+    “Uncategorized” header
+    same card grid
+
+[ empty state ]         ← only when zero accessible streams
+  shared empty-state component (icon + title + hint)
+```
+
+Mobile/desktop: single column stack; reuse public-home results header/grid classes. Light wrapper styles in `pages/home.css` only if needed.
+
+## Cards & actions
+
+- Metrics, DPP chip, org avatars: same as homepage `public_stream_card`.
+- `Href`: `/my/streams/:key/`.
+- Optional ellipsis menu (clone / edit / delete) using the same permission sources as today’s `workflowOptions` / `stream_card` (Formata builder for clone; Cerbos for edit/delete; edit-requires-purge + delete dialogs preserved).
+- Homepage cards stay menu-free when action flags are unset/false.
+- Prefer a shell around the public card (menu + dialogs outside the primary link) rather than nesting interactive controls inside the card `<a>`.
+
+## Templates & CSS
+
+| Piece | Plan |
+|-------|------|
+| `/my` body | Rewrite `home_picker_body` in `pages/home.html` |
+| Group chrome | Reuse/share category + subcategory headers + grid from `public_home_stream_results` (small shared group partial if needed; avoid a large `/` rewrite) |
+| Card | Extend `public_stream_card` or add shell for actions/dialogs |
+| Create card | Stop using `stream_card_create` on `/my` |
+| Empty | CSS-only `empty-state` component; migrate `public-stream-runs-empty` markup/classes to it; `/my` empty uses home-specific title/hint |
+| Old `stream_card` | Remove from `/my`; delete only if nothing else references it |
+
+Follow `.agents/skills/attesta-ui-components` and `docs/css.md` for tiers and layers.
+
+## Data flow
+
+1. `handleHome` authenticates; loads catalog + taxonomy + user.
+2. Filter accessible keys (rules above).
+3. Build public-style card views (instance/step/role/org metrics) with `/my` hrefs and action flags.
+4. Group by effective `categorySlug` / `subCategorySlug`; emit non-empty taxonomy groups in `sortOrder`; append Uncategorized.
+5. Render full page (no `/my` listing HTMX/SSE endpoint).
+
+## Testing
+
+- Access matrix: platform admin (all); org admin (org streams, no role required); role member (intersection); outsider (empty).
+- Grouping: taxonomy order; skip empty leaves; Uncategorized last; no 6-card cap.
+- Markup: result headers; card hrefs under `/my/streams/`; Create in header when allowed; menu absent without perms; empty-state when zero.
+- Empty-state extraction: public stream runs empty still renders via shared component contract.
+
+## Non-goals / unchanged
+
+- Public home sidebar, HTMX `/streams/public`, and public card links to `/streams/:key`.
+- Breadcrumbs on `/my` (none today).
+- Auth/session cookie behavior.

--- a/docs/superpowers/specs/2026-07-31-my-home-category-sidebar-anchors-design.md
+++ b/docs/superpowers/specs/2026-07-31-my-home-category-sidebar-anchors-design.md
@@ -1,0 +1,118 @@
+# `/my` category sidebar (anchors) + shared `category_sidebar`
+
+Date: 2026-07-31  
+Branch / worktree: `feat/my-home-catalog`  
+Related: `docs/superpowers/specs/2026-07-31-my-home-catalog-design.md`, `docs/superpowers/specs/2026-07-30-public-home-category-sidebar-design.md`
+
+## Goal
+
+Add a category sidebar to authenticated `/my` that matches the public-home category tree visually, but uses **in-page anchors** (not HTMX filters) to jump to catalog sections. Extract the sidebar into a shared **thin full** component used by both `/` and `/my`. On narrow viewports, wrap the `/my` sidebar in a CSS-only **left slide-in** `nav-drawer`.
+
+## Decisions
+
+1. **Leaf behavior on `/my`:** Subcategory leaves are anchors only (`href="#…"`). Category rows remain `<details>`/`<summary>` expand/collapse — not links. Public `/` keeps HTMX buttons (decision 7).
+2. **Sidebar contents on `/my`:** Only categories/subcategories with ≥1 accessible stream for the current user. Include an Uncategorized leaf when that group exists.
+3. **Layout on `/my`:** Two columns inside existing `u-max-w-7xl` / `.my-home`. Same page background — no public-home full-bleed streams split, no contrasting sidebar/results band colors.
+4. **Responsive:** Desktop (`md`+): sidebar always docked in the left column. Mobile: hamburger opens a left `nav-drawer`; drawer chrome hidden on desktop.
+5. **Active state:** Plain anchors only. No scroll-spy. Optional cheap `:target` styling is allowed; not required.
+6. **Component split:**
+   - **`category_sidebar`** — thin **full** component (template + CSS + view structs).
+   - **`nav-drawer`** — **CSS-only** shell (markup contract in CSS header; inline in `pages/home.html`).
+7. **Public `/`:** Keep HTMX filter semantics. Migrate inline sidebar markup to the shared template; leaf mode = PartialURL/PushURL buttons.
+
+## Out of scope
+
+- Scroll-spy / continuous active-leaf tracking
+- Changing public filter URLs, partial endpoint, or selection resolution
+- Extracting a second copy of the catalog results headers
+- New app JS modules for drawer open/close (Popover API / declarative HTML only)
+- Platform admin taxonomy CRUD changes
+
+## Layout (`/my`)
+
+```
+[ page-header ]
+  title + subtitle
+  [Categories] hamburger     ← mobile only (nav-drawer trigger)
+  [Create a stream]          ← existing, permission-gated
+
+[ my-home body grid ]        ← inside u-max-w-7xl; same bg
+  [ category_sidebar ]       ← desktop: docked column
+  [ catalog stack ]          ← existing groups + cards
+     section#cat-… per leaf
+       subcategory header
+       card grid
+
+[ empty state ]              ← zero groups: no sidebar, no drawer trigger
+```
+
+Mobile: catalog full width. **One** `category_sidebar` instance in the DOM: on `md`+ it is the docked left column; below `md` that same node is the `nav-drawer` panel (responsive CSS / reparenting-not-required). Do not render two copies of the tree.
+
+## Anchors & data
+
+**Section ids:** Stable ids on each catalog leaf block:
+
+- Taxonomy: `cat-{categorySlug}--{subCategorySlug}`
+- Uncategorized: `cat-uncategorized`
+
+Wrap subcategory header + its stream grid in a `<section id="…" class="…">` (or equivalent) with `scroll-margin-top` sufficient for the sticky topbar (`pages/home.css`).
+
+**Group fields:** Extend `MyHomeStreamGroupView` with slugs needed for ids (`CategorySlug`, `SubCategorySlug`) and/or a precomputed `AnchorID`. Category display name/icon header rules from the prior catalog polish stay (category header only on first non-empty leaf under a category).
+
+**Sidebar builder:** Derive the sidebar category list from the same accessible groups already built for `/my` (no second access pass). Categories with ≥1 leaf default `Expanded: true`. Uncategorized is a synthetic category named `Uncategorized` with a **single** leaf also labeled `Uncategorized` whose `Href` is `#cat-uncategorized` (keeps the same details→leaf shape as taxonomy paths).
+
+**Empty catalog:** No sidebar and no hamburger (empty-state only).
+
+## Components
+
+### `category_sidebar` (full, thin)
+
+| Piece | Path |
+|-------|------|
+| Template | `server/templates/components/category_sidebar.html` (`{{ define "category_sidebar" }}`) |
+| CSS | `web/src/styles/components/category-sidebar.css` (`.category-sidebar-*`) |
+| Views | Rename `PublicHomeCategoryView` / `PublicHomeSubCategoryView` → `CategorySidebarCategoryView` / `CategorySidebarLeafView`. Template root is a small wrapper (e.g. `CategorySidebarView{ Title, Categories []… }`) so the “Stream Categories” header stays inside the component. |
+
+**Leaf rendering rule (thin mode dispatch):**
+
+- If `Href` is non-empty → render `<a class="category-sidebar-subcategory" href="{{ .Href }}">`
+- Else → render HTMX `<button>` with `PartialURL` / `PushURL` / `Active` as today’s public home does
+
+No separate mode enum. Public builder fills PartialURL/PushURL and leaves `Href` empty. `/my` builder fills `Href` and leaves HTMX fields empty.
+
+**CSS migration:** Move `.public-home-category-sidebar*` / `.public-home-category*` / `.public-home-subcategor*` tree rules from `pages/public-home.css` into `components/category-sidebar.css` under `.category-sidebar-*`. Update public home + any tests that assert old class strings. Public streams split layout rules that only position the aside stay in `public-home.css` (or thin wrappers).
+
+**Public `/`:** Replace inline aside markup in `public_home.html` with `{{ template "category_sidebar" … }}`. Behavior unchanged.
+
+### `nav-drawer` (CSS-only)
+
+| Piece | Path |
+|-------|------|
+| CSS | `web/src/styles/components/nav-drawer.css` |
+| Markup | Inline in `pages/home.html` (markup-tree header in the CSS file) |
+
+**Mechanism:** Prefer HTML **Popover API** (`popover` + `popovertarget`) for open/close and backdrop dismiss without app JS. Hash navigation to catalog sections must remain independent of drawer open state (do not use `:target` to open the drawer).
+
+**Ownership:** `nav-drawer` owns trigger, panel, slide-from-left, backdrop. It does not restyle the category tree. Desktop: hide trigger + treat panel as in-flow column (page CSS in `home.css` may cooperate).
+
+## `/my` page CSS
+
+`pages/home.css`:
+
+- Grid for docked sidebar + catalog inside `.my-home`
+- `scroll-margin-top` on catalog section anchors
+- Any desktop/mobile visibility glue between `nav-drawer` and the grid that is page-specific
+
+## Testing
+
+- **Template:** `category_sidebar` with HTMX leaf attrs present when PartialURL set; anchor `<a href="#…">` when Href set; no HTMX attrs in anchor mode.
+- **`/my` builder:** Sidebar categories/leaves match non-empty groups only; Uncategorized leaf when present; `Href` matches section `id`.
+- **`/my` page markup:** When groups exist, hamburger/drawer trigger present (mobile contract); empty state omits sidebar and trigger.
+- **Public home:** Existing filter/partial/push-url tests updated for renamed types/classes; behavior assertions unchanged.
+- **CSS:** `task css:lint` after new component imports.
+
+## Non-goals / unchanged
+
+- Public home HTMX `/streams/public` contract
+- Access matrix for which streams appear on `/my` (already specified)
+- Card management shell / Create CTA placement from my-home catalog spec

--- a/docs/superpowers/specs/2026-07-31-my-home-category-sidebar-anchors-design.md
+++ b/docs/superpowers/specs/2026-07-31-my-home-category-sidebar-anchors-design.md
@@ -59,7 +59,7 @@ Wrap subcategory header + its stream grid in a `<section id="…" class="…">` 
 
 **Group fields:** Extend `MyHomeStreamGroupView` with slugs needed for ids (`CategorySlug`, `SubCategorySlug`) and/or a precomputed `AnchorID`. Category display name/icon header rules from the prior catalog polish stay (category header only on first non-empty leaf under a category).
 
-**Sidebar builder:** Derive the sidebar category list from the same accessible groups already built for `/my` (no second access pass). Categories with ≥1 leaf default `Expanded: true`. Uncategorized is a synthetic category named `Uncategorized` with a **single** leaf also labeled `Uncategorized` whose `Href` is `#cat-uncategorized` (keeps the same details→leaf shape as taxonomy paths).
+**Sidebar builder:** Derive the sidebar category list from the same accessible groups already built for `/my` (no second access pass). Only the **first** category starts `Expanded: true` (exclusive accordion on load; later opens close siblings via existing landing JS). Uncategorized is a synthetic category named `Uncategorized` with a **single** leaf also labeled `Uncategorized` whose `Href` is `#cat-uncategorized` (keeps the same details→leaf shape as taxonomy paths).
 
 **Empty catalog:** No sidebar and no hamburger (empty-state only).
 

--- a/server/cmd/server/category_sidebar_test.go
+++ b/server/cmd/server/category_sidebar_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCategorySidebarTemplateHTMXLeaf(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+	var out bytes.Buffer
+	view := CategorySidebarView{
+		Title: "Stream Categories",
+		Categories: []CategorySidebarCategoryView{{
+			Slug: "supply-chain", Name: "Supply Chain", IconURL: "/c.svg", Expanded: true,
+			SubCategories: []CategorySidebarLeafView{{
+				Slug: "procurement", Name: "Procurement", Active: true,
+				PartialURL: "/streams/public?category=supply-chain&subCategory=procurement",
+				PushURL:    "/?category=supply-chain&subCategory=procurement",
+			}},
+		}},
+	}
+	if err := tmpl.ExecuteTemplate(&out, "category_sidebar", view); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := out.String()
+	for _, want := range []string{
+		`class="category-sidebar"`,
+		`class="category-sidebar-title">Stream Categories<`,
+		`hx-get="/streams/public?category=supply-chain&amp;subCategory=procurement"`,
+		`hx-push-url="/?category=supply-chain&amp;subCategory=procurement"`,
+		`is-active`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("missing %q in %s", want, body)
+		}
+	}
+	if strings.Contains(body, `href="#`) {
+		t.Fatalf("HTMX leaf must not use href anchor, got %s", body)
+	}
+}
+
+func TestCategorySidebarTemplateAnchorLeaf(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+	var out bytes.Buffer
+	view := CategorySidebarView{
+		Title: "Stream Categories",
+		Categories: []CategorySidebarCategoryView{{
+			Slug: "supply-chain", Name: "Supply Chain", Expanded: true,
+			SubCategories: []CategorySidebarLeafView{{
+				Slug: "procurement", Name: "Procurement",
+				Href: "#cat-supply-chain--procurement",
+			}},
+		}},
+	}
+	if err := tmpl.ExecuteTemplate(&out, "category_sidebar", view); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := out.String()
+	if !strings.Contains(body, `href="#cat-supply-chain--procurement"`) {
+		t.Fatalf("missing anchor href, got %s", body)
+	}
+	if strings.Contains(body, "hx-get=") || strings.Contains(body, "<button") {
+		t.Fatalf("anchor leaf must not render HTMX button, got %s", body)
+	}
+}

--- a/server/cmd/server/components.go
+++ b/server/cmd/server/components.go
@@ -84,6 +84,32 @@ type PublicStreamPageView struct {
 	Blueprint     StreamInstanceDetailView
 }
 
+// CategorySidebarLeafView is one subcategory row in category_sidebar.
+// If Href is set, render an anchor; otherwise render an HTMX button using PartialURL/PushURL.
+type CategorySidebarLeafView struct {
+	Slug       string
+	Name       string
+	Active     bool
+	Href       string // /my anchors, e.g. #cat-supply-chain--procurement
+	PartialURL string // public home HTMX get
+	PushURL    string // public home hx-push-url
+}
+
+// CategorySidebarCategoryView is one accordion category in category_sidebar.
+type CategorySidebarCategoryView struct {
+	Slug          string
+	Name          string
+	IconURL       string
+	Expanded      bool
+	SubCategories []CategorySidebarLeafView
+}
+
+// CategorySidebarView is the root for templates/components/category_sidebar.html.
+type CategorySidebarView struct {
+	Title      string
+	Categories []CategorySidebarCategoryView
+}
+
 // PublicHomeSubCategoryView is one filterable leaf in the landing sidebar.
 type PublicHomeSubCategoryView struct {
 	Slug       string

--- a/server/cmd/server/components.go
+++ b/server/cmd/server/components.go
@@ -40,14 +40,18 @@ type ManagedPublicStreamCardView struct {
 }
 
 // MyHomeStreamGroupView is one taxonomy (or Uncategorized) block on /my.
-// CategoryName/CategoryIconURL are set only on the first non-empty subcategory
-// under a category so the category header is not repeated in the stacked catalog.
+// CategoryName/CategoryIconURL are always set; ShowCategoryHeader is true only
+// on the first non-empty subcategory under a category so the h2 is not repeated.
 type MyHomeStreamGroupView struct {
 	CategoryName           string
 	CategoryIconURL        string
+	CategorySlug           string
+	SubCategorySlug        string
 	SubCategoryName        string
 	SubCategoryIconURL     string
 	SubCategoryDescription string
+	AnchorID               string
+	ShowCategoryHeader     bool
 	Uncategorized          bool
 	Streams                []ManagedPublicStreamCardView
 }

--- a/server/cmd/server/components.go
+++ b/server/cmd/server/components.go
@@ -110,8 +110,9 @@ type CategorySidebarCategoryView struct {
 
 // CategorySidebarView is the root for templates/components/category_sidebar.html.
 type CategorySidebarView struct {
-	Title      string
-	Categories []CategorySidebarCategoryView
+	Title         string
+	CloseTargetID string // popover id for mobile drawer close; empty = no close control
+	Categories    []CategorySidebarCategoryView
 }
 
 // PublicHomeStreamResultsView is the HTMX swap target for landing stream cards.

--- a/server/cmd/server/components.go
+++ b/server/cmd/server/components.go
@@ -27,6 +27,29 @@ type PublicStreamCardOrgView struct {
 	Initials string
 }
 
+// ManagedPublicStreamCardView wraps a public stream card with optional /my management actions.
+type ManagedPublicStreamCardView struct {
+	Card              PublicStreamCardView
+	Key               string
+	CanClone          bool
+	CanEdit           bool
+	EditAction        string
+	EditRequiresPurge bool
+	CanDelete         bool
+	DeleteAction      string
+}
+
+// MyHomeStreamGroupView is one taxonomy (or Uncategorized) block on /my.
+type MyHomeStreamGroupView struct {
+	CategoryName           string
+	CategoryIconURL        string
+	SubCategoryName        string
+	SubCategoryIconURL     string
+	SubCategoryDescription string
+	Uncategorized          bool
+	Streams                []ManagedPublicStreamCardView
+}
+
 // PublicStreamCardView is the view model for templates/components/public_stream_card.html.
 type PublicStreamCardView struct {
 	Name                  string

--- a/server/cmd/server/components.go
+++ b/server/cmd/server/components.go
@@ -110,24 +110,6 @@ type CategorySidebarView struct {
 	Categories []CategorySidebarCategoryView
 }
 
-// PublicHomeSubCategoryView is one filterable leaf in the landing sidebar.
-type PublicHomeSubCategoryView struct {
-	Slug       string
-	Name       string
-	Active     bool
-	PartialURL string // /streams/public?category=…&subCategory=…
-	PushURL    string // /?category=…&subCategory=…
-}
-
-// PublicHomeCategoryView is one accordion category on the landing sidebar.
-type PublicHomeCategoryView struct {
-	Slug          string
-	Name          string
-	IconURL       string
-	Expanded      bool
-	SubCategories []PublicHomeSubCategoryView
-}
-
 // PublicHomeStreamResultsView is the HTMX swap target for landing stream cards.
 type PublicHomeStreamResultsView struct {
 	Streams                []PublicStreamCardView

--- a/server/cmd/server/components.go
+++ b/server/cmd/server/components.go
@@ -40,6 +40,8 @@ type ManagedPublicStreamCardView struct {
 }
 
 // MyHomeStreamGroupView is one taxonomy (or Uncategorized) block on /my.
+// CategoryName/CategoryIconURL are set only on the first non-empty subcategory
+// under a category so the category header is not repeated in the stacked catalog.
 type MyHomeStreamGroupView struct {
 	CategoryName           string
 	CategoryIconURL        string

--- a/server/cmd/server/home_handler_test.go
+++ b/server/cmd/server/home_handler_test.go
@@ -743,6 +743,140 @@ func TestHandleHomeRequiresAuthAtMy(t *testing.T) {
 	}
 }
 
+func writeMyHomeCatalogOtherOrgWorkflow(t *testing.T, path string) {
+	t.Helper()
+	content := "workflow:\n" +
+		"  name: \"Other Org Stream\"\n" +
+		"  categorySlug: \"" + publicHomeTestCategorySlug + "\"\n" +
+		"  subCategorySlug: \"" + publicHomeTestSubCategorySlug + "\"\n" +
+		"  steps:\n" +
+		"    - id: \"1\"\n" +
+		"      title: \"Step 1\"\n" +
+		"      order: 1\n" +
+		"      organization: \"org2\"\n" +
+		"      substeps:\n" +
+		"        - id: \"1.1\"\n" +
+		"          title: \"Input\"\n" +
+		"          order: 1\n" +
+		"          roles: [\"dep2\"]\n" +
+		"          inputKey: \"value\"\n" +
+		"          inputType: \"formata\"\n" +
+		"          schema:\n" +
+		"            type: object\n" +
+		"organizations:\n" +
+		"  - slug: \"org2\"\n" +
+		"    name: \"Organization 2\"\n" +
+		"roles:\n" +
+		"  - orgSlug: \"org2\"\n" +
+		"    slug: \"dep2\"\n" +
+		"    name: \"Department 2\"\n" +
+		"users:\n" +
+		"  - id: \"u2\"\n" +
+		"    name: \"User 2\"\n" +
+		"    departmentId: \"dep2\"\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write other org workflow %s: %v", path, err)
+	}
+}
+
+func TestHandleHomeCatalogWiring(t *testing.T) {
+	store := NewMemoryStore()
+	seedPlatformAdminTaxonomy(t, store)
+
+	tempDir := t.TempDir()
+	writePublicHomeWorkflowConfig(t, filepath.Join(tempDir, "accessible.yaml"), "Accessible Stream", "string", "Visible to org1")
+	writeMyHomeCatalogOtherOrgWorkflow(t, filepath.Join(tempDir, "other-org.yaml"))
+
+	now := time.Now().UTC()
+	sessionID := "session-my-home-catalog"
+	user := AccountUser{
+		ID:        primitive.NewObjectID(),
+		Email:     "member@example.com",
+		OrgSlug:   "org1",
+		RoleSlugs: []string{"dep1"},
+		Status:    "active",
+		CreatedAt: now,
+	}
+
+	server := &Server{
+		authorizer:  fakeAuthorizer{},
+		store:       store,
+		identity:    testIdentityForSessions(now, map[string]AccountUser{sessionID: user}),
+		tmpl:        parseTestTemplates(t),
+		configDir:   tempDir,
+		enforceAuth: true,
+		now:         func() time.Time { return now },
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/my", nil)
+	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: sessionID})
+	rec := httptest.NewRecorder()
+	server.handleHome(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		`class="my-home-catalog"`,
+		"Accessible Stream",
+		`href="/my/streams/accessible/"`,
+		"Supply Chain",
+		"Procurement",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in home catalog, got: %s", want, body)
+		}
+	}
+	for _, gone := range []string{
+		"Other Org Stream",
+		`href="/my/streams/other-org/"`,
+		`href="/streams/accessible"`,
+	} {
+		if strings.Contains(body, gone) {
+			t.Fatalf("did not expect %q in home catalog, got: %s", gone, body)
+		}
+	}
+
+	t.Run("org admin sees create stream in header", func(t *testing.T) {
+		adminSession := "session-my-home-org-admin"
+		admin := AccountUser{
+			ID:        primitive.NewObjectID(),
+			Email:     "admin@example.com",
+			OrgSlug:   "org1",
+			RoleSlugs: []string{"org-admin"},
+			Status:    "active",
+			CreatedAt: now,
+		}
+		adminServer := &Server{
+			authorizer:  fakeAuthorizer{},
+			store:       store,
+			identity:    testIdentityForSessions(now, map[string]AccountUser{adminSession: admin}),
+			tmpl:        parseTestTemplates(t),
+			configDir:   tempDir,
+			enforceAuth: true,
+			now:         func() time.Time { return now },
+		}
+		adminReq := httptest.NewRequest(http.MethodGet, "/my", nil)
+		adminReq.AddCookie(&http.Cookie{Name: "attesta_session", Value: adminSession})
+		adminRec := httptest.NewRecorder()
+		adminServer.handleHome(adminRec, adminReq)
+		if adminRec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", adminRec.Code, http.StatusOK)
+		}
+		adminBody := adminRec.Body.String()
+		for _, want := range []string{
+			`class="page-header-actions"`,
+			`href="/my/organization/formata-builder"`,
+			"Create a stream",
+		} {
+			if !strings.Contains(adminBody, want) {
+				t.Fatalf("expected %q in org admin home, got: %s", want, adminBody)
+			}
+		}
+	})
+}
+
 func TestHandleHomeListsProcesses(t *testing.T) {
 	store := NewMemoryStore()
 	now := time.Date(2026, 2, 3, 12, 0, 0, 0, time.UTC)

--- a/server/cmd/server/home_handler_test.go
+++ b/server/cmd/server/home_handler_test.go
@@ -817,6 +817,12 @@ func TestHandleHomeCatalogWiring(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
 	body := rec.Body.String()
+	if !strings.Contains(body, `href="#cat-`) {
+		t.Fatalf("expected sidebar anchor hrefs, got %s", body)
+	}
+	if !strings.Contains(body, `id="cat-`) {
+		t.Fatalf("expected catalog section ids, got %s", body)
+	}
 	for _, want := range []string{
 		`nav-drawer-trigger`,
 		`id="my-home-category-sidebar"`,

--- a/server/cmd/server/home_handler_test.go
+++ b/server/cmd/server/home_handler_test.go
@@ -1083,13 +1083,28 @@ func TestHandleHomeRendersWorkflowPicker(t *testing.T) {
 	writeWorkflowConfig(t, tempDir+"/workflow.yaml", "Main workflow", "string", "Main workflow description")
 	writeWorkflowConfig(t, tempDir+"/secondary.yaml", "Secondary workflow", "number")
 
+	now := time.Now().UTC()
+	sessionID := "session-home-picker"
+	user := AccountUser{
+		ID:        primitive.NewObjectID(),
+		Email:     "picker@example.com",
+		OrgSlug:   "org1",
+		RoleSlugs: []string{"dep1"},
+		Status:    "active",
+		CreatedAt: now,
+	}
+
 	server := &Server{
-		authorizer: fakeAuthorizer{},
-		tmpl:       homePickerTemplates(),
-		configDir:  tempDir,
+		authorizer:  fakeAuthorizer{},
+		store:       NewMemoryStore(),
+		identity:    testIdentityForSessions(now, map[string]AccountUser{sessionID: user}),
+		tmpl:        homePickerTemplates(),
+		configDir:   tempDir,
+		enforceAuth: true,
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/my", nil)
+	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: sessionID})
 	rec := httptest.NewRecorder()
 	server.handleHome(rec, req)
 
@@ -1097,13 +1112,13 @@ func TestHandleHomeRendersWorkflowPicker(t *testing.T) {
 		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
 	}
 	body := rec.Body.String()
-	if !strings.Contains(body, "PICK 2") {
-		t.Fatalf("expected picker marker, got %q", body)
+	if !strings.Contains(body, "PICK GROUPS 1") {
+		t.Fatalf("expected uncategorized group marker, got %q", body)
 	}
-	if !strings.Contains(body, "workflow:Main workflow:Main workflow description") || !strings.Contains(body, "secondary:Secondary workflow") {
-		t.Fatalf("expected workflow options in picker, got %q", body)
+	if !strings.Contains(body, "workflow:Main workflow:Main workflow description:instances=") || !strings.Contains(body, "secondary:Secondary workflow:instances=") {
+		t.Fatalf("expected accessible workflow cards in picker, got %q", body)
 	}
-	if strings.Contains(body, "secondary:Secondary workflow:Secondary workflow description:") {
+	if strings.Contains(body, "secondary:Secondary workflow:Secondary workflow description|") {
 		t.Fatalf("expected optional description to be omitted when empty, got %q", body)
 	}
 }
@@ -1204,86 +1219,27 @@ func TestNextAvailableAuthorizedActionFiltersByAvailableRoleAndOrganization(t *t
 	}
 }
 
-func TestHandleHomePickerMarksWorkflowCardsWithMyTurn(t *testing.T) {
+func TestHandleHomePickerRendersWorkflowCardsAndScopedLinks(t *testing.T) {
 	tempDir := t.TempDir()
 	writeWorkflowConfig(t, filepath.Join(tempDir, "workflow.yaml"), "Main workflow", "string", "Main workflow description")
+	writeWorkflowConfig(t, filepath.Join(tempDir, "secondary.yaml"), "Secondary workflow", "number")
 
-	store := NewMemoryStore()
-	processID := primitive.NewObjectID()
-	store.SeedProcess(Process{
-		ID:          processID,
-		WorkflowKey: "workflow",
-		CreatedAt:   time.Date(2026, 2, 5, 10, 0, 0, 0, time.UTC),
-		Status:      "active",
-		Progress: map[string]ProcessStep{
-			"1_1": {State: "pending"},
-		},
-	})
-
+	now := time.Now().UTC()
+	sessionID := "session-home-scoped-links"
 	user := AccountUser{
 		ID:        primitive.NewObjectID(),
-		Email:     "member@example.com",
+		Email:     "scoped-links@example.com",
 		OrgSlug:   "org1",
 		RoleSlugs: []string{"dep1"},
 		Status:    "active",
-		CreatedAt: time.Now().UTC(),
+		CreatedAt: now,
 	}
-	sessionID := "session-home-turn"
-
-	server := &Server{
-		authorizer:  fakeAuthorizer{},
-		store:       store,
-		identity:    testIdentityForSessions(time.Now().UTC(), map[string]AccountUser{sessionID: user}),
-		tmpl:        homePickerTemplates(),
-		configDir:   tempDir,
-		enforceAuth: true,
-	}
-
-	req := httptest.NewRequest(http.MethodGet, "/my", nil)
-	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: sessionID})
-	rec := httptest.NewRecorder()
-	server.handleHome(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
-	}
-	body := rec.Body.String()
-	expected := "workflow:Main workflow:Main workflow description:1/0/0:turn"
-	if !strings.Contains(body, expected) {
-		t.Fatalf("expected workflow turn marker %q, got %q", expected, body)
-	}
-}
-
-func TestHandleHomePickerRendersTurnIndicatorOnWorkflowCard(t *testing.T) {
-	tempDir := t.TempDir()
-	writeWorkflowConfig(t, filepath.Join(tempDir, "workflow.yaml"), "Main workflow", "string", "Main workflow description")
-
-	store := NewMemoryStore()
-	store.SeedProcess(Process{
-		ID:          primitive.NewObjectID(),
-		WorkflowKey: "workflow",
-		CreatedAt:   time.Date(2026, 2, 5, 10, 0, 0, 0, time.UTC),
-		Status:      "active",
-		Progress: map[string]ProcessStep{
-			"1_1": {State: "pending"},
-		},
-	})
-
-	user := AccountUser{
-		ID:        primitive.NewObjectID(),
-		Email:     "member-indicator@example.com",
-		OrgSlug:   "org1",
-		RoleSlugs: []string{"dep1"},
-		Status:    "active",
-		CreatedAt: time.Now().UTC(),
-	}
-	sessionID := "session-home-indicator"
 
 	tmpl := parseTestTemplates(t)
 	server := &Server{
 		authorizer:  fakeAuthorizer{},
-		store:       store,
-		identity:    testIdentityForSessions(time.Now().UTC(), map[string]AccountUser{sessionID: user}),
+		store:       NewMemoryStore(),
+		identity:    testIdentityForSessions(now, map[string]AccountUser{sessionID: user}),
 		tmpl:        tmpl,
 		configDir:   tempDir,
 		enforceAuth: true,
@@ -1298,41 +1254,15 @@ func TestHandleHomePickerRendersTurnIndicatorOnWorkflowCard(t *testing.T) {
 		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
 	}
 	body := rec.Body.String()
-	if !strings.Contains(body, `stream-card-turn-indicator`) {
-		t.Fatalf("expected workflow turn indicator markup, got %q", body)
-	}
-	if !strings.Contains(body, `aria-label="Your turn pending in Main workflow"`) {
-		t.Fatalf("expected accessible turn indicator label, got %q", body)
-	}
-}
-
-func TestHandleHomePickerRendersWorkflowCardsAndScopedLinks(t *testing.T) {
-	tempDir := t.TempDir()
-	writeWorkflowConfig(t, filepath.Join(tempDir, "workflow.yaml"), "Main workflow", "string", "Main workflow description")
-	writeWorkflowConfig(t, filepath.Join(tempDir, "secondary.yaml"), "Secondary workflow", "number")
-
-	tmpl := parseTestTemplates(t)
-	server := &Server{
-		authorizer: fakeAuthorizer{},
-		tmpl:       tmpl,
-		configDir:  tempDir,
-	}
-
-	req := httptest.NewRequest(http.MethodGet, "/my", nil)
-	rec := httptest.NewRecorder()
-	server.handleHome(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
-	}
-	body := rec.Body.String()
-	if !strings.Contains(body, `class="stack u-max-w-7xl u-mx-auto"`) ||
+	if !strings.Contains(body, `class="stack u-max-w-7xl u-mx-auto my-home"`) ||
 		!strings.Contains(body, `class="page-header"`) ||
 		!strings.Contains(body, "Choose a stream") {
 		t.Fatalf("expected home picker wrapper structure, got %q", body)
 	}
-	if !strings.Contains(body, `class="workflow-grid"`) || !strings.Contains(body, `class="stream-card"`) {
-		t.Fatalf("expected workflow card grid markup, got %q", body)
+	if !strings.Contains(body, `class="my-home-catalog"`) ||
+		!strings.Contains(body, `class="public-home-stream-grid"`) ||
+		!strings.Contains(body, `class="public-stream-card"`) {
+		t.Fatalf("expected public stream card grid markup, got %q", body)
 	}
 	if !strings.Contains(body, `href="/my/streams/workflow/"`) {
 		t.Fatalf("expected scoped workflow href for workflow key, got %q", body)
@@ -1343,8 +1273,8 @@ func TestHandleHomePickerRendersWorkflowCardsAndScopedLinks(t *testing.T) {
 	if !strings.Contains(body, "Main workflow description") {
 		t.Fatalf("expected description content in cards, got %q", body)
 	}
-	if !strings.Contains(body, "Not started") || !strings.Contains(body, "In progress") || !strings.Contains(body, "Completed") {
-		t.Fatalf("expected status labels in cards, got %q", body)
+	if !strings.Contains(body, "1 step") || !strings.Contains(body, "1 role") {
+		t.Fatalf("expected public card metrics in cards, got %q", body)
 	}
 }
 
@@ -1400,6 +1330,7 @@ func TestHandleHomePickerCreateStreamCardVisibility(t *testing.T) {
 		user := AccountUser{
 			ID:        primitive.NewObjectID(),
 			Email:     "org-admin-picker@example.com",
+			OrgSlug:   "org1",
 			RoleSlugs: []string{"org-admin"},
 			Status:    "active",
 			CreatedAt: time.Now().UTC(),
@@ -1424,11 +1355,17 @@ func TestHandleHomePickerCreateStreamCardVisibility(t *testing.T) {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 		}
 		body := rec.Body.String()
-		if !strings.Contains(body, `href="/my/organization/formata-builder"`) {
-			t.Fatalf("expected create stream card for org admin, got %q", body)
+		for _, want := range []string{
+			`class="page-header-actions"`,
+			`href="/my/organization/formata-builder"`,
+			"Create a stream",
+		} {
+			if !strings.Contains(body, want) {
+				t.Fatalf("expected %q in org admin home header, got %q", want, body)
+			}
 		}
-		if !strings.Contains(body, "stream-card-cta") || !strings.Contains(body, "Create new stream") {
-			t.Fatalf("expected create stream card cta for org admin, got %q", body)
+		if strings.Contains(body, "stream-card-cta") || strings.Contains(body, "Create new stream") {
+			t.Fatalf("did not expect legacy create stream card on /my, got %q", body)
 		}
 	})
 
@@ -1437,6 +1374,7 @@ func TestHandleHomePickerCreateStreamCardVisibility(t *testing.T) {
 		user := AccountUser{
 			ID:        primitive.NewObjectID(),
 			Email:     "member-picker@example.com",
+			OrgSlug:   "org1",
 			RoleSlugs: []string{"operator"},
 			Status:    "active",
 			CreatedAt: time.Now().UTC(),
@@ -1550,6 +1488,7 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 			ID:             primitive.NewObjectID(),
 			IdentityUserID: "creator-home-user",
 			Email:          "creator-home@example.com",
+			OrgSlug:        "org1",
 			RoleSlugs:      []string{"org-admin"},
 			Status:         "active",
 		}
@@ -1582,7 +1521,7 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 		}
 		body := rec.Body.String()
-		if !strings.Contains(body, `class="btn btn-ghost btn-icon stream-card-menu-trigger"`) {
+		if !strings.Contains(body, `class="btn btn-ghost btn-icon public-stream-card-menu-trigger"`) {
 			t.Fatalf("expected workflow actions menu trigger for creator, got %q", body)
 		}
 		if !strings.Contains(body, `href="/my/organization/formata-builder?stream=`+stream.ID.Hex()+`&new=true"`) {
@@ -1614,6 +1553,7 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 			ID:             primitive.NewObjectID(),
 			IdentityUserID: "creator-home-started-user",
 			Email:          "creator-home-started@example.com",
+			OrgSlug:        "org1",
 			RoleSlugs:      []string{"org-admin"},
 			Status:         "active",
 		}
@@ -1653,7 +1593,7 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 		}
 		body := rec.Body.String()
-		if !strings.Contains(body, `class="btn btn-ghost btn-icon stream-card-menu-trigger"`) {
+		if !strings.Contains(body, `class="btn btn-ghost btn-icon public-stream-card-menu-trigger"`) {
 			t.Fatalf("expected workflow actions menu trigger for started stream, got %q", body)
 		}
 		if strings.Contains(body, `id="delete-workflow-`+stream.ID.Hex()+`"`) {
@@ -1668,10 +1608,10 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 		if strings.Contains(body, `href="/my/organization/formata-builder?stream=`+stream.ID.Hex()+`"`) {
 			t.Fatalf("did not expect direct edit action for started stream, got %q", body)
 		}
-		if !strings.Contains(body, `class="stream-card-menu-item stream-card-menu-item-disabled"`) {
+		if !strings.Contains(body, `class="public-stream-card-menu-item public-stream-card-menu-item-disabled"`) {
 			t.Fatalf("expected disabled edit action for started stream, got %q", body)
 		}
-		if !strings.Contains(body, `class="stream-card-menu-item stream-card-menu-item-danger stream-card-menu-item-disabled"`) {
+		if !strings.Contains(body, `class="public-stream-card-menu-item public-stream-card-menu-item-danger public-stream-card-menu-item-disabled"`) {
 			t.Fatalf("expected disabled delete action for started stream, got %q", body)
 		}
 	})
@@ -1717,7 +1657,7 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 		}
 		body := rec.Body.String()
-		if !strings.Contains(body, `class="btn btn-ghost btn-icon stream-card-menu-trigger"`) {
+		if !strings.Contains(body, `class="btn btn-ghost btn-icon public-stream-card-menu-trigger"`) {
 			t.Fatalf("expected workflow actions menu trigger for platform admin, got %q", body)
 		}
 		if !strings.Contains(body, `href="/my/organization/formata-builder?stream=`+stream.ID.Hex()+`&new=true"`) {
@@ -1749,6 +1689,7 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 			ID:             primitive.NewObjectID(),
 			IdentityUserID: "member-home-user",
 			Email:          "member-home@example.com",
+			OrgSlug:        "org1",
 			RoleSlugs:      []string{"inspector"},
 			Status:         "active",
 		}
@@ -1781,7 +1722,7 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 		}
 		body := rec.Body.String()
-		if strings.Contains(body, `stream-card-menu-trigger`) {
+		if strings.Contains(body, `public-stream-card-menu-trigger`) {
 			t.Fatalf("did not expect workflow actions menu trigger without builder access, got %q", body)
 		}
 		if strings.Contains(body, `href="/my/organization/formata-builder?stream=`+stream.ID.Hex()+`&new=true"`) {
@@ -1790,13 +1731,16 @@ func TestHandleHomePickerDeleteButtonVisibility(t *testing.T) {
 		if strings.Contains(body, `href="/my/organization/formata-builder?stream=`+stream.ID.Hex()+`"`) {
 			t.Fatalf("did not expect edit action without builder access, got %q", body)
 		}
-		if strings.Contains(body, `stream-card-menu-item-danger stream-card-menu-item-disabled`) {
+		if strings.Contains(body, `public-stream-card-menu-item-danger public-stream-card-menu-item-disabled`) {
 			t.Fatalf("did not expect delete action without builder access, got %q", body)
 		}
 	})
 }
 
 func TestHandleHomeRendersWorkflowPickerCountsByWorkflow(t *testing.T) {
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "secret")
+
 	tempDir := t.TempDir()
 	writeTwoSubstepWorkflowConfig(t, tempDir+"/workflow.yaml", "Main workflow")
 	writeTwoSubstepWorkflowConfig(t, tempDir+"/secondary.yaml", "Secondary workflow")
@@ -1862,13 +1806,15 @@ func TestHandleHomeRendersWorkflowPickerCountsByWorkflow(t *testing.T) {
 	})
 
 	server := &Server{
-		authorizer: fakeAuthorizer{},
-		tmpl:       homePickerTemplates(),
-		configDir:  tempDir,
-		store:      store,
+		authorizer:  fakeAuthorizer{},
+		tmpl:        homePickerTemplates(),
+		configDir:   tempDir,
+		store:       store,
+		enforceAuth: true,
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/my", nil)
+	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 	rec := httptest.NewRecorder()
 	server.handleHome(rec, req)
 
@@ -1876,11 +1822,11 @@ func TestHandleHomeRendersWorkflowPickerCountsByWorkflow(t *testing.T) {
 		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
 	}
 	body := rec.Body.String()
-	if !strings.Contains(body, "workflow:Main workflow:2/1/1") {
-		t.Fatalf("expected workflow counts 2/1/1, got %q", body)
+	if !strings.Contains(body, "workflow:Main workflow:instances=4:active=3|") {
+		t.Fatalf("expected workflow instance metrics, got %q", body)
 	}
-	if !strings.Contains(body, "secondary:Secondary workflow:0/1/1") {
-		t.Fatalf("expected secondary counts 0/1/1, got %q", body)
+	if !strings.Contains(body, "secondary:Secondary workflow:instances=2:active=1|") {
+		t.Fatalf("expected secondary instance metrics, got %q", body)
 	}
 }
 
@@ -2397,7 +2343,7 @@ PROCESSES {{range .Processes}}{{.ID}}:{{.Name}}:{{.Status}}:{{.Percent}}|{{end}}
 func homePickerTemplates() *template.Template {
 	return template.Must(template.New("test").Parse(`
 {{define "layout.html"}}{{template "home_picker_body" .}}{{end}}
-{{define "home_picker_body"}}PICK {{len .Workflows}} {{range .Workflows}}{{.Key}}:{{.Name}}{{if .Description}}:{{.Description}}{{end}}:{{.Counts.NotStarted}}/{{.Counts.Started}}/{{.Counts.Terminated}}{{if .HasUserTurn}}:turn{{end}}|{{end}}{{end}}
+{{define "home_picker_body"}}PICK GROUPS {{len .Groups}}{{if .ShowCreateStream}} CREATE{{end}} {{range .Groups}}{{range .Streams}}{{.Key}}:{{.Card.Name}}{{if .Card.Description}}:{{.Card.Description}}{{end}}:instances={{.Card.InstanceCount}}:active={{.Card.ActiveCount}}|{{end}}{{end}}{{end}}
 {{define "home.html"}}{{template "layout.html" .}}{{end}}
 `))
 }

--- a/server/cmd/server/home_handler_test.go
+++ b/server/cmd/server/home_handler_test.go
@@ -818,6 +818,9 @@ func TestHandleHomeCatalogWiring(t *testing.T) {
 	}
 	body := rec.Body.String()
 	for _, want := range []string{
+		`nav-drawer-trigger`,
+		`id="my-home-category-sidebar"`,
+		`class="category-sidebar"`,
 		`class="my-home-catalog"`,
 		"Accessible Stream",
 		`href="/my/streams/accessible/"`,

--- a/server/cmd/server/home_handler_test.go
+++ b/server/cmd/server/home_handler_test.go
@@ -24,7 +24,7 @@ func TestHandlePublicHomeRendersTaxonomySidebar(t *testing.T) {
 	server.handlePublicHome(rec, req)
 	body := rec.Body.String()
 	for _, want := range []string{
-		`class="public-home-category-sidebar"`,
+		`class="category-sidebar"`,
 		"Supply Chain",
 		"Procurement",
 		"Order Fulfillment",

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -304,16 +304,12 @@ type PublicCatalogRole struct {
 	Palette string `json:"palette"`
 }
 
-type WorkflowPickerView struct {
-	PageBase
-	Workflows            []StreamCardView
-	ShowCreateStreamCard bool
-	Error                string
-	Confirmation         string
-}
-
 type HomeWorkflowPickerView struct {
-	WorkflowPickerView
+	PageBase
+	Groups           []MyHomeStreamGroupView
+	ShowCreateStream bool
+	Error            string
+	Confirmation     string
 }
 
 type PaginationLink struct {
@@ -2110,23 +2106,16 @@ func (s *Server) handleHome(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	options, err := s.workflowOptions(r.Context(), user)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	showCreateStreamCard, authErr := s.canViewFormataBuilder(r.Context(), user)
+	showCreateStream, authErr := s.canViewFormataBuilder(r.Context(), user)
 	if authErr != nil {
 		logRequestError(r, authErr, "cerbos check failed for formata builder card")
 	}
 	view := HomeWorkflowPickerView{
-		WorkflowPickerView: WorkflowPickerView{
-			PageBase:             s.pageBaseForUser(user, "home_picker_body", "", ""),
-			Workflows:            options,
-			ShowCreateStreamCard: showCreateStreamCard,
-			Error:                homePickerMessage(r, "error"),
-			Confirmation:         homePickerMessage(r, "confirmation"),
-		},
+		PageBase:         s.pageBaseForUser(user, "home_picker_body", "", ""),
+		Groups:           nil,
+		ShowCreateStream: showCreateStream,
+		Error:            homePickerMessage(r, "error"),
+		Confirmation:     homePickerMessage(r, "confirmation"),
 	}
 	if err := s.tmpl.ExecuteTemplate(w, "home.html", view); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -1576,18 +1576,7 @@ func (s *Server) workflowOptions(ctx context.Context, user *AccountUser) ([]Stre
 		stream, ok := streamsByKey[key]
 		if ok && s.authorizer != nil && user != nil {
 			hasProcesses := option.Counts.NotStarted+option.Counts.Started+option.Counts.Terminated > 0
-			option.CanClone = canEditSavedStreams
-			if canEditSavedStreams {
-				allowed, err := s.canEditStream(ctx, user, key, formataStreamCreatorID(stream), hasProcesses)
-				if err == nil {
-					option.CanEdit = allowed
-					option.EditRequiresPurge = allowed && hasProcesses
-				}
-			}
-			allowed, err := s.authorizer.CanDeleteStream(ctx, user, key, formataStreamCreatorID(stream), hasProcesses)
-			if err == nil {
-				option.CanDelete = allowed
-			}
+			option.CanClone, option.CanEdit, option.EditRequiresPurge, option.CanDelete = s.streamManagementFlags(ctx, user, key, stream, hasProcesses, canEditSavedStreams)
 		}
 		options = append(options, option)
 	}
@@ -2110,10 +2099,16 @@ func (s *Server) handleHome(w http.ResponseWriter, r *http.Request) {
 	if authErr != nil {
 		logRequestError(r, authErr, "cerbos check failed for formata builder card")
 	}
+	groups, err := s.buildMyHomeCatalog(r.Context(), user)
+	if err != nil {
+		logRequestError(r, err, "build my home catalog")
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
 	view := HomeWorkflowPickerView{
 		PageBase:         s.pageBaseForUser(user, "home_picker_body", "", ""),
-		Groups:           nil,
-		ShowCreateStream: showCreateStream,
+		Groups:           groups,
+		ShowCreateStream: showCreateStream && authErr == nil,
 		Error:            homePickerMessage(r, "error"),
 		Confirmation:     homePickerMessage(r, "confirmation"),
 	}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -2062,11 +2062,11 @@ func (s *Server) handlePublicHome(w http.ResponseWriter, r *http.Request) {
 	}
 	view := struct {
 		PageBase
-		Categories    []PublicHomeCategoryView
+		Sidebar       CategorySidebarView
 		StreamResults PublicHomeStreamResultsView
 	}{
-		PageBase:   base,
-		Categories: buildPublicHomeCategories(categories, cat, sub),
+		PageBase:      base,
+		Sidebar:       buildPublicHomeCategories(categories, cat, sub),
 		StreamResults: buildPublicHomeStreamResultsView(categories, cat, sub, streams, publicHomeCreateStreamHref(signedIn)),
 	}
 	if err := s.tmpl.ExecuteTemplate(w, "public_home.html", view); err != nil {

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -307,6 +307,7 @@ type PublicCatalogRole struct {
 type HomeWorkflowPickerView struct {
 	PageBase
 	Groups           []MyHomeStreamGroupView
+	Sidebar          CategorySidebarView
 	ShowCreateStream bool
 	Error            string
 	Confirmation     string
@@ -2108,6 +2109,7 @@ func (s *Server) handleHome(w http.ResponseWriter, r *http.Request) {
 	view := HomeWorkflowPickerView{
 		PageBase:         s.pageBaseForUser(user, "home_picker_body", "", ""),
 		Groups:           groups,
+		Sidebar:          buildMyHomeCategorySidebar(groups),
 		ShowCreateStream: showCreateStream && authErr == nil,
 		Error:            homePickerMessage(r, "error"),
 		Confirmation:     homePickerMessage(r, "confirmation"),

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -1479,24 +1479,6 @@ func processStatusLabel(status string) string {
 	}
 }
 
-func workflowProcessCounts(def WorkflowDef, processes []Process) WorkflowProcessCounts {
-	counts := WorkflowProcessCounts{}
-	for _, process := range processes {
-		process.Progress = normalizeProgressKeys(process.Progress)
-		status := deriveProcessStatus(def, &process)
-		doneCount, _, _ := processProgressStats(def, &process)
-		switch {
-		case status == processStatusDone || status == processStatusTerminated:
-			counts.Terminated++
-		case doneCount == 0:
-			counts.NotStarted++
-		default:
-			counts.Started++
-		}
-	}
-	return counts
-}
-
 func formataStreamCreatorID(stream FormataBuilderStream) string {
 	if trimmed := strings.TrimSpace(stream.CreatedByUserID); trimmed != "" {
 		return trimmed
@@ -1509,79 +1491,6 @@ func homePickerMessage(r *http.Request, key string) string {
 		return ""
 	}
 	return strings.TrimSpace(r.URL.Query().Get(key))
-}
-
-func (s *Server) workflowOptions(ctx context.Context, user *AccountUser) ([]StreamCardView, error) {
-	catalog, err := s.workflowCatalog()
-	if err != nil {
-		return nil, err
-	}
-	canEditSavedStreams := false
-	if user != nil {
-		if allowed, err := s.canViewFormataBuilder(ctx, user); err == nil {
-			canEditSavedStreams = allowed
-		}
-	}
-	streamsByKey := map[string]FormataBuilderStream{}
-	if s.store != nil {
-		streams, err := s.store.ListFormataBuilderStreams(ctx)
-		if err != nil {
-			return nil, err
-		}
-		for _, stream := range streams {
-			if stream.ID.IsZero() {
-				continue
-			}
-			streamsByKey[stream.ID.Hex()] = stream
-		}
-	}
-	keys := sortedWorkflowKeys(catalog)
-	options := make([]StreamCardView, 0, len(keys))
-	for _, key := range keys {
-		cfg := catalog[key]
-		option := StreamCardView{
-			Key:          key,
-			Name:         cfg.Workflow.Name,
-			Description:  strings.TrimSpace(cfg.Workflow.Description),
-			Counts:       WorkflowProcessCounts{},
-			EditAction:   organizationPath("formata-builder?stream=" + key),
-			DeleteAction: streamPath(key) + "/delete",
-		}
-		if s.store == nil {
-			options = append(options, option)
-			continue
-		}
-		processes, listErr := s.store.ListRecentProcessesByWorkflow(ctx, key, 0)
-		if listErr != nil {
-			return nil, listErr
-		}
-		option.Counts = workflowProcessCounts(cfg.Workflow, processes)
-		actor := actorFromAccountUser(user, key)
-		if len(actor.RoleSlugs) == 0 && !s.enforceAuth {
-			actor.RoleSlugs = s.roles(cfg)
-			if len(actor.RoleSlugs) > 0 {
-				actor.Role = actor.RoleSlugs[0]
-			}
-		}
-		roleMeta := s.roleMetaIndex(ctx)
-		for _, process := range processes {
-			process.Progress = normalizeProgressKeys(process.Progress)
-			if deriveProcessStatus(cfg.Workflow, &process) != "active" {
-				continue
-			}
-			if _, ok := nextAuthorizedSubstepBody(cfg.Workflow, &process, key, actor, roleMeta, cfg.Roles); ok {
-				option.HasUserTurn = true
-				break
-			}
-		}
-		stream, ok := streamsByKey[key]
-		if ok && s.authorizer != nil && user != nil {
-			hasProcesses := option.Counts.NotStarted+option.Counts.Started+option.Counts.Terminated > 0
-			option.CanClone, option.CanEdit, option.EditRequiresPurge, option.CanDelete = s.streamManagementFlags(ctx, user, key, stream, hasProcesses, canEditSavedStreams)
-		}
-		options = append(options, option)
-	}
-	return options, nil
 }
 
 func (s *Server) selectedWorkflowUnvalidated(r *http.Request) (string, RuntimeConfig, error) {

--- a/server/cmd/server/managed_public_stream_card_test.go
+++ b/server/cmd/server/managed_public_stream_card_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestManagedPublicStreamCardRendersMenuAndMyHref(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+	var out bytes.Buffer
+	view := ManagedPublicStreamCardView{
+		Key:          "wf-a",
+		CanClone:     true,
+		CanEdit:      true,
+		EditAction:   "/my/organization/formata-builder?stream=wf-a",
+		CanDelete:    true,
+		DeleteAction: "/my/streams/wf-a/delete",
+		Card: PublicStreamCardView{
+			Name: "Alpha",
+			Href: "/my/streams/wf-a/",
+		},
+	}
+	if err := tmpl.ExecuteTemplate(&out, "managed_public_stream_card", view); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := out.String()
+	for _, want := range []string{
+		`href="/my/streams/wf-a/"`,
+		`class="public-stream-card-shell"`,
+		"Clone",
+		`id="delete-workflow-wf-a"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("missing %q in %s", want, body)
+		}
+	}
+}
+
+func TestManagedPublicStreamCardHidesMenuWithoutClone(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+	var out bytes.Buffer
+	view := ManagedPublicStreamCardView{
+		Key: "wf-a",
+		Card: PublicStreamCardView{
+			Name: "Alpha",
+			Href: "/my/streams/wf-a/",
+		},
+	}
+	if err := tmpl.ExecuteTemplate(&out, "managed_public_stream_card", view); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if strings.Contains(out.String(), "public-stream-card-menu") {
+		t.Fatalf("menu should be absent: %s", out.String())
+	}
+}

--- a/server/cmd/server/my_home.go
+++ b/server/cmd/server/my_home.go
@@ -10,6 +10,7 @@ func buildMyHomeStreamGroups(categories []TaxonomyCategoryNode, cardsByKey map[s
 
 	var groups []MyHomeStreamGroupView
 	for _, category := range categories {
+		categoryHeaderEmitted := false
 		for _, sub := range category.SubCategories {
 			var streams []ManagedPublicStreamCardView
 			for _, key := range accessibleKeys {
@@ -34,14 +35,18 @@ func buildMyHomeStreamGroups(categories []TaxonomyCategoryNode, cardsByKey map[s
 			if len(streams) == 0 {
 				continue
 			}
-			groups = append(groups, MyHomeStreamGroupView{
-				CategoryName:           category.Name,
-				CategoryIconURL:        category.IconURL,
+			group := MyHomeStreamGroupView{
 				SubCategoryName:        sub.Name,
 				SubCategoryIconURL:     sub.IconURL,
 				SubCategoryDescription: sub.Description,
 				Streams:                streams,
-			})
+			}
+			if !categoryHeaderEmitted {
+				group.CategoryName = category.Name
+				group.CategoryIconURL = category.IconURL
+				categoryHeaderEmitted = true
+			}
+			groups = append(groups, group)
 		}
 	}
 

--- a/server/cmd/server/my_home.go
+++ b/server/cmd/server/my_home.go
@@ -1,5 +1,7 @@
 package main
 
+import "context"
+
 func buildMyHomeStreamGroups(categories []TaxonomyCategoryNode, cardsByKey map[string]ManagedPublicStreamCardView, catalog map[string]RuntimeConfig, accessibleKeys []string) []MyHomeStreamGroupView {
 	remaining := make(map[string]struct{}, len(accessibleKeys))
 	for _, key := range accessibleKeys {
@@ -62,4 +64,89 @@ func buildMyHomeStreamGroups(categories []TaxonomyCategoryNode, cardsByKey map[s
 		})
 	}
 	return groups
+}
+
+// streamManagementFlags mirrors workflowOptions CanClone/CanEdit/CanDelete rules.
+func (s *Server) streamManagementFlags(ctx context.Context, user *AccountUser, key string, stream FormataBuilderStream, hasProcesses, canEditSavedStreams bool) (canClone, canEdit, editRequiresPurge, canDelete bool) {
+	if s.authorizer == nil || user == nil {
+		return false, false, false, false
+	}
+	canClone = canEditSavedStreams
+	if canEditSavedStreams {
+		if allowed, err := s.canEditStream(ctx, user, key, formataStreamCreatorID(stream), hasProcesses); err == nil {
+			canEdit = allowed
+			editRequiresPurge = allowed && hasProcesses
+		}
+	}
+	if allowed, err := s.authorizer.CanDeleteStream(ctx, user, key, formataStreamCreatorID(stream), hasProcesses); err == nil {
+		canDelete = allowed
+	}
+	return canClone, canEdit, editRequiresPurge, canDelete
+}
+
+func (s *Server) buildMyHomeCatalog(ctx context.Context, user *AccountUser) ([]MyHomeStreamGroupView, error) {
+	catalog, err := s.workflowCatalog()
+	if err != nil {
+		return nil, err
+	}
+	var categories []TaxonomyCategoryNode
+	if s.store != nil {
+		categories, err = loadTaxonomyTree(ctx, s.store)
+		if err != nil {
+			return nil, err
+		}
+	}
+	logoURLs := organizationLogoURLMap(ctx, s.identity)
+
+	canEditSavedStreams := false
+	if user != nil {
+		if allowed, err := s.canViewFormataBuilder(ctx, user); err == nil {
+			canEditSavedStreams = allowed
+		}
+	}
+
+	streamsByKey := map[string]FormataBuilderStream{}
+	if s.store != nil {
+		streams, listErr := s.store.ListFormataBuilderStreams(ctx)
+		if listErr != nil {
+			return nil, listErr
+		}
+		for _, stream := range streams {
+			if stream.ID.IsZero() {
+				continue
+			}
+			streamsByKey[stream.ID.Hex()] = stream
+		}
+	}
+
+	var accessibleKeys []string
+	for _, key := range sortedWorkflowKeys(catalog) {
+		if userCanAccessStream(user, catalog[key]) {
+			accessibleKeys = append(accessibleKeys, key)
+		}
+	}
+
+	cardsByKey := make(map[string]ManagedPublicStreamCardView, len(accessibleKeys))
+	for _, key := range accessibleKeys {
+		cfg := catalog[key]
+		card, buildErr := s.buildPublicStreamCardView(ctx, key, cfg, logoURLs)
+		if buildErr != nil {
+			return nil, buildErr
+		}
+		card.Href = streamPath(key) + "/"
+
+		managed := ManagedPublicStreamCardView{
+			Key:          key,
+			Card:         card,
+			EditAction:   organizationPath("formata-builder?stream=" + key),
+			DeleteAction: streamPath(key) + "/delete",
+		}
+		if stream, ok := streamsByKey[key]; ok {
+			hasProcesses := card.InstanceCount > 0
+			managed.CanClone, managed.CanEdit, managed.EditRequiresPurge, managed.CanDelete = s.streamManagementFlags(ctx, user, key, stream, hasProcesses, canEditSavedStreams)
+		}
+		cardsByKey[key] = managed
+	}
+
+	return buildMyHomeStreamGroups(categories, cardsByKey, catalog, accessibleKeys), nil
 }

--- a/server/cmd/server/my_home.go
+++ b/server/cmd/server/my_home.go
@@ -1,0 +1,65 @@
+package main
+
+func buildMyHomeStreamGroups(categories []TaxonomyCategoryNode, cardsByKey map[string]ManagedPublicStreamCardView, catalog map[string]RuntimeConfig, accessibleKeys []string) []MyHomeStreamGroupView {
+	remaining := make(map[string]struct{}, len(accessibleKeys))
+	for _, key := range accessibleKeys {
+		remaining[key] = struct{}{}
+	}
+
+	var groups []MyHomeStreamGroupView
+	for _, category := range categories {
+		for _, sub := range category.SubCategories {
+			var streams []ManagedPublicStreamCardView
+			for _, key := range accessibleKeys {
+				if _, ok := remaining[key]; !ok {
+					continue
+				}
+				cfg, ok := catalog[key]
+				if !ok {
+					continue
+				}
+				if cfg.Workflow.CategorySlug != category.Slug || cfg.Workflow.SubCategorySlug != sub.Slug {
+					continue
+				}
+				card, ok := cardsByKey[key]
+				if !ok {
+					delete(remaining, key)
+					continue
+				}
+				streams = append(streams, card)
+				delete(remaining, key)
+			}
+			if len(streams) == 0 {
+				continue
+			}
+			groups = append(groups, MyHomeStreamGroupView{
+				CategoryName:           category.Name,
+				CategoryIconURL:        category.IconURL,
+				SubCategoryName:        sub.Name,
+				SubCategoryIconURL:     sub.IconURL,
+				SubCategoryDescription: sub.Description,
+				Streams:                streams,
+			})
+		}
+	}
+
+	var uncategorized []ManagedPublicStreamCardView
+	for _, key := range accessibleKeys {
+		if _, ok := remaining[key]; !ok {
+			continue
+		}
+		card, ok := cardsByKey[key]
+		if !ok {
+			continue
+		}
+		uncategorized = append(uncategorized, card)
+	}
+	if len(uncategorized) > 0 {
+		groups = append(groups, MyHomeStreamGroupView{
+			CategoryName:  "Uncategorized",
+			Uncategorized: true,
+			Streams:       uncategorized,
+		})
+	}
+	return groups
+}

--- a/server/cmd/server/my_home.go
+++ b/server/cmd/server/my_home.go
@@ -1,6 +1,16 @@
 package main
 
-import "context"
+import (
+	"context"
+	"strings"
+)
+
+func myHomeAnchorID(categorySlug, subCategorySlug string, uncategorized bool) string {
+	if uncategorized {
+		return "cat-uncategorized"
+	}
+	return "cat-" + strings.TrimSpace(categorySlug) + "--" + strings.TrimSpace(subCategorySlug)
+}
 
 func buildMyHomeStreamGroups(categories []TaxonomyCategoryNode, cardsByKey map[string]ManagedPublicStreamCardView, catalog map[string]RuntimeConfig, accessibleKeys []string) []MyHomeStreamGroupView {
 	remaining := make(map[string]struct{}, len(accessibleKeys))
@@ -36,16 +46,18 @@ func buildMyHomeStreamGroups(categories []TaxonomyCategoryNode, cardsByKey map[s
 				continue
 			}
 			group := MyHomeStreamGroupView{
+				CategoryName:           category.Name,
+				CategoryIconURL:        category.IconURL,
+				CategorySlug:           category.Slug,
+				SubCategorySlug:        sub.Slug,
 				SubCategoryName:        sub.Name,
 				SubCategoryIconURL:     sub.IconURL,
 				SubCategoryDescription: sub.Description,
+				AnchorID:               myHomeAnchorID(category.Slug, sub.Slug, false),
+				ShowCategoryHeader:     !categoryHeaderEmitted,
 				Streams:                streams,
 			}
-			if !categoryHeaderEmitted {
-				group.CategoryName = category.Name
-				group.CategoryIconURL = category.IconURL
-				categoryHeaderEmitted = true
-			}
+			categoryHeaderEmitted = true
 			groups = append(groups, group)
 		}
 	}
@@ -63,9 +75,11 @@ func buildMyHomeStreamGroups(categories []TaxonomyCategoryNode, cardsByKey map[s
 	}
 	if len(uncategorized) > 0 {
 		groups = append(groups, MyHomeStreamGroupView{
-			CategoryName:  "Uncategorized",
-			Uncategorized: true,
-			Streams:       uncategorized,
+			CategoryName:       "Uncategorized",
+			AnchorID:           myHomeAnchorID("", "", true),
+			ShowCategoryHeader: true,
+			Uncategorized:      true,
+			Streams:            uncategorized,
 		})
 	}
 	return groups

--- a/server/cmd/server/my_home.go
+++ b/server/cmd/server/my_home.go
@@ -127,7 +127,11 @@ func buildMyHomeCategorySidebar(groups []MyHomeStreamGroupView) CategorySidebarV
 		})
 	}
 	flush()
-	return CategorySidebarView{Title: "Stream Categories", Categories: cats}
+	return CategorySidebarView{
+		Title:         "Stream Categories",
+		CloseTargetID: "my-home-category-sidebar",
+		Categories:    cats,
+	}
 }
 
 // streamManagementFlags mirrors workflowOptions CanClone/CanEdit/CanDelete rules.

--- a/server/cmd/server/my_home.go
+++ b/server/cmd/server/my_home.go
@@ -134,7 +134,7 @@ func buildMyHomeCategorySidebar(groups []MyHomeStreamGroupView) CategorySidebarV
 	}
 }
 
-// streamManagementFlags mirrors workflowOptions CanClone/CanEdit/CanDelete rules.
+// streamManagementFlags derives CanClone/CanEdit/CanDelete for managed stream cards.
 func (s *Server) streamManagementFlags(ctx context.Context, user *AccountUser, key string, stream FormataBuilderStream, hasProcesses, canEditSavedStreams bool) (canClone, canEdit, editRequiresPurge, canDelete bool) {
 	if s.authorizer == nil || user == nil {
 		return false, false, false, false

--- a/server/cmd/server/my_home.go
+++ b/server/cmd/server/my_home.go
@@ -85,6 +85,51 @@ func buildMyHomeStreamGroups(categories []TaxonomyCategoryNode, cardsByKey map[s
 	return groups
 }
 
+func buildMyHomeCategorySidebar(groups []MyHomeStreamGroupView) CategorySidebarView {
+	var cats []CategorySidebarCategoryView
+	var current *CategorySidebarCategoryView
+
+	flush := func() {
+		if current != nil {
+			cats = append(cats, *current)
+			current = nil
+		}
+	}
+
+	for _, g := range groups {
+		if g.Uncategorized {
+			flush()
+			cats = append(cats, CategorySidebarCategoryView{
+				Slug:     "uncategorized",
+				Name:     "Uncategorized",
+				Expanded: true,
+				SubCategories: []CategorySidebarLeafView{{
+					Slug: "uncategorized",
+					Name: "Uncategorized",
+					Href: "#" + g.AnchorID,
+				}},
+			})
+			continue
+		}
+		if current == nil || current.Slug != g.CategorySlug {
+			flush()
+			current = &CategorySidebarCategoryView{
+				Slug:     g.CategorySlug,
+				Name:     g.CategoryName,
+				IconURL:  g.CategoryIconURL,
+				Expanded: true,
+			}
+		}
+		current.SubCategories = append(current.SubCategories, CategorySidebarLeafView{
+			Slug: g.SubCategorySlug,
+			Name: g.SubCategoryName,
+			Href: "#" + g.AnchorID,
+		})
+	}
+	flush()
+	return CategorySidebarView{Title: "Stream Categories", Categories: cats}
+}
+
 // streamManagementFlags mirrors workflowOptions CanClone/CanEdit/CanDelete rules.
 func (s *Server) streamManagementFlags(ctx context.Context, user *AccountUser, key string, stream FormataBuilderStream, hasProcesses, canEditSavedStreams bool) (canClone, canEdit, editRequiresPurge, canDelete bool) {
 	if s.authorizer == nil || user == nil {

--- a/server/cmd/server/my_home.go
+++ b/server/cmd/server/my_home.go
@@ -91,6 +91,7 @@ func buildMyHomeCategorySidebar(groups []MyHomeStreamGroupView) CategorySidebarV
 
 	flush := func() {
 		if current != nil {
+			current.Expanded = len(cats) == 0
 			cats = append(cats, *current)
 			current = nil
 		}
@@ -102,7 +103,7 @@ func buildMyHomeCategorySidebar(groups []MyHomeStreamGroupView) CategorySidebarV
 			cats = append(cats, CategorySidebarCategoryView{
 				Slug:     "uncategorized",
 				Name:     "Uncategorized",
-				Expanded: true,
+				Expanded: len(cats) == 0,
 				SubCategories: []CategorySidebarLeafView{{
 					Slug: "uncategorized",
 					Name: "Uncategorized",
@@ -114,10 +115,9 @@ func buildMyHomeCategorySidebar(groups []MyHomeStreamGroupView) CategorySidebarV
 		if current == nil || current.Slug != g.CategorySlug {
 			flush()
 			current = &CategorySidebarCategoryView{
-				Slug:     g.CategorySlug,
-				Name:     g.CategoryName,
-				IconURL:  g.CategoryIconURL,
-				Expanded: true,
+				Slug:    g.CategorySlug,
+				Name:    g.CategoryName,
+				IconURL: g.CategoryIconURL,
 			}
 		}
 		current.SubCategories = append(current.SubCategories, CategorySidebarLeafView{

--- a/server/cmd/server/my_home_access.go
+++ b/server/cmd/server/my_home_access.go
@@ -1,0 +1,38 @@
+package main
+
+import "strings"
+
+func userCanAccessStream(user *AccountUser, cfg RuntimeConfig) bool {
+	if user == nil {
+		return false
+	}
+	if user.IsPlatformAdmin {
+		return true
+	}
+	org := strings.TrimSpace(user.OrgSlug)
+	if org == "" {
+		return false
+	}
+	participates := false
+	for _, o := range cfg.Organizations {
+		if strings.TrimSpace(o.Slug) == org {
+			participates = true
+			break
+		}
+	}
+	if !participates {
+		return false
+	}
+	if userIsOrgAdmin(user) {
+		return true
+	}
+	for _, role := range cfg.Roles {
+		if strings.TrimSpace(role.OrgSlug) != org {
+			continue
+		}
+		if containsRole(user.RoleSlugs, strings.TrimSpace(role.Slug)) {
+			return true
+		}
+	}
+	return false
+}

--- a/server/cmd/server/my_home_access_test.go
+++ b/server/cmd/server/my_home_access_test.go
@@ -1,0 +1,74 @@
+package main
+
+import "testing"
+
+func TestUserCanAccessStream(t *testing.T) {
+	cfg := RuntimeConfig{
+		Organizations: []WorkflowOrganization{{Slug: "acme", Name: "Acme"}},
+		Roles: []WorkflowRole{
+			{OrgSlug: "acme", Slug: "operator", Name: "Operator"},
+			{OrgSlug: "other", Slug: "reviewer", Name: "Reviewer"},
+		},
+	}
+	otherOrgCfg := RuntimeConfig{
+		Organizations: []WorkflowOrganization{{Slug: "other", Name: "Other"}},
+		Roles:         []WorkflowRole{{OrgSlug: "other", Slug: "reviewer", Name: "Reviewer"}},
+	}
+
+	cases := []struct {
+		name string
+		user *AccountUser
+		cfg  RuntimeConfig
+		want bool
+	}{
+		{
+			name: "platform admin sees all",
+			user: &AccountUser{IsPlatformAdmin: true},
+			cfg:  otherOrgCfg,
+			want: true,
+		},
+		{
+			name: "org admin sees org streams without workflow role",
+			user: &AccountUser{OrgSlug: "acme", RoleSlugs: []string{"org-admin"}},
+			cfg:  cfg,
+			want: true,
+		},
+		{
+			name: "org admin does not see other org streams",
+			user: &AccountUser{OrgSlug: "acme", RoleSlugs: []string{"org-admin"}},
+			cfg:  otherOrgCfg,
+			want: false,
+		},
+		{
+			name: "role member matching org+role",
+			user: &AccountUser{OrgSlug: "acme", RoleSlugs: []string{"operator"}},
+			cfg:  cfg,
+			want: true,
+		},
+		{
+			name: "role member wrong role",
+			user: &AccountUser{OrgSlug: "acme", RoleSlugs: []string{"reviewer"}},
+			cfg:  cfg,
+			want: false,
+		},
+		{
+			name: "outsider",
+			user: &AccountUser{OrgSlug: "stranger", RoleSlugs: []string{"operator"}},
+			cfg:  cfg,
+			want: false,
+		},
+		{
+			name: "nil user",
+			user: nil,
+			cfg:  cfg,
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := userCanAccessStream(tc.user, tc.cfg); got != tc.want {
+				t.Fatalf("userCanAccessStream = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/server/cmd/server/my_home_stream_group_test.go
+++ b/server/cmd/server/my_home_stream_group_test.go
@@ -29,7 +29,6 @@ func TestMyHomeStreamGroupTemplateRendersCategoryHeaders(t *testing.T) {
 
 	for _, want := range []string{
 		`id="cat-supply-chain--procurement"`,
-		`class="my-home-category-rule"`,
 		`class="public-home-results-category-header"`,
 		`class="public-home-results-category-name">Supply Chain<`,
 		`class="public-home-results-subcategory-header"`,
@@ -96,9 +95,6 @@ func TestMyHomeStreamGroupTemplateOmitsCategoryHeaderWhenEmpty(t *testing.T) {
 	body := out.String()
 	if strings.Contains(body, `class="public-home-results-category-header"`) {
 		t.Fatalf("ShowCategoryHeader false must omit category header, got: %s", body)
-	}
-	if strings.Contains(body, `class="my-home-category-rule"`) {
-		t.Fatalf("ShowCategoryHeader false must omit category rule, got: %s", body)
 	}
 	if !strings.Contains(body, `class="public-home-results-subcategory-name"`) || !strings.Contains(body, "Order Fulfillment") {
 		t.Fatalf("expected subcategory header, got: %s", body)

--- a/server/cmd/server/my_home_stream_group_test.go
+++ b/server/cmd/server/my_home_stream_group_test.go
@@ -140,6 +140,11 @@ func TestHomePickerBodyRendersSidebarAndDrawerTrigger(t *testing.T) {
 			t.Fatalf("missing %q in %s", want, body)
 		}
 	}
+	headerIdx := strings.Index(body, `class="page-header-head"`)
+	barIdx := strings.Index(body, `class="my-home-category-bar"`)
+	if headerIdx < 0 || barIdx < 0 || barIdx < headerIdx {
+		t.Fatalf("category bar must render below page-header-head; header=%d bar=%d body=%s", headerIdx, barIdx, body)
+	}
 }
 
 func TestHomePickerBodyTemplateRendersEmptyState(t *testing.T) {

--- a/server/cmd/server/my_home_stream_group_test.go
+++ b/server/cmd/server/my_home_stream_group_test.go
@@ -16,6 +16,8 @@ func TestMyHomeStreamGroupTemplateRendersCategoryHeaders(t *testing.T) {
 		SubCategoryName:        "Procurement",
 		SubCategoryIconURL:     "/static/taxonomy/procurement-workflow.svg",
 		SubCategoryDescription: "PO management",
+		ShowCategoryHeader:     true,
+		AnchorID:               "cat-supply-chain--procurement",
 		Streams: []ManagedPublicStreamCardView{
 			{Card: PublicStreamCardView{Name: "Example Stream"}},
 		},
@@ -26,6 +28,7 @@ func TestMyHomeStreamGroupTemplateRendersCategoryHeaders(t *testing.T) {
 	body := out.String()
 
 	for _, want := range []string{
+		`id="cat-supply-chain--procurement"`,
 		`class="public-home-results-category-header"`,
 		`class="public-home-results-category-name">Supply Chain<`,
 		`class="public-home-results-subcategory-header"`,
@@ -46,8 +49,10 @@ func TestMyHomeStreamGroupTemplateUncategorizedOmitsSubcategoryHeader(t *testing
 
 	var out bytes.Buffer
 	group := MyHomeStreamGroupView{
-		CategoryName:  "Uncategorized",
-		Uncategorized: true,
+		CategoryName:       "Uncategorized",
+		Uncategorized:      true,
+		ShowCategoryHeader: true,
+		AnchorID:           "cat-uncategorized",
 		Streams: []ManagedPublicStreamCardView{
 			{Card: PublicStreamCardView{Name: "Loose Stream"}},
 		},
@@ -76,7 +81,10 @@ func TestMyHomeStreamGroupTemplateOmitsCategoryHeaderWhenEmpty(t *testing.T) {
 
 	var out bytes.Buffer
 	group := MyHomeStreamGroupView{
+		CategoryName:    "Supply Chain",
 		SubCategoryName: "Order Fulfillment",
+		ShowCategoryHeader: false,
+		AnchorID:        "cat-supply-chain--order-fulfillment",
 		Streams: []ManagedPublicStreamCardView{
 			{Card: PublicStreamCardView{Name: "Follow-on Stream"}},
 		},
@@ -86,7 +94,7 @@ func TestMyHomeStreamGroupTemplateOmitsCategoryHeaderWhenEmpty(t *testing.T) {
 	}
 	body := out.String()
 	if strings.Contains(body, `class="public-home-results-category-header"`) {
-		t.Fatalf("empty CategoryName must omit category header, got: %s", body)
+		t.Fatalf("ShowCategoryHeader false must omit category header, got: %s", body)
 	}
 	if !strings.Contains(body, `class="public-home-results-subcategory-name"`) || !strings.Contains(body, "Order Fulfillment") {
 		t.Fatalf("expected subcategory header, got: %s", body)

--- a/server/cmd/server/my_home_stream_group_test.go
+++ b/server/cmd/server/my_home_stream_group_test.go
@@ -124,6 +124,7 @@ func TestHomePickerBodyRendersSidebarAndDrawerTrigger(t *testing.T) {
 	}
 	body := out.String()
 	for _, want := range []string{
+		`class="my-home-category-bar"`,
 		`nav-drawer-trigger`,
 		`popovertarget="my-home-category-sidebar"`,
 		`id="my-home-category-sidebar"`,

--- a/server/cmd/server/my_home_stream_group_test.go
+++ b/server/cmd/server/my_home_stream_group_test.go
@@ -71,6 +71,28 @@ func TestMyHomeStreamGroupTemplateUncategorizedOmitsSubcategoryHeader(t *testing
 	}
 }
 
+func TestMyHomeStreamGroupTemplateOmitsCategoryHeaderWhenEmpty(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+
+	var out bytes.Buffer
+	group := MyHomeStreamGroupView{
+		SubCategoryName: "Order Fulfillment",
+		Streams: []ManagedPublicStreamCardView{
+			{Card: PublicStreamCardView{Name: "Follow-on Stream"}},
+		},
+	}
+	if err := tmpl.ExecuteTemplate(&out, "my_home_stream_group", group); err != nil {
+		t.Fatalf("render my_home_stream_group template: %v", err)
+	}
+	body := out.String()
+	if strings.Contains(body, `class="public-home-results-category-header"`) {
+		t.Fatalf("empty CategoryName must omit category header, got: %s", body)
+	}
+	if !strings.Contains(body, `class="public-home-results-subcategory-name"`) || !strings.Contains(body, "Order Fulfillment") {
+		t.Fatalf("expected subcategory header, got: %s", body)
+	}
+}
+
 func TestHomePickerBodyTemplateRendersEmptyState(t *testing.T) {
 	tmpl := parseTestTemplates(t)
 

--- a/server/cmd/server/my_home_stream_group_test.go
+++ b/server/cmd/server/my_home_stream_group_test.go
@@ -125,7 +125,7 @@ func TestHomePickerBodyRendersSidebarAndDrawerTrigger(t *testing.T) {
 	}
 	body := out.String()
 	for _, want := range []string{
-		`class="my-home-category-bar"`,
+		`class="my-home-category-menu"`,
 		`nav-drawer-trigger`,
 		`popovertarget="my-home-category-sidebar"`,
 		`popovertargetaction="hide"`,
@@ -140,10 +140,13 @@ func TestHomePickerBodyRendersSidebarAndDrawerTrigger(t *testing.T) {
 			t.Fatalf("missing %q in %s", want, body)
 		}
 	}
+	if strings.Contains(body, `class="my-home-category-bar"`) {
+		t.Fatalf("mobile category bar must be removed, got: %s", body)
+	}
 	headerIdx := strings.Index(body, `class="page-header-head"`)
-	barIdx := strings.Index(body, `class="my-home-category-bar"`)
-	if headerIdx < 0 || barIdx < 0 || barIdx < headerIdx {
-		t.Fatalf("category bar must render below page-header-head; header=%d bar=%d body=%s", headerIdx, barIdx, body)
+	menuIdx := strings.Index(body, `class="my-home-category-menu"`)
+	if headerIdx < 0 || menuIdx < 0 || menuIdx < headerIdx {
+		t.Fatalf("category menu must render below page-header-head; header=%d menu=%d body=%s", headerIdx, menuIdx, body)
 	}
 }
 

--- a/server/cmd/server/my_home_stream_group_test.go
+++ b/server/cmd/server/my_home_stream_group_test.go
@@ -101,6 +101,43 @@ func TestMyHomeStreamGroupTemplateOmitsCategoryHeaderWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestHomePickerBodyRendersSidebarAndDrawerTrigger(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+	var out bytes.Buffer
+	view := HomeWorkflowPickerView{
+		PageBase: PageBase{Body: "home_picker_body"},
+		Groups: []MyHomeStreamGroupView{{
+			CategoryName: "Supply Chain", SubCategoryName: "Procurement",
+			AnchorID: "cat-supply-chain--procurement", ShowCategoryHeader: true,
+			Streams: []ManagedPublicStreamCardView{{Card: PublicStreamCardView{Name: "A"}}},
+		}},
+		Sidebar: CategorySidebarView{
+			Title: "Stream Categories",
+			Categories: []CategorySidebarCategoryView{{
+				Name: "Supply Chain", Expanded: true,
+				SubCategories: []CategorySidebarLeafView{{Name: "Procurement", Href: "#cat-supply-chain--procurement"}},
+			}},
+		},
+	}
+	if err := tmpl.ExecuteTemplate(&out, "home_picker_body", view); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := out.String()
+	for _, want := range []string{
+		`nav-drawer-trigger`,
+		`popovertarget="my-home-category-sidebar"`,
+		`id="my-home-category-sidebar"`,
+		`class="category-sidebar"`,
+		`href="#cat-supply-chain--procurement"`,
+		`id="cat-supply-chain--procurement"`,
+		`class="my-home-catalog"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("missing %q in %s", want, body)
+		}
+	}
+}
+
 func TestHomePickerBodyTemplateRendersEmptyState(t *testing.T) {
 	tmpl := parseTestTemplates(t)
 
@@ -126,6 +163,14 @@ func TestHomePickerBodyTemplateRendersEmptyState(t *testing.T) {
 	}
 	if strings.Contains(body, `class="my-home-catalog"`) {
 		t.Fatalf("empty home picker must not render catalog, got: %s", body)
+	}
+	for _, gone := range []string{
+		`nav-drawer-trigger`,
+		`category-sidebar`,
+	} {
+		if strings.Contains(body, gone) {
+			t.Fatalf("empty home picker must not render %q, got: %s", gone, body)
+		}
 	}
 }
 

--- a/server/cmd/server/my_home_stream_group_test.go
+++ b/server/cmd/server/my_home_stream_group_test.go
@@ -29,6 +29,7 @@ func TestMyHomeStreamGroupTemplateRendersCategoryHeaders(t *testing.T) {
 
 	for _, want := range []string{
 		`id="cat-supply-chain--procurement"`,
+		`class="my-home-category-rule"`,
 		`class="public-home-results-category-header"`,
 		`class="public-home-results-category-name">Supply Chain<`,
 		`class="public-home-results-subcategory-header"`,
@@ -95,6 +96,9 @@ func TestMyHomeStreamGroupTemplateOmitsCategoryHeaderWhenEmpty(t *testing.T) {
 	body := out.String()
 	if strings.Contains(body, `class="public-home-results-category-header"`) {
 		t.Fatalf("ShowCategoryHeader false must omit category header, got: %s", body)
+	}
+	if strings.Contains(body, `class="my-home-category-rule"`) {
+		t.Fatalf("ShowCategoryHeader false must omit category rule, got: %s", body)
 	}
 	if !strings.Contains(body, `class="public-home-results-subcategory-name"`) || !strings.Contains(body, "Order Fulfillment") {
 		t.Fatalf("expected subcategory header, got: %s", body)

--- a/server/cmd/server/my_home_stream_group_test.go
+++ b/server/cmd/server/my_home_stream_group_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestMyHomeStreamGroupTemplateRendersCategoryHeaders(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+
+	var out bytes.Buffer
+	group := MyHomeStreamGroupView{
+		CategoryName:           "Supply Chain",
+		CategoryIconURL:        "/static/taxonomy/batch-traceability.svg",
+		SubCategoryName:        "Procurement",
+		SubCategoryIconURL:     "/static/taxonomy/procurement-workflow.svg",
+		SubCategoryDescription: "PO management",
+		Streams: []ManagedPublicStreamCardView{
+			{Card: PublicStreamCardView{Name: "Example Stream"}},
+		},
+	}
+	if err := tmpl.ExecuteTemplate(&out, "my_home_stream_group", group); err != nil {
+		t.Fatalf("render my_home_stream_group template: %v", err)
+	}
+	body := out.String()
+
+	for _, want := range []string{
+		`class="public-home-results-category-header"`,
+		`class="public-home-results-category-name">Supply Chain<`,
+		`class="public-home-results-subcategory-header"`,
+		`class="public-home-results-subcategory-name"`,
+		"Procurement",
+		"PO management",
+		`class="public-home-stream-grid"`,
+		"Example Stream",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in rendered group, got: %s", want, body)
+		}
+	}
+}
+
+func TestMyHomeStreamGroupTemplateUncategorizedOmitsSubcategoryHeader(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+
+	var out bytes.Buffer
+	group := MyHomeStreamGroupView{
+		CategoryName:  "Uncategorized",
+		Uncategorized: true,
+		Streams: []ManagedPublicStreamCardView{
+			{Card: PublicStreamCardView{Name: "Loose Stream"}},
+		},
+	}
+	if err := tmpl.ExecuteTemplate(&out, "my_home_stream_group", group); err != nil {
+		t.Fatalf("render my_home_stream_group template: %v", err)
+	}
+	body := out.String()
+
+	for _, want := range []string{
+		`class="public-home-results-category-name">Uncategorized<`,
+		`class="public-home-stream-grid"`,
+		"Loose Stream",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in rendered uncategorized group, got: %s", want, body)
+		}
+	}
+	if strings.Contains(body, `class="public-home-results-subcategory-header"`) {
+		t.Fatalf("uncategorized group must not render subcategory header, got: %s", body)
+	}
+}
+
+func TestHomePickerBodyTemplateRendersEmptyState(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+
+	var out bytes.Buffer
+	view := HomeWorkflowPickerView{
+		PageBase: PageBase{Body: "home_picker_body"},
+	}
+	if err := tmpl.ExecuteTemplate(&out, "home_picker_body", view); err != nil {
+		t.Fatalf("render home_picker_body template: %v", err)
+	}
+	body := out.String()
+
+	for _, want := range []string{
+		`my-home"`,
+		"Choose a stream",
+		`class="empty-state"`,
+		`class="empty-state-title">No streams available<`,
+		"Streams for your organization and roles will appear here.",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in empty home picker, got: %s", want, body)
+		}
+	}
+	if strings.Contains(body, `class="my-home-catalog"`) {
+		t.Fatalf("empty home picker must not render catalog, got: %s", body)
+	}
+}
+
+func TestHomePickerBodyTemplateRendersCreateStreamAction(t *testing.T) {
+	tmpl := parseTestTemplates(t)
+
+	var out bytes.Buffer
+	view := HomeWorkflowPickerView{
+		PageBase:         PageBase{Body: "home_picker_body"},
+		ShowCreateStream: true,
+	}
+	if err := tmpl.ExecuteTemplate(&out, "home_picker_body", view); err != nil {
+		t.Fatalf("render home_picker_body template: %v", err)
+	}
+	body := out.String()
+
+	for _, want := range []string{
+		`class="page-header-actions"`,
+		`href="/my/organization/formata-builder"`,
+		"Create a stream",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in home picker with create CTA, got: %s", want, body)
+		}
+	}
+}

--- a/server/cmd/server/my_home_stream_group_test.go
+++ b/server/cmd/server/my_home_stream_group_test.go
@@ -112,7 +112,8 @@ func TestHomePickerBodyRendersSidebarAndDrawerTrigger(t *testing.T) {
 			Streams: []ManagedPublicStreamCardView{{Card: PublicStreamCardView{Name: "A"}}},
 		}},
 		Sidebar: CategorySidebarView{
-			Title: "Stream Categories",
+			Title:         "Stream Categories",
+			CloseTargetID: "my-home-category-sidebar",
 			Categories: []CategorySidebarCategoryView{{
 				Name: "Supply Chain", Expanded: true,
 				SubCategories: []CategorySidebarLeafView{{Name: "Procurement", Href: "#cat-supply-chain--procurement"}},
@@ -127,6 +128,8 @@ func TestHomePickerBodyRendersSidebarAndDrawerTrigger(t *testing.T) {
 		`class="my-home-category-bar"`,
 		`nav-drawer-trigger`,
 		`popovertarget="my-home-category-sidebar"`,
+		`popovertargetaction="hide"`,
+		`category-sidebar-close`,
 		`id="my-home-category-sidebar"`,
 		`class="category-sidebar"`,
 		`href="#cat-supply-chain--procurement"`,

--- a/server/cmd/server/my_home_test.go
+++ b/server/cmd/server/my_home_test.go
@@ -133,6 +133,9 @@ func TestBuildMyHomeCategorySidebarFromGroups(t *testing.T) {
 	if got.Categories[1].Name != "Uncategorized" || got.Categories[1].SubCategories[0].Href != "#cat-uncategorized" {
 		t.Fatalf("uncat=%+v", got.Categories[1])
 	}
+	if got.Categories[1].Expanded {
+		t.Fatalf("only first category should start expanded, uncat=%+v", got.Categories[1])
+	}
 	if got.Categories[0].SubCategories[0].PartialURL != "" {
 		t.Fatalf("my leaves must not set PartialURL")
 	}

--- a/server/cmd/server/my_home_test.go
+++ b/server/cmd/server/my_home_test.go
@@ -124,6 +124,9 @@ func TestBuildMyHomeCategorySidebarFromGroups(t *testing.T) {
 	if got.Title != "Stream Categories" || len(got.Categories) != 2 {
 		t.Fatalf("got=%+v", got)
 	}
+	if got.CloseTargetID != "my-home-category-sidebar" {
+		t.Fatalf("CloseTargetID=%q", got.CloseTargetID)
+	}
 	if !got.Categories[0].Expanded || got.Categories[0].Name != "Supply Chain" || len(got.Categories[0].SubCategories) != 2 {
 		t.Fatalf("cat0=%+v", got.Categories[0])
 	}

--- a/server/cmd/server/my_home_test.go
+++ b/server/cmd/server/my_home_test.go
@@ -113,3 +113,27 @@ func TestBuildMyHomeStreamGroupsSetsAnchorIDs(t *testing.T) {
 		t.Fatalf("uncat=%+v", groups[2])
 	}
 }
+
+func TestBuildMyHomeCategorySidebarFromGroups(t *testing.T) {
+	groups := []MyHomeStreamGroupView{
+		{CategorySlug: "supply-chain", CategoryName: "Supply Chain", CategoryIconURL: "/c.svg", SubCategorySlug: "procurement", SubCategoryName: "Procurement", AnchorID: "cat-supply-chain--procurement", ShowCategoryHeader: true},
+		{CategorySlug: "supply-chain", CategoryName: "Supply Chain", CategoryIconURL: "/c.svg", SubCategorySlug: "order-fulfillment", SubCategoryName: "Order Fulfillment", AnchorID: "cat-supply-chain--order-fulfillment"},
+		{Uncategorized: true, CategoryName: "Uncategorized", AnchorID: "cat-uncategorized", ShowCategoryHeader: true},
+	}
+	got := buildMyHomeCategorySidebar(groups)
+	if got.Title != "Stream Categories" || len(got.Categories) != 2 {
+		t.Fatalf("got=%+v", got)
+	}
+	if !got.Categories[0].Expanded || got.Categories[0].Name != "Supply Chain" || len(got.Categories[0].SubCategories) != 2 {
+		t.Fatalf("cat0=%+v", got.Categories[0])
+	}
+	if got.Categories[0].SubCategories[0].Href != "#cat-supply-chain--procurement" {
+		t.Fatalf("href0=%q", got.Categories[0].SubCategories[0].Href)
+	}
+	if got.Categories[1].Name != "Uncategorized" || got.Categories[1].SubCategories[0].Href != "#cat-uncategorized" {
+		t.Fatalf("uncat=%+v", got.Categories[1])
+	}
+	if got.Categories[0].SubCategories[0].PartialURL != "" {
+		t.Fatalf("my leaves must not set PartialURL")
+	}
+}

--- a/server/cmd/server/my_home_test.go
+++ b/server/cmd/server/my_home_test.go
@@ -1,0 +1,56 @@
+package main
+
+import "testing"
+
+func TestBuildMyHomeStreamGroupsOrdersTaxonomyAndUncategorized(t *testing.T) {
+	categories := []TaxonomyCategoryNode{
+		{
+			Slug: "supply-chain", Name: "Supply Chain", IconURL: "/c.svg", SortOrder: 1,
+			SubCategories: []TaxonomySubCategoryNode{
+				{Slug: "procurement", Name: "Procurement", Description: "PO", IconURL: "/s.svg", SortOrder: 1},
+				{Slug: "order-fulfillment", Name: "Order Fulfillment", SortOrder: 2},
+			},
+		},
+	}
+	catalog := map[string]RuntimeConfig{
+		"a": {Workflow: WorkflowDef{Name: "A", CategorySlug: "supply-chain", SubCategorySlug: "order-fulfillment"}},
+		"b": {Workflow: WorkflowDef{Name: "B", CategorySlug: "supply-chain", SubCategorySlug: "procurement"}},
+		"c": {Workflow: WorkflowDef{Name: "C"}}, // uncategorized
+	}
+	cards := map[string]ManagedPublicStreamCardView{
+		"a": {Key: "a", Card: PublicStreamCardView{Name: "A"}},
+		"b": {Key: "b", Card: PublicStreamCardView{Name: "B"}},
+		"c": {Key: "c", Card: PublicStreamCardView{Name: "C"}},
+	}
+	groups := buildMyHomeStreamGroups(categories, cards, catalog, []string{"a", "b", "c"})
+	if len(groups) != 3 {
+		t.Fatalf("len(groups)=%d want 3", len(groups))
+	}
+	if groups[0].SubCategoryName != "Procurement" || groups[0].Streams[0].Key != "b" {
+		t.Fatalf("first group = %+v", groups[0])
+	}
+	if groups[1].SubCategoryName != "Order Fulfillment" || groups[1].Streams[0].Key != "a" {
+		t.Fatalf("second group = %+v", groups[1])
+	}
+	if !groups[2].Uncategorized || groups[2].CategoryName != "Uncategorized" || groups[2].Streams[0].Key != "c" {
+		t.Fatalf("uncategorized = %+v", groups[2])
+	}
+}
+
+func TestBuildMyHomeStreamGroupsSkipsEmptyLeaves(t *testing.T) {
+	categories := []TaxonomyCategoryNode{{
+		Slug: "supply-chain", Name: "Supply Chain",
+		SubCategories: []TaxonomySubCategoryNode{
+			{Slug: "procurement", Name: "Procurement"},
+			{Slug: "order-fulfillment", Name: "Order Fulfillment"},
+		},
+	}}
+	catalog := map[string]RuntimeConfig{
+		"b": {Workflow: WorkflowDef{CategorySlug: "supply-chain", SubCategorySlug: "procurement"}},
+	}
+	cards := map[string]ManagedPublicStreamCardView{"b": {Key: "b"}}
+	groups := buildMyHomeStreamGroups(categories, cards, catalog, []string{"b"})
+	if len(groups) != 1 || groups[0].SubCategoryName != "Procurement" {
+		t.Fatalf("got %+v", groups)
+	}
+}

--- a/server/cmd/server/my_home_test.go
+++ b/server/cmd/server/my_home_test.go
@@ -29,14 +29,17 @@ func TestBuildMyHomeStreamGroupsOrdersTaxonomyAndUncategorized(t *testing.T) {
 	if groups[0].SubCategoryName != "Procurement" || groups[0].Streams[0].Key != "b" {
 		t.Fatalf("first group = %+v", groups[0])
 	}
-	if groups[0].CategoryName != "Supply Chain" || groups[0].CategoryIconURL != "/c.svg" {
+	if groups[0].CategoryName != "Supply Chain" || groups[0].CategoryIconURL != "/c.svg" || !groups[0].ShowCategoryHeader {
 		t.Fatalf("first group should show category header = %+v", groups[0])
 	}
 	if groups[1].SubCategoryName != "Order Fulfillment" || groups[1].Streams[0].Key != "a" {
 		t.Fatalf("second group = %+v", groups[1])
 	}
-	if groups[1].CategoryName != "" || groups[1].CategoryIconURL != "" {
+	if groups[1].ShowCategoryHeader {
 		t.Fatalf("second group under same category must omit category header = %+v", groups[1])
+	}
+	if groups[1].CategoryName != "Supply Chain" || groups[1].CategoryIconURL != "/c.svg" {
+		t.Fatalf("second group must retain category metadata for sidebar builder = %+v", groups[1])
 	}
 	if !groups[2].Uncategorized || groups[2].CategoryName != "Uncategorized" || groups[2].Streams[0].Key != "c" {
 		t.Fatalf("uncategorized = %+v", groups[2])
@@ -59,7 +62,54 @@ func TestBuildMyHomeStreamGroupsSkipsEmptyLeaves(t *testing.T) {
 	if len(groups) != 1 || groups[0].SubCategoryName != "Order Fulfillment" {
 		t.Fatalf("got %+v", groups)
 	}
-	if groups[0].CategoryName != "Supply Chain" || groups[0].CategoryIconURL != "/c.svg" {
+	if groups[0].CategoryName != "Supply Chain" || groups[0].CategoryIconURL != "/c.svg" || !groups[0].ShowCategoryHeader {
 		t.Fatalf("first non-empty leaf under category should show category header = %+v", groups[0])
+	}
+}
+
+func TestMyHomeAnchorID(t *testing.T) {
+	if got := myHomeAnchorID("supply-chain", "procurement", false); got != "cat-supply-chain--procurement" {
+		t.Fatalf("got %q", got)
+	}
+	if got := myHomeAnchorID("", "", true); got != "cat-uncategorized" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestBuildMyHomeStreamGroupsSetsAnchorIDs(t *testing.T) {
+	categories := []TaxonomyCategoryNode{
+		{
+			Slug: "supply-chain", Name: "Supply Chain", IconURL: "/c.svg", SortOrder: 1,
+			SubCategories: []TaxonomySubCategoryNode{
+				{Slug: "procurement", Name: "Procurement", Description: "PO", IconURL: "/s.svg", SortOrder: 1},
+				{Slug: "order-fulfillment", Name: "Order Fulfillment", SortOrder: 2},
+			},
+		},
+	}
+	catalog := map[string]RuntimeConfig{
+		"a": {Workflow: WorkflowDef{Name: "A", CategorySlug: "supply-chain", SubCategorySlug: "order-fulfillment"}},
+		"b": {Workflow: WorkflowDef{Name: "B", CategorySlug: "supply-chain", SubCategorySlug: "procurement"}},
+		"c": {Workflow: WorkflowDef{Name: "C"}}, // uncategorized
+	}
+	cards := map[string]ManagedPublicStreamCardView{
+		"a": {Key: "a", Card: PublicStreamCardView{Name: "A"}},
+		"b": {Key: "b", Card: PublicStreamCardView{Name: "B"}},
+		"c": {Key: "c", Card: PublicStreamCardView{Name: "C"}},
+	}
+	groups := buildMyHomeStreamGroups(categories, cards, catalog, []string{"a", "b", "c"})
+	if groups[0].AnchorID != "cat-supply-chain--procurement" || groups[0].CategorySlug != "supply-chain" {
+		t.Fatalf("first=%+v", groups[0])
+	}
+	if !groups[0].ShowCategoryHeader || groups[0].CategoryName != "Supply Chain" {
+		t.Fatalf("first header=%+v", groups[0])
+	}
+	if groups[1].AnchorID != "cat-supply-chain--order-fulfillment" || groups[1].ShowCategoryHeader {
+		t.Fatalf("second=%+v", groups[1])
+	}
+	if groups[1].CategoryName != "Supply Chain" {
+		t.Fatalf("second must retain CategoryName for sidebar builder, got %+v", groups[1])
+	}
+	if groups[2].AnchorID != "cat-uncategorized" || !groups[2].Uncategorized {
+		t.Fatalf("uncat=%+v", groups[2])
 	}
 }

--- a/server/cmd/server/my_home_test.go
+++ b/server/cmd/server/my_home_test.go
@@ -29,8 +29,14 @@ func TestBuildMyHomeStreamGroupsOrdersTaxonomyAndUncategorized(t *testing.T) {
 	if groups[0].SubCategoryName != "Procurement" || groups[0].Streams[0].Key != "b" {
 		t.Fatalf("first group = %+v", groups[0])
 	}
+	if groups[0].CategoryName != "Supply Chain" || groups[0].CategoryIconURL != "/c.svg" {
+		t.Fatalf("first group should show category header = %+v", groups[0])
+	}
 	if groups[1].SubCategoryName != "Order Fulfillment" || groups[1].Streams[0].Key != "a" {
 		t.Fatalf("second group = %+v", groups[1])
+	}
+	if groups[1].CategoryName != "" || groups[1].CategoryIconURL != "" {
+		t.Fatalf("second group under same category must omit category header = %+v", groups[1])
 	}
 	if !groups[2].Uncategorized || groups[2].CategoryName != "Uncategorized" || groups[2].Streams[0].Key != "c" {
 		t.Fatalf("uncategorized = %+v", groups[2])
@@ -39,18 +45,21 @@ func TestBuildMyHomeStreamGroupsOrdersTaxonomyAndUncategorized(t *testing.T) {
 
 func TestBuildMyHomeStreamGroupsSkipsEmptyLeaves(t *testing.T) {
 	categories := []TaxonomyCategoryNode{{
-		Slug: "supply-chain", Name: "Supply Chain",
+		Slug: "supply-chain", Name: "Supply Chain", IconURL: "/c.svg",
 		SubCategories: []TaxonomySubCategoryNode{
 			{Slug: "procurement", Name: "Procurement"},
 			{Slug: "order-fulfillment", Name: "Order Fulfillment"},
 		},
 	}}
 	catalog := map[string]RuntimeConfig{
-		"b": {Workflow: WorkflowDef{CategorySlug: "supply-chain", SubCategorySlug: "procurement"}},
+		"b": {Workflow: WorkflowDef{CategorySlug: "supply-chain", SubCategorySlug: "order-fulfillment"}},
 	}
 	cards := map[string]ManagedPublicStreamCardView{"b": {Key: "b"}}
 	groups := buildMyHomeStreamGroups(categories, cards, catalog, []string{"b"})
-	if len(groups) != 1 || groups[0].SubCategoryName != "Procurement" {
+	if len(groups) != 1 || groups[0].SubCategoryName != "Order Fulfillment" {
 		t.Fatalf("got %+v", groups)
+	}
+	if groups[0].CategoryName != "Supply Chain" || groups[0].CategoryIconURL != "/c.svg" {
+		t.Fatalf("first non-empty leaf under category should show category header = %+v", groups[0])
 	}
 }

--- a/server/cmd/server/public_home.go
+++ b/server/cmd/server/public_home.go
@@ -65,17 +65,17 @@ func buildPublicHomeStreamResultsView(categories []TaxonomyCategoryNode, cat, su
 	return view
 }
 
-func buildPublicHomeCategories(categories []TaxonomyCategoryNode, selectedCat, selectedSub string) []PublicHomeCategoryView {
-	out := make([]PublicHomeCategoryView, 0, len(categories))
+func buildPublicHomeCategories(categories []TaxonomyCategoryNode, selectedCat, selectedSub string) CategorySidebarView {
+	out := make([]CategorySidebarCategoryView, 0, len(categories))
 	for _, cat := range categories {
-		subs := make([]PublicHomeSubCategoryView, 0, len(cat.SubCategories))
+		subs := make([]CategorySidebarLeafView, 0, len(cat.SubCategories))
 		for _, sub := range cat.SubCategories {
 			query := url.Values{
 				"category":    {cat.Slug},
 				"subCategory": {sub.Slug},
 			}
 			encoded := query.Encode()
-			subs = append(subs, PublicHomeSubCategoryView{
+			subs = append(subs, CategorySidebarLeafView{
 				Slug:       sub.Slug,
 				Name:       sub.Name,
 				Active:     cat.Slug == selectedCat && sub.Slug == selectedSub,
@@ -83,7 +83,7 @@ func buildPublicHomeCategories(categories []TaxonomyCategoryNode, selectedCat, s
 				PushURL:    publicHomePath(cat.Slug, sub.Slug),
 			})
 		}
-		out = append(out, PublicHomeCategoryView{
+		out = append(out, CategorySidebarCategoryView{
 			Slug:          cat.Slug,
 			Name:          cat.Name,
 			IconURL:       cat.IconURL,
@@ -91,7 +91,10 @@ func buildPublicHomeCategories(categories []TaxonomyCategoryNode, selectedCat, s
 			SubCategories: subs,
 		})
 	}
-	return out
+	return CategorySidebarView{
+		Title:      "Stream Categories",
+		Categories: out,
+	}
 }
 
 func publicHomeCreateStreamHref(signedIn bool) string {

--- a/server/cmd/server/public_home_test.go
+++ b/server/cmd/server/public_home_test.go
@@ -150,25 +150,28 @@ func TestBuildPublicHomeCategoriesMarksActiveAndURLs(t *testing.T) {
 		},
 	}
 	got := buildPublicHomeCategories(cats, "supply-chain", "order-fulfillment")
-	if len(got) != 2 {
-		t.Fatalf("len=%d", len(got))
+	if got.Title != "Stream Categories" {
+		t.Fatalf("title=%q", got.Title)
 	}
-	if !got[0].Expanded || got[1].Expanded {
-		t.Fatalf("expanded flags: %#v", got)
+	if len(got.Categories) != 2 {
+		t.Fatalf("len=%d", len(got.Categories))
 	}
-	if got[0].SubCategories[1].Active != true || got[0].SubCategories[0].Active {
-		t.Fatalf("active flags: %#v", got[0].SubCategories)
+	if !got.Categories[0].Expanded || got.Categories[1].Expanded {
+		t.Fatalf("expanded flags: %#v", got.Categories)
+	}
+	if got.Categories[0].SubCategories[1].Active != true || got.Categories[0].SubCategories[0].Active {
+		t.Fatalf("active flags: %#v", got.Categories[0].SubCategories)
 	}
 	wantPartial := "/streams/public?category=supply-chain&subCategory=order-fulfillment"
 	wantPush := "/?category=supply-chain&subCategory=order-fulfillment"
-	if got[0].SubCategories[1].PartialURL != wantPartial {
-		t.Fatalf("PartialURL=%q", got[0].SubCategories[1].PartialURL)
+	if got.Categories[0].SubCategories[1].PartialURL != wantPartial {
+		t.Fatalf("PartialURL=%q", got.Categories[0].SubCategories[1].PartialURL)
 	}
-	if got[0].SubCategories[1].PushURL != wantPush {
-		t.Fatalf("PushURL=%q", got[0].SubCategories[1].PushURL)
+	if got.Categories[0].SubCategories[1].PushURL != wantPush {
+		t.Fatalf("PushURL=%q", got.Categories[0].SubCategories[1].PushURL)
 	}
-	if got[1].Name != "Compliance and Quality" || len(got[1].SubCategories) != 1 {
-		t.Fatalf("expected zero-stream category still present: %#v", got[1])
+	if got.Categories[1].Name != "Compliance and Quality" || len(got.Categories[1].SubCategories) != 1 {
+		t.Fatalf("expected zero-stream category still present: %#v", got.Categories[1])
 	}
 }
 

--- a/server/cmd/server/public_stream_test.go
+++ b/server/cmd/server/public_stream_test.go
@@ -295,7 +295,7 @@ func TestPublicStreamBodyTemplateEmptyRuns(t *testing.T) {
 	if !strings.Contains(out.String(), "No completed runs yet") {
 		t.Fatalf("expected empty copy, got: %s", out.String())
 	}
-	if !strings.Contains(out.String(), `class="public-stream-runs-empty"`) {
+	if !strings.Contains(out.String(), `class="empty-state"`) {
 		t.Fatalf("expected empty state, got: %s", out.String())
 	}
 }

--- a/server/cmd/server/test_helpers_test.go
+++ b/server/cmd/server/test_helpers_test.go
@@ -88,7 +88,7 @@ func testTemplates() *template.Template {
   {{else if eq .Body "dept_dashboard_body"}}{{template "dept_dashboard_body" .}}
   {{else if eq .Body "dept_process_body"}}{{template "dept_process_body" .}}{{end}}
 {{end}}
-	{{define "home_picker_body"}}HOME_PICKER {{range .Workflows}}{{.Key}}:{{.Name}}{{if .Description}}:{{.Description}}{{end}}:{{.Counts.NotStarted}}/{{.Counts.Started}}/{{.Counts.Terminated}}|{{end}}{{end}}
+	{{define "home_picker_body"}}HOME_PICKER GROUPS {{len .Groups}}{{if .ShowCreateStream}} CREATE{{end}}{{end}}
 	{{define "public_home_body"}}PUBLIC_HOME{{end}}
 	{{define "public_home.html"}}{{template "layout.html" .}}{{end}}
 	{{define "signup_body"}}SIGNUP {{.Email}} {{.Error}}{{end}}

--- a/server/templates/components/category_sidebar.html
+++ b/server/templates/components/category_sidebar.html
@@ -1,8 +1,22 @@
 {{ define "category_sidebar" }}
 <aside class="category-sidebar" aria-label="Stream categories" data-landing-category-sidebar>
   <div class="category-sidebar-header">
-    {{ template "icon-layout-grid" . }}
-    <p class="category-sidebar-title">{{ .Title }}</p>
+    <div class="category-sidebar-header-main">
+      {{ template "icon-layout-grid" . }}
+      <p class="category-sidebar-title">{{ .Title }}</p>
+    </div>
+    {{ if .CloseTargetID }}
+    <button
+      type="button"
+      class="btn btn-ghost btn-icon category-sidebar-close"
+      popovertarget="{{ .CloseTargetID }}"
+      popovertargetaction="hide"
+      aria-label="Close stream categories"
+      title="Close"
+    >
+      {{ template "icon-close" . }}
+    </button>
+    {{ end }}
   </div>
   <div class="category-sidebar-list">
     {{ range .Categories }}

--- a/server/templates/components/category_sidebar.html
+++ b/server/templates/components/category_sidebar.html
@@ -1,0 +1,48 @@
+{{ define "category_sidebar" }}
+<aside class="category-sidebar" aria-label="Stream categories" data-landing-category-sidebar>
+  <div class="category-sidebar-header">
+    {{ template "icon-layout-grid" . }}
+    <p class="category-sidebar-title">{{ .Title }}</p>
+  </div>
+  <div class="category-sidebar-list">
+    {{ range .Categories }}
+      <details class="category-sidebar-category" {{ if .Expanded }}open{{ end }} data-category-slug="{{ .Slug }}">
+        <summary class="category-sidebar-category-summary">
+          <span class="category-sidebar-category-label">
+            {{ if .IconURL }}
+              <img class="category-sidebar-category-icon" src="{{ .IconURL }}" alt="" width="20" height="20" />
+            {{ end }}
+            <span>{{ .Name }}</span>
+          </span>
+          <span class="category-sidebar-category-chevron" aria-hidden="true">
+            {{ template "icon-chevron-right" }}
+          </span>
+        </summary>
+        <div class="category-sidebar-subcategories">
+          {{ range .SubCategories }}
+            {{ if .Href }}
+              <a
+                class="category-sidebar-subcategory{{ if .Active }} is-active{{ end }}"
+                href="{{ .Href }}"
+                data-subcategory-slug="{{ .Slug }}"
+              >{{ .Name }}</a>
+            {{ else }}
+              <button
+                type="button"
+                class="category-sidebar-subcategory{{ if .Active }} is-active{{ end }}"
+                data-subcategory-slug="{{ .Slug }}"
+                hx-get="{{ .PartialURL }}"
+                hx-target="#public-home-stream-results"
+                hx-swap="outerHTML"
+                hx-push-url="{{ .PushURL }}"
+              >{{ .Name }}</button>
+            {{ end }}
+          {{ end }}
+        </div>
+      </details>
+    {{ else }}
+      <p class="category-sidebar-empty">No categories yet.</p>
+    {{ end }}
+  </div>
+</aside>
+{{ end }}

--- a/server/templates/components/managed_public_stream_card.html
+++ b/server/templates/components/managed_public_stream_card.html
@@ -1,0 +1,138 @@
+{{/* /my catalog card shell: management menu + dialogs outside public_stream_card link. */}}
+
+{{ define "managed_public_stream_card" }}
+  <div class="public-stream-card-shell">
+    {{ if .CanClone }}
+      <details class="public-stream-card-menu">
+        <summary
+          class="btn btn-ghost btn-icon public-stream-card-menu-trigger"
+          aria-label="Open actions for {{ .Card.Name }}"
+          title="Open actions for {{ .Card.Name }}"
+        >
+          {{ template "icon-ellipsis-vertical" . }}
+        </summary>
+        <div class="public-stream-card-dropdown">
+          <a
+            href="{{ .EditAction }}&new=true"
+            class="public-stream-card-menu-item"
+          >
+            {{ template "icon-clone" . }} Clone
+          </a>
+          {{ if .CanEdit }}
+            {{ if .EditRequiresPurge }}
+              <button
+                type="button"
+                class="public-stream-card-menu-item public-stream-card-menu-item-danger"
+                onclick="document.getElementById('edit-workflow-{{ .Key }}').showModal()"
+              >
+                {{ template "icon-pencil" . }} Edit
+              </button>
+            {{ else }}
+              <a
+                href="{{ .EditAction }}"
+                class="public-stream-card-menu-item"
+              >
+                {{ template "icon-pencil" . }} Edit
+              </a>
+            {{ end }}
+          {{ else }}
+            <button
+              type="button"
+              class="public-stream-card-menu-item public-stream-card-menu-item-disabled"
+              disabled
+            >
+              {{ template "icon-pencil" . }} Edit
+            </button>
+          {{ end }}
+          {{ if .CanDelete }}
+            <button
+              type="button"
+              class="public-stream-card-menu-item public-stream-card-menu-item-danger"
+              onclick="document.getElementById('delete-workflow-{{ .Key }}').showModal()"
+            >
+              {{ template "icon-trash" . }} Delete
+            </button>
+          {{ else }}
+            <button
+              type="button"
+              class="public-stream-card-menu-item public-stream-card-menu-item-danger public-stream-card-menu-item-disabled"
+              disabled
+            >
+              {{ template "icon-trash" . }} Delete
+            </button>
+          {{ end }}
+        </div>
+      </details>
+    {{ end }}
+    {{ template "public_stream_card" .Card }}
+    {{ if .EditRequiresPurge }}
+      <dialog id="edit-workflow-{{ .Key }}" class="dialog">
+        <div class="dialog-card">
+          <header class="dialog-head">
+            <div>
+              <h3 class="dialog-title u-text-danger">
+                Danger zone - {{ template "icon-pencil" . }} Edit stream
+              </h3>
+              <p class="dialog-subtitle">{{ .Card.Name }}</p>
+            </div>
+            <button
+              type="button"
+              class="btn btn-ghost btn-icon dialog-close"
+              onclick="document.getElementById('edit-workflow-{{ .Key }}').close()"
+            >
+              {{ template "icon-close" . }}
+            </button>
+          </header>
+          <p class="u-m-0 u-mb-5">
+            Saving changes to this stream will permanently delete all
+            existing instances and their collected workflow data.
+            Continue only if you want to proceed.
+          </p>
+          <div class="dialog-actions">
+            <a href="{{ .EditAction }}">
+              <button type="button" class="btn btn-danger">
+                Continue to editor
+              </button>
+            </a>
+          </div>
+        </div>
+      </dialog>
+    {{ end }}
+    {{ if .CanDelete }}
+      <dialog id="delete-workflow-{{ .Key }}" class="dialog">
+        <div class="dialog-card">
+          <header class="dialog-head">
+            <div>
+              <h3 class="dialog-title u-text-danger">
+                Danger zone - {{ template "icon-trash" . }} Delete stream
+              </h3>
+              <p class="dialog-subtitle">{{ .Card.Name }}</p>
+            </div>
+            <button
+              type="button"
+              class="btn btn-ghost btn-icon dialog-close"
+              onclick="document.getElementById('delete-workflow-{{ .Key }}').close()"
+            >
+              {{ template "icon-close" . }}
+            </button>
+          </header>
+          <p class="u-m-0 u-mb-5">
+            This will permanently delete the stream and its workflow data.
+            Confirm only if you want to continue.
+          </p>
+          <form
+            method="post"
+            action="{{ .DeleteAction }}"
+            class="input-form"
+          >
+            <div class="dialog-actions">
+              <button type="submit" class="btn btn-danger">
+                Delete stream
+              </button>
+            </div>
+          </form>
+        </div>
+      </dialog>
+    {{ end }}
+  </div>
+{{ end }}

--- a/server/templates/components/my_home_stream_group.html
+++ b/server/templates/components/my_home_stream_group.html
@@ -1,5 +1,21 @@
 {{ define "my_home_stream_group" }}
-  {{ if .CategoryName }}
+  {{ if .Uncategorized }}
+  <section class="my-home-catalog-section" id="{{ .AnchorID }}">
+    {{ if .ShowCategoryHeader }}
+    <header class="public-home-results-category-header">
+      <h2 class="public-home-results-category-name">{{ .CategoryName }}</h2>
+    </header>
+    {{ end }}
+    {{ if .Streams }}
+    <div class="public-home-stream-grid">
+      {{ range .Streams }}
+        {{ template "managed_public_stream_card" . }}
+      {{ end }}
+    </div>
+    {{ end }}
+  </section>
+  {{ else }}
+  {{ if .ShowCategoryHeader }}
   <header class="public-home-results-category-header">
     {{ if .CategoryIconURL }}
     <img
@@ -13,34 +29,37 @@
     <h2 class="public-home-results-category-name">{{ .CategoryName }}</h2>
   </header>
   {{ end }}
-  {{ if and (not .Uncategorized) .SubCategoryName }}
-  <header class="public-home-results-subcategory-header">
-    <div class="public-home-results-subcategory-title-row">
-      {{ if .SubCategoryIconURL }}
-      <img
-        class="public-home-results-subcategory-icon"
-        src="{{ .SubCategoryIconURL }}"
-        alt=""
-        width="28"
-        height="28"
-      />
+  <section class="my-home-catalog-section" id="{{ .AnchorID }}">
+    {{ if .SubCategoryName }}
+    <header class="public-home-results-subcategory-header">
+      <div class="public-home-results-subcategory-title-row">
+        {{ if .SubCategoryIconURL }}
+        <img
+          class="public-home-results-subcategory-icon"
+          src="{{ .SubCategoryIconURL }}"
+          alt=""
+          width="28"
+          height="28"
+        />
+        {{ end }}
+        <h3 class="public-home-results-subcategory-name">
+          {{ .SubCategoryName }}
+        </h3>
+      </div>
+      {{ if .SubCategoryDescription }}
+      <p class="public-home-results-subcategory-description">
+        {{ .SubCategoryDescription }}
+      </p>
       {{ end }}
-      <h3 class="public-home-results-subcategory-name">
-        {{ .SubCategoryName }}
-      </h3>
+    </header>
+    {{ end }}
+    {{ if .Streams }}
+    <div class="public-home-stream-grid">
+      {{ range .Streams }}
+        {{ template "managed_public_stream_card" . }}
+      {{ end }}
     </div>
-    {{ if .SubCategoryDescription }}
-    <p class="public-home-results-subcategory-description">
-      {{ .SubCategoryDescription }}
-    </p>
     {{ end }}
-  </header>
-  {{ end }}
-  {{ if .Streams }}
-  <div class="public-home-stream-grid">
-    {{ range .Streams }}
-      {{ template "managed_public_stream_card" . }}
-    {{ end }}
-  </div>
+  </section>
   {{ end }}
 {{ end }}

--- a/server/templates/components/my_home_stream_group.html
+++ b/server/templates/components/my_home_stream_group.html
@@ -1,0 +1,44 @@
+{{ define "my_home_stream_group" }}
+  {{ if .CategoryName }}
+  <header class="public-home-results-category-header">
+    {{ if .CategoryIconURL }}
+    <img
+      class="public-home-results-category-icon"
+      src="{{ .CategoryIconURL }}"
+      alt=""
+      width="24"
+      height="24"
+    />
+    {{ end }}
+    <h2 class="public-home-results-category-name">{{ .CategoryName }}</h2>
+  </header>
+  {{ end }}
+  {{ if and (not .Uncategorized) .SubCategoryName }}
+  <header class="public-home-results-subcategory-header">
+    <div class="public-home-results-subcategory-title-row">
+      {{ if .SubCategoryIconURL }}
+      <img
+        class="public-home-results-subcategory-icon"
+        src="{{ .SubCategoryIconURL }}"
+        alt=""
+        width="28"
+        height="28"
+      />
+      {{ end }}
+      <h3 class="public-home-results-subcategory-name">
+        {{ .SubCategoryName }}
+      </h3>
+    </div>
+    {{ if .SubCategoryDescription }}
+    <p class="public-home-results-subcategory-description">
+      {{ .SubCategoryDescription }}
+    </p>
+    {{ end }}
+  </header>
+  {{ end }}
+  <div class="public-home-stream-grid">
+    {{ range .Streams }}
+      {{ template "managed_public_stream_card" . }}
+    {{ end }}
+  </div>
+{{ end }}

--- a/server/templates/components/my_home_stream_group.html
+++ b/server/templates/components/my_home_stream_group.html
@@ -1,7 +1,6 @@
 {{ define "my_home_stream_group" }}
   {{ if .Uncategorized }}
   {{ if .ShowCategoryHeader }}
-  <hr class="my-home-category-rule" aria-hidden="true" />
   <header class="public-home-results-category-header">
     <h2 class="public-home-results-category-name">{{ .CategoryName }}</h2>
   </header>
@@ -17,7 +16,6 @@
   </section>
   {{ else }}
   {{ if .ShowCategoryHeader }}
-  <hr class="my-home-category-rule" aria-hidden="true" />
   <header class="public-home-results-category-header">
     {{ if .CategoryIconURL }}
     <img

--- a/server/templates/components/my_home_stream_group.html
+++ b/server/templates/components/my_home_stream_group.html
@@ -1,11 +1,12 @@
 {{ define "my_home_stream_group" }}
   {{ if .Uncategorized }}
+  {{ if .ShowCategoryHeader }}
+  <hr class="my-home-category-rule" aria-hidden="true" />
+  <header class="public-home-results-category-header">
+    <h2 class="public-home-results-category-name">{{ .CategoryName }}</h2>
+  </header>
+  {{ end }}
   <section class="my-home-catalog-section" id="{{ .AnchorID }}">
-    {{ if .ShowCategoryHeader }}
-    <header class="public-home-results-category-header">
-      <h2 class="public-home-results-category-name">{{ .CategoryName }}</h2>
-    </header>
-    {{ end }}
     {{ if .Streams }}
     <div class="public-home-stream-grid">
       {{ range .Streams }}
@@ -16,6 +17,7 @@
   </section>
   {{ else }}
   {{ if .ShowCategoryHeader }}
+  <hr class="my-home-category-rule" aria-hidden="true" />
   <header class="public-home-results-category-header">
     {{ if .CategoryIconURL }}
     <img

--- a/server/templates/components/my_home_stream_group.html
+++ b/server/templates/components/my_home_stream_group.html
@@ -36,9 +36,11 @@
     {{ end }}
   </header>
   {{ end }}
+  {{ if .Streams }}
   <div class="public-home-stream-grid">
     {{ range .Streams }}
       {{ template "managed_public_stream_card" . }}
     {{ end }}
   </div>
+  {{ end }}
 {{ end }}

--- a/server/templates/components/public_home_stream_group.html
+++ b/server/templates/components/public_home_stream_group.html
@@ -1,0 +1,46 @@
+{{ define "public_home_stream_group" }}
+  {{ if .CategoryName }}
+  <header class="public-home-results-category-header">
+    {{ if .CategoryIconURL }}
+    <img
+      class="public-home-results-category-icon"
+      src="{{ .CategoryIconURL }}"
+      alt=""
+      width="24"
+      height="24"
+    />
+    {{ end }}
+    <h2 class="public-home-results-category-name">{{ .CategoryName }}</h2>
+  </header>
+  {{ end }}
+  {{ if .SubCategoryName }}
+  <header class="public-home-results-subcategory-header">
+    <div class="public-home-results-subcategory-title-row">
+      {{ if .SubCategoryIconURL }}
+      <img
+        class="public-home-results-subcategory-icon"
+        src="{{ .SubCategoryIconURL }}"
+        alt=""
+        width="28"
+        height="28"
+      />
+      {{ end }}
+      <h3 class="public-home-results-subcategory-name">
+        {{ .SubCategoryName }}
+      </h3>
+    </div>
+    {{ if .SubCategoryDescription }}
+    <p class="public-home-results-subcategory-description">
+      {{ .SubCategoryDescription }}
+    </p>
+    {{ end }}
+  </header>
+  {{ end }}
+  {{ if .Streams }}
+  <div class="public-home-stream-grid">
+    {{ range .Streams }}
+      {{ template "public_stream_card" . }}
+    {{ end }}
+  </div>
+  {{ end }}
+{{ end }}

--- a/server/templates/components/public_home_stream_results.html
+++ b/server/templates/components/public_home_stream_results.html
@@ -1,45 +1,7 @@
 {{ define "public_home_stream_results" }}
 <div class="public-home-stream-results" id="public-home-stream-results">
-  {{ if .CategoryName }}
-  <header class="public-home-results-category-header">
-    {{ if .CategoryIconURL }}
-    <img
-      class="public-home-results-category-icon"
-      src="{{ .CategoryIconURL }}"
-      alt=""
-      width="24"
-      height="24"
-    />
-    {{ end }}
-    <h2 class="public-home-results-category-name">{{ .CategoryName }}</h2>
-  </header>
-  {{ end }} {{ if .SubCategoryName }}
-  <header class="public-home-results-subcategory-header">
-    <div class="public-home-results-subcategory-title-row">
-      {{ if .SubCategoryIconURL }}
-      <img
-        class="public-home-results-subcategory-icon"
-        src="{{ .SubCategoryIconURL }}"
-        alt=""
-        width="28"
-        height="28"
-      />
-      {{ end }}
-      <h3 class="public-home-results-subcategory-name">
-        {{ .SubCategoryName }}
-      </h3>
-    </div>
-    {{ if .SubCategoryDescription }}
-    <p class="public-home-results-subcategory-description">
-      {{ .SubCategoryDescription }}
-    </p>
-    {{ end }}
-  </header>
-  {{ end }} {{ if .Streams }}
-  <div class="public-home-stream-grid">
-    {{ range .Streams }} {{ template "public_stream_card" . }} {{ end }}
-  </div>
-  {{ else }}
+  {{ template "public_home_stream_group" . }}
+  {{ if not .Streams }}
   <div class="public-home-stream-empty">
     <p>No public streams in this category yet.</p>
     <a class="btn btn-secondary btn-sm" href="{{ .CreateStreamHref }}">

--- a/server/templates/icons.html
+++ b/server/templates/icons.html
@@ -401,6 +401,24 @@
   </svg>
 {{ end }}
 
+{{ define "icon-menu" }}
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="icon-svg icon-svg-md"
+    aria-hidden="true"
+  >
+    <path d="M4 5h16" />
+    <path d="M4 12h16" />
+    <path d="M4 19h16" />
+  </svg>
+{{ end }}
+
 {{ define "icon-layers-2" }}
   <svg
     xmlns="http://www.w3.org/2000/svg"

--- a/server/templates/pages/home.html
+++ b/server/templates/pages/home.html
@@ -1,30 +1,40 @@
 {{/* Used on /my to render the stream picker (home_picker_body). */}}
 
 {{ define "home_picker_body" }}
-  <section class="stack u-max-w-7xl u-mx-auto">
-    <section class="page-header">
+<section class="stack u-max-w-7xl u-mx-auto my-home">
+  <section class="page-header">
+    <div class="page-header-head">
       <div class="page-header-body">
         <h1>Choose a stream</h1>
         <p>Select a stream to start or continue process tracking</p>
       </div>
-    </section>
-    {{ if .Confirmation }}
-      <p class="confirmation">{{ .Confirmation }}</p>
-    {{ end }}
-    {{ template "error_banner.html" . }}
-    {{ if .Workflows }}
-      <div class="workflow-grid">
-        {{ range .Workflows }}
-          {{ template "stream_card" . }}
-        {{ end }}
-        {{ if .ShowCreateStreamCard }}
-          {{ template "stream_card_create" . }}
-        {{ end }}
+      {{ if .ShowCreateStream }}
+      <div class="page-header-actions">
+        <a class="btn btn-primary" href="/my/organization/formata-builder">
+          {{ template "icon-plus" . }} Create a stream
+        </a>
       </div>
-    {{ else }}
-      <p class="muted">No streams configured</p>
-    {{ end }}
+      {{ end }}
+    </div>
   </section>
+  {{ if .Confirmation }}
+    <p class="confirmation">{{ .Confirmation }}</p>
+  {{ end }}
+  {{ template "error_banner.html" . }}
+  {{ if .Groups }}
+    <div class="my-home-catalog">
+      {{ range .Groups }}
+        {{ template "my_home_stream_group" . }}
+      {{ end }}
+    </div>
+  {{ else }}
+    <div class="empty-state">
+      {{ template "icon-layers-2" . }}
+      <p class="empty-state-title">No streams available</p>
+      <p class="empty-state-hint">Streams for your organization and roles will appear here.</p>
+    </div>
+  {{ end }}
+</section>
 {{ end }}
 
 {{ define "home.html" }}

--- a/server/templates/pages/home.html
+++ b/server/templates/pages/home.html
@@ -8,11 +8,24 @@
         <h1>Choose a stream</h1>
         <p>Select a stream to start or continue process tracking</p>
       </div>
-      {{ if .ShowCreateStream }}
+      {{ if or .Groups .ShowCreateStream }}
       <div class="page-header-actions">
+        {{ if .Groups }}
+        <button
+          type="button"
+          class="btn btn-ghost btn-icon nav-drawer-trigger"
+          popovertarget="my-home-category-sidebar"
+          aria-label="Open stream categories"
+          title="Stream categories"
+        >
+          {{ template "icon-layout-grid" . }}
+        </button>
+        {{ end }}
+        {{ if .ShowCreateStream }}
         <a class="btn btn-primary" href="/my/organization/formata-builder">
           {{ template "icon-plus" . }} Create a stream
         </a>
+        {{ end }}
       </div>
       {{ end }}
     </div>
@@ -22,10 +35,19 @@
   {{ end }}
   {{ template "error_banner.html" . }}
   {{ if .Groups }}
-    <div class="my-home-catalog">
-      {{ range .Groups }}
-        {{ template "my_home_stream_group" . }}
-      {{ end }}
+    <div class="my-home-body">
+      <div
+        id="my-home-category-sidebar"
+        class="nav-drawer-panel my-home-sidebar"
+        popover
+      >
+        {{ template "category_sidebar" .Sidebar }}
+      </div>
+      <div class="my-home-catalog">
+        {{ range .Groups }}
+          {{ template "my_home_stream_group" . }}
+        {{ end }}
+      </div>
     </div>
   {{ else }}
     <div class="empty-state">

--- a/server/templates/pages/home.html
+++ b/server/templates/pages/home.html
@@ -17,20 +17,6 @@
       {{ end }}
     </div>
   </section>
-  {{ if .Groups }}
-  <div class="my-home-category-bar">
-    <button
-      type="button"
-      class="btn btn-ghost nav-drawer-trigger"
-      popovertarget="my-home-category-sidebar"
-      aria-label="Open stream categories"
-      title="Stream categories"
-    >
-      {{ template "icon-layout-grid" . }}
-      Stream categories
-    </button>
-  </div>
-  {{ end }}
   {{ if .Confirmation }}
     <p class="confirmation">{{ .Confirmation }}</p>
   {{ end }}
@@ -45,6 +31,17 @@
         {{ template "category_sidebar" .Sidebar }}
       </div>
       <div class="my-home-catalog">
+        <div class="my-home-category-menu">
+          <button
+            type="button"
+            class="btn btn-ghost btn-icon nav-drawer-trigger"
+            popovertarget="my-home-category-sidebar"
+            aria-label="Open stream categories"
+            title="Stream categories"
+          >
+            {{ template "icon-menu" . }}
+          </button>
+        </div>
         {{ range .Groups }}
           {{ template "my_home_stream_group" . }}
         {{ end }}

--- a/server/templates/pages/home.html
+++ b/server/templates/pages/home.html
@@ -2,20 +2,6 @@
 
 {{ define "home_picker_body" }}
 <section class="stack u-max-w-7xl u-mx-auto my-home">
-  {{ if .Groups }}
-  <div class="my-home-category-bar">
-    <button
-      type="button"
-      class="btn btn-ghost nav-drawer-trigger"
-      popovertarget="my-home-category-sidebar"
-      aria-label="Open stream categories"
-      title="Stream categories"
-    >
-      {{ template "icon-layout-grid" . }}
-      Stream categories
-    </button>
-  </div>
-  {{ end }}
   <section class="page-header">
     <div class="page-header-head">
       <div class="page-header-body">
@@ -31,6 +17,20 @@
       {{ end }}
     </div>
   </section>
+  {{ if .Groups }}
+  <div class="my-home-category-bar">
+    <button
+      type="button"
+      class="btn btn-ghost nav-drawer-trigger"
+      popovertarget="my-home-category-sidebar"
+      aria-label="Open stream categories"
+      title="Stream categories"
+    >
+      {{ template "icon-layout-grid" . }}
+      Stream categories
+    </button>
+  </div>
+  {{ end }}
   {{ if .Confirmation }}
     <p class="confirmation">{{ .Confirmation }}</p>
   {{ end }}

--- a/server/templates/pages/home.html
+++ b/server/templates/pages/home.html
@@ -2,30 +2,31 @@
 
 {{ define "home_picker_body" }}
 <section class="stack u-max-w-7xl u-mx-auto my-home">
+  {{ if .Groups }}
+  <div class="my-home-category-bar">
+    <button
+      type="button"
+      class="btn btn-ghost nav-drawer-trigger"
+      popovertarget="my-home-category-sidebar"
+      aria-label="Open stream categories"
+      title="Stream categories"
+    >
+      {{ template "icon-layout-grid" . }}
+      Stream categories
+    </button>
+  </div>
+  {{ end }}
   <section class="page-header">
     <div class="page-header-head">
       <div class="page-header-body">
         <h1>Choose a stream</h1>
         <p>Select a stream to start or continue process tracking</p>
       </div>
-      {{ if or .Groups .ShowCreateStream }}
+      {{ if .ShowCreateStream }}
       <div class="page-header-actions">
-        {{ if .Groups }}
-        <button
-          type="button"
-          class="btn btn-ghost btn-icon nav-drawer-trigger"
-          popovertarget="my-home-category-sidebar"
-          aria-label="Open stream categories"
-          title="Stream categories"
-        >
-          {{ template "icon-layout-grid" . }}
-        </button>
-        {{ end }}
-        {{ if .ShowCreateStream }}
         <a class="btn btn-primary" href="/my/organization/formata-builder">
           {{ template "icon-plus" . }} Create a stream
         </a>
-        {{ end }}
       </div>
       {{ end }}
     </div>

--- a/server/templates/pages/public_home.html
+++ b/server/templates/pages/public_home.html
@@ -19,44 +19,7 @@
     </section>
 
     <div class="public-home-streams-split" id="streams">
-      <aside class="public-home-category-sidebar" aria-label="Stream categories" data-landing-category-sidebar>
-        <div class="public-home-category-sidebar-header">
-          {{ template "icon-layout-grid" . }}
-          <p class="public-home-category-sidebar-title">Stream Categories</p>
-        </div>
-        <div class="public-home-category-sidebar-list">
-          {{ range .Categories }}
-            <details class="public-home-category" {{ if .Expanded }}open{{ end }} data-category-slug="{{ .Slug }}">
-              <summary class="public-home-category-summary">
-                <span class="public-home-category-label">
-                  {{ if .IconURL }}
-                    <img class="public-home-category-icon" src="{{ .IconURL }}" alt="" width="20" height="20" />
-                  {{ end }}
-                  <span>{{ .Name }}</span>
-                </span>
-                <span class="public-home-category-chevron" aria-hidden="true">
-                  {{ template "icon-chevron-right" }}
-                </span>
-              </summary>
-              <div class="public-home-subcategories">
-                {{ range .SubCategories }}
-                  <button
-                    type="button"
-                    class="public-home-subcategory{{ if .Active }} is-active{{ end }}"
-                    data-subcategory-slug="{{ .Slug }}"
-                    hx-get="{{ .PartialURL }}"
-                    hx-target="#public-home-stream-results"
-                    hx-swap="outerHTML"
-                    hx-push-url="{{ .PushURL }}"
-                  >{{ .Name }}</button>
-                {{ end }}
-              </div>
-            </details>
-          {{ else }}
-            <p class="public-home-category-sidebar-empty">No categories yet.</p>
-          {{ end }}
-        </div>
-      </aside>
+      {{ template "category_sidebar" .Sidebar }}
 
       {{ template "public_home_stream_results" .StreamResults }}
     </div>

--- a/server/templates/pages/public_stream.html
+++ b/server/templates/pages/public_stream.html
@@ -127,10 +127,10 @@
           {{ end }}
         </ul>
         {{ else }}
-        <div class="public-stream-runs-empty">
+        <div class="empty-state">
           {{ template "icon-layers-2" . }}
-          <p class="public-stream-runs-empty-title">No completed runs yet</p>
-          <p class="public-stream-runs-empty-hint">
+          <p class="empty-state-title">No completed runs yet</p>
+          <p class="empty-state-hint">
             Finished runs with a DPP will appear here.
           </p>
         </div>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1680,3 +1680,37 @@ const initLandingCategorySidebar = () => {
 };
 
 initLandingCategorySidebar();
+
+const initMyHomeCategoryDrawer = () => {
+  const panel = document.getElementById("my-home-category-sidebar");
+  if (!(panel instanceof HTMLElement) || typeof panel.hidePopover !== "function") {
+    return;
+  }
+
+  const closeIfOpen = () => {
+    if (panel.matches(":popover-open")) {
+      panel.hidePopover();
+    }
+  };
+
+  panel.addEventListener("click", (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) {
+      return;
+    }
+    const leaf = target.closest("a.category-sidebar-subcategory[href^='#']");
+    if (leaf instanceof HTMLElement && panel.contains(leaf)) {
+      closeIfOpen();
+    }
+  });
+
+  window.addEventListener(
+    "scroll",
+    () => {
+      closeIfOpen();
+    },
+    { passive: true },
+  );
+};
+
+initMyHomeCategoryDrawer();

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1626,10 +1626,10 @@ const initLandingCategorySidebar = () => {
       if (!(target instanceof HTMLDetailsElement)) {
         return;
       }
-      if (!target.classList.contains("public-home-category") || !target.open) {
+      if (!target.classList.contains("category-sidebar-category") || !target.open) {
         return;
       }
-      for (const other of root.querySelectorAll("details.public-home-category")) {
+      for (const other of root.querySelectorAll("details.category-sidebar-category")) {
         if (other !== target) {
           other.open = false;
         }
@@ -1642,11 +1642,11 @@ const initLandingCategorySidebar = () => {
     if (!(target instanceof Element)) {
       return;
     }
-    const btn = target.closest(".public-home-subcategory");
+    const btn = target.closest(".category-sidebar-subcategory");
     if (!(btn instanceof HTMLElement) || !root.contains(btn)) {
       return;
     }
-    for (const other of root.querySelectorAll(".public-home-subcategory")) {
+    for (const other of root.querySelectorAll(".category-sidebar-subcategory")) {
       other.classList.remove("is-active");
     }
     btn.classList.add("is-active");

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -6,6 +6,7 @@
 @import url("./components/sidebar-nav.css");
 @import url("./components/dialog.css");
 @import url("./components/toast.css");
+@import url("./components/empty-state.css");
 @import url("./components/button.css");
 @import url("./components/list-row.css");
 @import url("./components/tip.css");

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -23,5 +23,6 @@
 @import url("./components/home-feature-card.css");
 @import url("./components/public-stream-card.css");
 @import url("./components/category-sidebar.css");
+@import url("./components/nav-drawer.css");
 @import url("./components/site-footer.css");
 @import url("./components/stream.css");

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -22,5 +22,6 @@
 @import url("./components/home-phase-card.css");
 @import url("./components/home-feature-card.css");
 @import url("./components/public-stream-card.css");
+@import url("./components/category-sidebar.css");
 @import url("./components/site-footer.css");
 @import url("./components/stream.css");

--- a/web/src/styles/components/category-sidebar.css
+++ b/web/src/styles/components/category-sidebar.css
@@ -1,0 +1,173 @@
+/*
+ * Category sidebar — stream catalog taxonomy nav (full component).
+ *
+ * aside.category-sidebar
+ *   .category-sidebar-header
+ *     .icon-svg
+ *     p.category-sidebar-title
+ *   .category-sidebar-list
+ *     details.category-sidebar-category
+ *       summary.category-sidebar-category-summary
+ *         span.category-sidebar-category-label
+ *           img.category-sidebar-category-icon?
+ *           span
+ *         span.category-sidebar-category-chevron
+ *       .category-sidebar-subcategories
+ *         a.category-sidebar-subcategory[.is-active] | button.category-sidebar-subcategory[.is-active]
+ *     p.category-sidebar-empty
+ */
+
+.category-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  background: var(--card);
+  border-bottom: 1px solid var(--border);
+  overflow: hidden;
+  padding: var(--space-6) var(--space-5);
+}
+
+.category-sidebar-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.category-sidebar-header .icon-svg {
+  width: 24px;
+  height: 24px;
+}
+
+.category-sidebar-title {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: var(--font-medium);
+  line-height: 1.75rem;
+  color: var(--foreground);
+}
+
+.category-sidebar-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.category-sidebar-category {
+  border-radius: 8px;
+  background: var(--muted);
+  border: 1px solid transparent;
+  interpolate-size: allow-keywords;
+}
+
+.category-sidebar-category[open],
+.category-sidebar-category:not([open]):hover {
+  border-color: var(--border);
+}
+
+.category-sidebar-category::details-content {
+  block-size: 0;
+  overflow: hidden;
+  transition:
+    block-size 0.2s ease,
+    content-visibility 0.2s allow-discrete;
+}
+
+.category-sidebar-category[open]::details-content {
+  block-size: auto;
+}
+
+.category-sidebar-category-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  cursor: pointer;
+  list-style: none;
+}
+
+.category-sidebar-category-summary::-webkit-details-marker {
+  display: none;
+}
+
+.category-sidebar-category-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--muted-foreground);
+}
+
+.category-sidebar-category[open] .category-sidebar-category-label {
+  font-weight: var(--font-semibold);
+  color: var(--foreground);
+}
+
+.category-sidebar-category-icon {
+  width: 20px;
+  height: 20px;
+}
+
+.category-sidebar-category-chevron {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: var(--muted-foreground);
+  transition: transform 0.2s ease;
+}
+
+.category-sidebar-category[open] .category-sidebar-category-chevron {
+  transform: rotate(90deg);
+}
+
+.category-sidebar-subcategories {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 0 var(--space-3) var(--space-3) var(--space-5);
+}
+
+.category-sidebar-subcategory {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  overflow: hidden;
+  text-align: left;
+  border: 0;
+  border-radius: 6px;
+  padding: var(--space-2) var(--space-3);
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: var(--text-sm);
+  cursor: pointer;
+}
+
+a.category-sidebar-subcategory {
+  text-decoration: none;
+  color: inherit;
+}
+
+.category-sidebar-subcategory:hover {
+  background: var(--success-muted);
+  color: var(--primary);
+}
+
+.category-sidebar-subcategory::before {
+  content: "";
+  flex-shrink: 0;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: transparent;
+}
+
+.category-sidebar-subcategory.is-active {
+  background: var(--success-muted);
+  color: var(--primary);
+  font-weight: var(--font-medium);
+}
+
+.category-sidebar-subcategory.is-active::before {
+  background: var(--primary);
+}

--- a/web/src/styles/components/category-sidebar.css
+++ b/web/src/styles/components/category-sidebar.css
@@ -3,8 +3,10 @@
  *
  * aside.category-sidebar
  *   .category-sidebar-header
- *     .icon-svg
- *     p.category-sidebar-title
+ *     .category-sidebar-header-main
+ *       .icon-svg
+ *       p.category-sidebar-title
+ *     button.category-sidebar-close?  (drawer close; CloseTargetID set)
  *   .category-sidebar-list
  *     details.category-sidebar-category
  *       summary.category-sidebar-category-summary
@@ -30,12 +32,25 @@
 .category-sidebar-header {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: var(--space-2);
 }
 
-.category-sidebar-header .icon-svg {
+.category-sidebar-header-main {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.category-sidebar-header-main .icon-svg {
   width: 24px;
   height: 24px;
+  flex-shrink: 0;
+}
+
+.category-sidebar-close {
+  flex-shrink: 0;
 }
 
 .category-sidebar-title {

--- a/web/src/styles/components/empty-state.css
+++ b/web/src/styles/components/empty-state.css
@@ -1,0 +1,43 @@
+/*
+ * Empty state — centered dashed placeholder (CSS-only).
+ *
+ * div.empty-state
+ *   (optional .icon-svg)
+ *   p.empty-state-title
+ *   p.empty-state-hint
+ */
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--muted) 60%, transparent);
+  color: var(--muted-foreground);
+  text-align: center;
+}
+
+.empty-state .icon-svg {
+  width: 24px;
+  height: 24px;
+  color: var(--muted-foreground);
+}
+
+.empty-state-title {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  line-height: 1.25rem;
+}
+
+.empty-state-hint {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: var(--text-xs);
+  line-height: 1rem;
+}

--- a/web/src/styles/components/nav-drawer.css
+++ b/web/src/styles/components/nav-drawer.css
@@ -1,0 +1,26 @@
+/*
+ * Nav drawer — left slide-in shell (CSS-only).
+ *
+ * button.nav-drawer-trigger[popovertarget="…"]
+ * div.nav-drawer-panel[popover][id="…"]   (hosts page content, e.g. category_sidebar)
+ *
+ * Desktop: page CSS forces .nav-drawer-panel into normal flow and hides the trigger.
+ * Do not use :target to open — hashes are reserved for in-page section anchors.
+ */
+
+.nav-drawer-panel {
+  margin: 0;
+  border: 0;
+  padding: 0;
+  background: var(--background);
+  color: var(--foreground);
+  width: min(18rem, 92vw);
+  height: 100dvh;
+  max-height: 100dvh;
+  overflow: auto;
+}
+
+.nav-drawer-panel:popover-open {
+  position: fixed;
+  inset: 0 auto 0 0;
+}

--- a/web/src/styles/components/nav-drawer.css
+++ b/web/src/styles/components/nav-drawer.css
@@ -1,5 +1,5 @@
 /*
- * Nav drawer — left slide-in shell (CSS-only).
+ * Nav drawer — left slide-in shell (CSS-only open/close via Popover API).
  *
  * button.nav-drawer-trigger[popovertarget="…"]
  * div.nav-drawer-panel[popover][id="…"]   (hosts page content, e.g. category_sidebar)
@@ -12,15 +12,63 @@
   margin: 0;
   border: 0;
   padding: 0;
-  background: var(--background);
+  background: var(--card);
   color: var(--foreground);
   width: min(18rem, 92vw);
   height: 100dvh;
   max-height: 100dvh;
   overflow: auto;
+  transition:
+    transform 0.2s ease,
+    display 0.2s allow-discrete,
+    overlay 0.2s allow-discrete;
 }
 
 .nav-drawer-panel:popover-open {
   position: fixed;
   inset: 0 auto 0 0;
+  transform: translateX(0);
+}
+
+/* Closed popover exit + entry start (desktop in-flow resets transform). */
+.nav-drawer-panel:not(:popover-open) {
+  transform: translateX(-100%);
+}
+
+@starting-style {
+  .nav-drawer-panel:popover-open {
+    transform: translateX(-100%);
+  }
+}
+
+.nav-drawer-panel::backdrop {
+  background: transparent;
+  transition:
+    background 0.2s ease,
+    display 0.2s allow-discrete,
+    overlay 0.2s allow-discrete;
+}
+
+.nav-drawer-panel:popover-open::backdrop {
+  background: var(--backdrop-modal);
+  backdrop-filter: blur(2px);
+}
+
+@starting-style {
+  .nav-drawer-panel:popover-open::backdrop {
+    background: transparent;
+  }
+}
+
+.nav-drawer-panel .category-sidebar {
+  min-height: 100%;
+  background: transparent;
+  border-bottom: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nav-drawer-panel,
+  .nav-drawer-panel::backdrop {
+    transition: none;
+  }
 }

--- a/web/src/styles/components/public-stream-card.css
+++ b/web/src/styles/components/public-stream-card.css
@@ -49,6 +49,11 @@
   background: color-mix(in srgb, var(--primary) 12%, var(--card));
 }
 
+.public-stream-card-menu-trigger:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
 .public-stream-card-dropdown {
   position: absolute;
   top: calc(100%);

--- a/web/src/styles/components/public-stream-card.css
+++ b/web/src/styles/components/public-stream-card.css
@@ -1,7 +1,10 @@
 /*
  * Public stream card — public homepage catalog tile (full component).
  *
- * a.public-stream-card | article.public-stream-card
+ * .public-stream-card-shell
+ *   details.public-stream-card-menu > summary.public-stream-card-menu-trigger
+ *     + .public-stream-card-dropdown > .public-stream-card-menu-item[+modifiers]
+ *   a.public-stream-card | article.public-stream-card
  *   .public-stream-card-header
  *     h3.public-stream-card-title
  *     p.public-stream-card-description
@@ -15,6 +18,100 @@
  *       .public-stream-card-orgs-head > strong + span.public-stream-card-orgs-count
  *       .public-stream-card-avatars > img | span.public-stream-card-avatar | span.public-stream-card-avatar-more
  */
+
+.public-stream-card-shell {
+  position: relative;
+}
+
+.public-stream-card-menu {
+  position: absolute;
+  top: var(--space-3);
+  right: var(--space-3);
+  z-index: 10;
+}
+
+.public-stream-card-menu-trigger {
+  list-style: none;
+  background: var(--card);
+  color: var(--foreground);
+}
+
+.public-stream-card-menu-trigger::marker {
+  content: "";
+}
+
+.public-stream-card-menu-trigger::-webkit-details-marker {
+  display: none;
+}
+
+.public-stream-card-menu-trigger:hover,
+.public-stream-card-menu[open] .public-stream-card-menu-trigger {
+  background: color-mix(in srgb, var(--primary) 12%, var(--card));
+}
+
+.public-stream-card-dropdown {
+  position: absolute;
+  top: calc(100%);
+  right: 0;
+  min-width: 160px;
+  padding: var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--card);
+  box-shadow: 0 10px 26px var(--shadow);
+  z-index: 40;
+  display: grid;
+  gap: var(--space-1);
+}
+
+.public-stream-card-menu-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 7px 9px;
+  gap: var(--space-2);
+  margin: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--foreground);
+  text-decoration: none;
+  text-align: left;
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.public-stream-card-menu-item:hover {
+  background: var(--muted);
+  text-decoration: none;
+}
+
+.public-stream-card-menu-item-disabled,
+.public-stream-card-menu-item:disabled {
+  color: var(--muted-foreground);
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.public-stream-card-menu-item-disabled:hover,
+.public-stream-card-menu-item:disabled:hover {
+  background: transparent;
+}
+
+.public-stream-card-menu-item-danger {
+  color: var(--destructive);
+}
+
+.public-stream-card-menu-item-danger:hover {
+  background: color-mix(in srgb, var(--destructive) 10%, var(--card));
+}
+
+.public-stream-card-menu-item-danger.public-stream-card-menu-item-disabled,
+.public-stream-card-menu-item-danger:disabled {
+  color: var(--muted-foreground);
+}
 
 .public-stream-card {
   display: flex;

--- a/web/src/styles/layout/chrome.css
+++ b/web/src/styles/layout/chrome.css
@@ -204,15 +204,11 @@
 
 .page {
   flex: 1;
-  padding: var(--space-7) 32px 60px;
+  padding: var(--space-12) 32px 60px;
 }
 
 .page.page-landing {
   padding: 0;
-}
-
-.page:has(.breadcrumbs) {
-  padding-top: var(--space-4);
 }
 
 .stack {

--- a/web/src/styles/layout/responsive.css
+++ b/web/src/styles/layout/responsive.css
@@ -1,10 +1,6 @@
 @media (--md-down) {
   .page {
-    padding: var(--space-4) var(--space-4) 32px;
-  }
-
-  .page:has(.breadcrumbs) {
-    padding-top: var(--space-2);
+    padding: var(--space-12) var(--space-4) 32px;
   }
 
   .topbar {

--- a/web/src/styles/pages/home.css
+++ b/web/src/styles/pages/home.css
@@ -15,6 +15,19 @@ html:has(.my-home) {
   min-width: 0;
 }
 
+/* Hide the rule before the first category; later ones separate categories. */
+.my-home-catalog > .my-home-category-rule:first-child {
+  display: none;
+}
+
+.my-home-category-rule {
+  margin: 0;
+  border: none;
+  border-top: 1px solid var(--border);
+  /* Match sticky category header bleed over .page padding. */
+  margin-inline: calc(-1 * var(--space-4));
+}
+
 .my-home-catalog-section {
   display: flex;
   flex-direction: column;
@@ -84,6 +97,10 @@ html:has(.my-home) {
   .my-home .public-home-results-category-header {
     margin-inline: calc(-1 * var(--space-8));
     padding-inline: var(--space-8);
+  }
+
+  .my-home-category-rule {
+    margin-inline: calc(-1 * var(--space-8));
   }
 
   .my-home-category-bar {

--- a/web/src/styles/pages/home.css
+++ b/web/src/styles/pages/home.css
@@ -86,6 +86,10 @@ html:has(.my-home) {
     padding: 0;
     min-height: 0;
   }
+
+  .my-home .category-sidebar-close {
+    display: none;
+  }
 }
 
 @media (--md-down) {

--- a/web/src/styles/pages/home.css
+++ b/web/src/styles/pages/home.css
@@ -2,6 +2,21 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-8);
+  min-width: 0;
+}
+
+.my-home-catalog-section {
+  scroll-margin-top: 44px;
+}
+
+.my-home-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.my-home .nav-drawer-trigger {
+  display: inline-flex;
 }
 
 .home-workflow-panel-main {
@@ -14,6 +29,36 @@
 
 .instances-panel {
   scroll-margin-top: 140px;
+}
+
+@media (--md-up) {
+  .my-home-body {
+    display: grid;
+    grid-template-columns: 18rem minmax(0, 1fr);
+    gap: var(--space-8);
+    align-items: start;
+  }
+
+  .my-home .nav-drawer-trigger {
+    display: none;
+  }
+
+  .my-home .nav-drawer-panel.my-home-sidebar {
+    display: block;
+    position: static;
+    inset: auto;
+    width: auto;
+    height: auto;
+    max-height: none;
+    overflow: visible;
+    background: transparent;
+  }
+
+  .my-home .category-sidebar {
+    background: transparent;
+    border-bottom: 0;
+    padding: 0;
+  }
 }
 
 @media (--md-down) {

--- a/web/src/styles/pages/home.css
+++ b/web/src/styles/pages/home.css
@@ -35,6 +35,9 @@ html:has(.my-home) {
   /* Above public-stream-card-menu (10) and dropdown (40). */
   z-index: 45;
   padding-top: var(--space-4);
+  /* Bleed over .page inline padding (space-4 on md-down; space-8/32px on md-up). */
+  margin-inline: calc(-1 * var(--space-4));
+  padding-inline: var(--space-4);
   background: var(--background);
 }
 
@@ -78,6 +81,11 @@ html:has(.my-home) {
 }
 
 @media (--md-up) {
+  .my-home .public-home-results-category-header {
+    margin-inline: calc(-1 * var(--space-8));
+    padding-inline: var(--space-8);
+  }
+
   .my-home-category-bar {
     display: none;
   }
@@ -122,9 +130,6 @@ html:has(.my-home) {
   .my-home .public-home-results-category-header {
     /* Flush under sticky Stream categories bar (no hairline gap). */
     top: var(--my-home-category-bar-height);
-    /* Match category bar: bleed to viewport edges over .page padding. */
-    margin-inline: calc(-1 * var(--space-4));
-    padding-inline: var(--space-4);
   }
 
   .my-home-catalog-section {

--- a/web/src/styles/pages/home.css
+++ b/web/src/styles/pages/home.css
@@ -20,8 +20,23 @@ html:has(.my-home) {
   gap: var(--space-6);
 }
 
-.my-home .nav-drawer-trigger {
+/* Mobile-only sticky strip so categories stay reachable while scrolling. */
+.my-home-category-bar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  margin-inline: calc(-1 * var(--space-4));
+  padding: var(--space-2) var(--space-4);
+  background: var(--background);
+  border-bottom: 1px solid var(--border);
+}
+
+.my-home-category-bar .nav-drawer-trigger {
   display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
 }
 
 .home-workflow-panel-main {
@@ -37,6 +52,10 @@ html:has(.my-home) {
 }
 
 @media (--md-up) {
+  .my-home-category-bar {
+    display: none;
+  }
+
   .my-home-body {
     display: grid;
     grid-template-columns: 18rem minmax(0, 1fr);
@@ -44,22 +63,20 @@ html:has(.my-home) {
     align-items: start;
   }
 
-  .my-home .nav-drawer-trigger {
-    display: none;
-  }
-
   .my-home .nav-drawer-panel.my-home-sidebar {
     display: block;
     position: sticky;
-    top: 44px;
-    right: auto;
-    bottom: auto;
-    left: auto;
+    inset: 44px auto auto;
     width: auto;
     height: auto;
     max-height: none;
     overflow: visible;
     background: transparent;
+    transform: none;
+  }
+
+  .my-home .nav-drawer-panel.my-home-sidebar:not(:popover-open) {
+    transform: none;
   }
 
   .my-home .category-sidebar {
@@ -67,10 +84,16 @@ html:has(.my-home) {
     border-bottom: 0;
     border-right: 0;
     padding: 0;
+    min-height: 0;
   }
 }
 
 @media (--md-down) {
+  .my-home-catalog-section {
+    /* topbar offset unused; sticky category bar (~52px) + breathing room */
+    scroll-margin-top: 3.5rem;
+  }
+
   .preview-panel,
   .instances-panel {
     scroll-margin-top: var(--space-3);

--- a/web/src/styles/pages/home.css
+++ b/web/src/styles/pages/home.css
@@ -30,6 +30,7 @@ html:has(.my-home) {
   margin-inline: calc(-1 * var(--space-4));
   padding: var(--space-2) var(--space-4);
   background: var(--background);
+  border-top: 1px solid var(--border);
   border-bottom: 1px solid var(--border);
 }
 
@@ -37,6 +38,7 @@ html:has(.my-home) {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
+  transform: translateX(calc(-1 * var(--space-3)));
 }
 
 .home-workflow-panel-main {

--- a/web/src/styles/pages/home.css
+++ b/web/src/styles/pages/home.css
@@ -1,3 +1,9 @@
+.my-home-catalog {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+}
+
 .home-workflow-panel-main {
   display: grid;
 }

--- a/web/src/styles/pages/home.css
+++ b/web/src/styles/pages/home.css
@@ -1,3 +1,8 @@
+/* Viewport hash jumps from category sidebar anchors. */
+html:has(.my-home) {
+  scroll-behavior: smooth;
+}
+
 .my-home-catalog {
   display: flex;
   flex-direction: column;

--- a/web/src/styles/pages/home.css
+++ b/web/src/styles/pages/home.css
@@ -13,8 +13,10 @@ html:has(.my-home) {
 .my-home-catalog-section {
   display: flex;
   flex-direction: column;
+
   /* Match .public-home-stream-grid gap between subcategory header and cards. */
   gap: var(--space-4);
+
   /* Sticky category header clearance (padding-top + title + padding-bottom). */
   scroll-margin-top: 4.5rem;
 }
@@ -27,9 +29,11 @@ html:has(.my-home) {
 .my-home .public-home-results-category-header {
   position: sticky;
   top: 0;
+
   /* Above public-stream-card-menu (10) and dropdown (40). */
   z-index: 45;
   padding-top: var(--space-4);
+
   /* Bleed over .page inline padding (space-4 on md-down; space-8/32px on md-up). */
   margin-inline: calc(-1 * var(--space-4));
   padding-inline: var(--space-4);
@@ -97,6 +101,7 @@ html:has(.my-home) {
     background: transparent;
     border-bottom: 0;
     border-right: 0;
+
     /* Match sticky category header padding-top. */
     padding: var(--space-4) 0 0;
     min-height: 0;
@@ -116,6 +121,7 @@ html:has(.my-home) {
     z-index: 47;
     height: 0;
     margin: 0;
+
     /* Cancel .my-home-catalog gap so the control aligns with the first header. */
     margin-bottom: calc(-1 * var(--space-8));
     overflow: visible;
@@ -124,6 +130,7 @@ html:has(.my-home) {
 
   .my-home-category-menu .nav-drawer-trigger {
     position: absolute;
+
     /* Match header padding, then nudge -3x / -1y. */
     top: calc(var(--space-4) - var(--space-1));
     left: calc(var(--space-4) - var(--space-3) - var(--space-2));
@@ -133,6 +140,7 @@ html:has(.my-home) {
 
   .my-home .public-home-results-category-header {
     top: 0;
+
     /* Room for the shared hamburger to the left of the title. */
     padding-inline-start: calc(var(--space-4) + 2.25rem + var(--space-2));
   }

--- a/web/src/styles/pages/home.css
+++ b/web/src/styles/pages/home.css
@@ -15,19 +15,6 @@ html:has(.my-home) {
   min-width: 0;
 }
 
-/* Hide the rule before the first category; later ones separate categories. */
-.my-home-catalog > .my-home-category-rule:first-child {
-  display: none;
-}
-
-.my-home-category-rule {
-  margin: 0;
-  border: none;
-  border-top: 1px solid var(--border);
-  /* Match sticky category header bleed over .page padding. */
-  margin-inline: calc(-1 * var(--space-4));
-}
-
 .my-home-catalog-section {
   display: flex;
   flex-direction: column;
@@ -52,6 +39,11 @@ html:has(.my-home) {
   margin-inline: calc(-1 * var(--space-4));
   padding-inline: var(--space-4);
   background: var(--background);
+}
+
+/* Extra separation between categories (on top of .my-home-catalog gap). */
+.my-home-catalog > .public-home-results-category-header:not(:first-child) {
+  margin-top: var(--space-8);
 }
 
 .my-home-body {
@@ -99,10 +91,6 @@ html:has(.my-home) {
     padding-inline: var(--space-8);
   }
 
-  .my-home-category-rule {
-    margin-inline: calc(-1 * var(--space-8));
-  }
-
   .my-home-category-bar {
     display: none;
   }
@@ -117,7 +105,7 @@ html:has(.my-home) {
   .my-home .nav-drawer-panel.my-home-sidebar {
     display: block;
     position: sticky;
-    inset: 44px auto auto;
+    inset: 0 auto auto;
     width: auto;
     height: auto;
     max-height: none;
@@ -134,7 +122,8 @@ html:has(.my-home) {
     background: transparent;
     border-bottom: 0;
     border-right: 0;
-    padding: 0;
+    /* Match sticky category header padding-top. */
+    padding: var(--space-4) 0 0;
     min-height: 0;
   }
 

--- a/web/src/styles/pages/home.css
+++ b/web/src/styles/pages/home.css
@@ -3,6 +3,11 @@ html:has(.my-home) {
   scroll-behavior: smooth;
 }
 
+/* Mobile sticky Stream categories bar: padding + btn (~36px) + borders. */
+.my-home {
+  --my-home-category-bar-height: 54px;
+}
+
 .my-home-catalog {
   display: flex;
   flex-direction: column;
@@ -11,7 +16,18 @@ html:has(.my-home) {
 }
 
 .my-home-catalog-section {
-  scroll-margin-top: 44px;
+  /* Sticky category header clearance (padding-top + title + padding-bottom). */
+  scroll-margin-top: 4.5rem;
+}
+
+/* Stick category titles while scrolling the catalog (desktop: under viewport top). */
+.my-home .public-home-results-category-header {
+  position: sticky;
+  top: 0;
+  /* Above public-stream-card-menu (10) and dropdown (40). */
+  z-index: 45;
+  padding-top: var(--space-4);
+  background: var(--background);
 }
 
 .my-home-body {
@@ -24,7 +40,7 @@ html:has(.my-home) {
 .my-home-category-bar {
   position: sticky;
   top: 0;
-  z-index: 20;
+  z-index: 46;
   display: flex;
   align-items: center;
   margin-inline: calc(-1 * var(--space-4));
@@ -95,9 +111,17 @@ html:has(.my-home) {
 }
 
 @media (--md-down) {
+  .my-home .public-home-results-category-header {
+    /* Flush under sticky Stream categories bar (no hairline gap). */
+    top: var(--my-home-category-bar-height);
+    /* Match category bar: bleed to viewport edges over .page padding. */
+    margin-inline: calc(-1 * var(--space-4));
+    padding-inline: var(--space-4);
+  }
+
   .my-home-catalog-section {
-    /* topbar offset unused; sticky category bar (~52px) + breathing room */
-    scroll-margin-top: 3.5rem;
+    /* Sticky category bar + sticky category header (~4rem). */
+    scroll-margin-top: calc(var(--my-home-category-bar-height) + 4rem);
   }
 
   .preview-panel,

--- a/web/src/styles/pages/home.css
+++ b/web/src/styles/pages/home.css
@@ -3,11 +3,6 @@ html:has(.my-home) {
   scroll-behavior: smooth;
 }
 
-/* Mobile sticky Stream categories bar: padding + btn (~36px) + borders. */
-.my-home {
-  --my-home-category-bar-height: 54px;
-}
-
 .my-home-catalog {
   display: flex;
   flex-direction: column;
@@ -41,9 +36,9 @@ html:has(.my-home) {
   background: var(--background);
 }
 
-/* Extra separation between categories (on top of .my-home-catalog gap). */
-.my-home-catalog > .public-home-results-category-header:not(:first-child) {
-  margin-top: var(--space-8);
+/* Extra separation before the next category (avoid margin on sticky headers). */
+.my-home-catalog-section:has(+ .public-home-results-category-header) {
+  margin-bottom: var(--space-8);
 }
 
 .my-home-body {
@@ -52,25 +47,9 @@ html:has(.my-home) {
   gap: var(--space-6);
 }
 
-/* Mobile-only sticky strip so categories stay reachable while scrolling. */
-.my-home-category-bar {
-  position: sticky;
-  top: 0;
-  z-index: 46;
-  display: flex;
-  align-items: center;
-  margin-inline: calc(-1 * var(--space-4));
-  padding: var(--space-2) var(--space-4);
-  background: var(--background);
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-}
-
-.my-home-category-bar .nav-drawer-trigger {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  transform: translateX(calc(-1 * var(--space-3)));
+/* Single mobile drawer control — sticky beside category titles (one for all headers). */
+.my-home-category-menu {
+  display: none;
 }
 
 .home-workflow-panel-main {
@@ -89,10 +68,6 @@ html:has(.my-home) {
   .my-home .public-home-results-category-header {
     margin-inline: calc(-1 * var(--space-8));
     padding-inline: var(--space-8);
-  }
-
-  .my-home-category-bar {
-    display: none;
   }
 
   .my-home-body {
@@ -133,14 +108,38 @@ html:has(.my-home) {
 }
 
 @media (--md-down) {
+  .my-home-category-menu {
+    /* Zero-height sticky host; button is absolutely placed so start/stuck match. */
+    display: block;
+    position: sticky;
+    top: 0;
+    z-index: 47;
+    height: 0;
+    margin: 0;
+    /* Cancel .my-home-catalog gap so the control aligns with the first header. */
+    margin-bottom: calc(-1 * var(--space-8));
+    overflow: visible;
+    pointer-events: none;
+  }
+
+  .my-home-category-menu .nav-drawer-trigger {
+    position: absolute;
+    /* Match header padding, then nudge -3x / -1y. */
+    top: calc(var(--space-4) - var(--space-1));
+    left: calc(var(--space-4) - var(--space-3) - var(--space-2));
+    pointer-events: auto;
+    background: var(--background);
+  }
+
   .my-home .public-home-results-category-header {
-    /* Flush under sticky Stream categories bar (no hairline gap). */
-    top: var(--my-home-category-bar-height);
+    top: 0;
+    /* Room for the shared hamburger to the left of the title. */
+    padding-inline-start: calc(var(--space-4) + 2.25rem + var(--space-2));
   }
 
   .my-home-catalog-section {
-    /* Sticky category bar + sticky category header (~4rem). */
-    scroll-margin-top: calc(var(--my-home-category-bar-height) + 4rem);
+    /* Sticky category header clearance only. */
+    scroll-margin-top: 4.5rem;
   }
 
   .preview-panel,

--- a/web/src/styles/pages/home.css
+++ b/web/src/styles/pages/home.css
@@ -35,7 +35,7 @@
   .my-home-body {
     display: grid;
     grid-template-columns: 18rem minmax(0, 1fr);
-    gap: var(--space-8);
+    gap: var(--space-12);
     align-items: start;
   }
 
@@ -45,8 +45,11 @@
 
   .my-home .nav-drawer-panel.my-home-sidebar {
     display: block;
-    position: static;
-    inset: auto;
+    position: sticky;
+    top: 44px;
+    right: auto;
+    bottom: auto;
+    left: auto;
     width: auto;
     height: auto;
     max-height: none;
@@ -57,6 +60,7 @@
   .my-home .category-sidebar {
     background: transparent;
     border-bottom: 0;
+    border-right: 0;
     padding: 0;
   }
 }

--- a/web/src/styles/pages/home.css
+++ b/web/src/styles/pages/home.css
@@ -16,8 +16,16 @@ html:has(.my-home) {
 }
 
 .my-home-catalog-section {
+  display: flex;
+  flex-direction: column;
+  /* Match .public-home-stream-grid gap between subcategory header and cards. */
+  gap: var(--space-4);
   /* Sticky category header clearance (padding-top + title + padding-bottom). */
   scroll-margin-top: 4.5rem;
+}
+
+.my-home .public-home-results-subcategory-header {
+  padding-bottom: 0;
 }
 
 /* Stick category titles while scrolling the catalog (desktop: under viewport top). */

--- a/web/src/styles/pages/public-home.css
+++ b/web/src/styles/pages/public-home.css
@@ -159,6 +159,7 @@
 h2.public-home-results-category-name {
   margin: 0;
   font-family: var(--font-sans);
+  /* Match .category-sidebar-title. */
   font-size: var(--text-lg);
   font-weight: var(--font-medium);
   line-height: 1.75rem;
@@ -186,9 +187,10 @@ h2.public-home-results-category-name {
 
 .public-home-results-subcategory-name {
   margin: 0;
-  font-size: var(--text-xl);
+  /* One step under category / sidebar title (text-lg). */
+  font-size: var(--text-base);
   font-weight: var(--font-semibold);
-  line-height: 1.75rem;
+  line-height: 1.5rem;
   color: var(--foreground);
 }
 

--- a/web/src/styles/pages/public-home.css
+++ b/web/src/styles/pages/public-home.css
@@ -4,13 +4,14 @@
  * div.public-home
  *   section.public-home-hero | .public-home-process | .public-home-features | .public-home-dev
  *   .public-home-streams-split#streams (full-bleed band; content capped at 8xl / 88rem)
- *     aside.public-home-category-sidebar  (--card, left bleed via ::before; shared padding like results)
+ *     aside.category-sidebar  (--card, left bleed via ::before; shared padding like results)
  *     .public-home-stream-results         (--muted, right bleed via ::after; padding on shell)
  *
  * Shared chrome footer: components/site_footer.html (+ site-footer.css).
  * Phase tiles use CSS-only component .home-phase-card (components/home-phase-card.css).
  * Feature tiles use CSS-only component .home-feature-card (components/home-feature-card.css).
  * Stream tiles use full component .public-stream-card (components/public-stream-card.css).
+ * Category nav uses full component .category-sidebar (components/category-sidebar.css).
  */
 
 .public-home {
@@ -128,156 +129,6 @@
   width: 100%;
   border-block: 1px solid var(--border);
   overflow: hidden;
-}
-
-.public-home-category-sidebar {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
-  background: var(--card);
-  border-bottom: 1px solid var(--border);
-  overflow: hidden;
-  padding: var(--space-6) var(--space-5);
-}
-
-.public-home-category-sidebar-header {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.public-home-category-sidebar-header .icon-svg {
-  width: 24px;
-  height: 24px;
-}
-
-.public-home-category-sidebar-title {
-  margin: 0;
-  font-size: var(--text-lg);
-  font-weight: var(--font-medium);
-  line-height: 1.75rem;
-  color: var(--foreground);
-}
-
-.public-home-category-sidebar-list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-}
-
-.public-home-category {
-  border-radius: 8px;
-  background: var(--muted);
-  border: 1px solid transparent;
-  interpolate-size: allow-keywords;
-}
-
-.public-home-category[open],
-.public-home-category:not([open]):hover {
-  border-color: var(--border);
-}
-
-.public-home-category::details-content {
-  block-size: 0;
-  overflow: hidden;
-  transition:
-    block-size 0.2s ease,
-    content-visibility 0.2s allow-discrete;
-}
-
-.public-home-category[open]::details-content {
-  block-size: auto;
-}
-
-.public-home-category-summary {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
-  padding: var(--space-3) var(--space-4);
-  cursor: pointer;
-  list-style: none;
-}
-
-.public-home-category-summary::-webkit-details-marker {
-  display: none;
-}
-
-.public-home-category-label {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-size: var(--text-sm);
-  font-weight: var(--font-medium);
-  color: var(--muted-foreground);
-}
-
-.public-home-category[open] .public-home-category-label {
-  font-weight: var(--font-semibold);
-  color: var(--foreground);
-}
-
-.public-home-category-icon {
-  width: 20px;
-  height: 20px;
-}
-
-.public-home-category-chevron {
-  display: inline-flex;
-  flex-shrink: 0;
-  color: var(--muted-foreground);
-  transition: transform 0.2s ease;
-}
-
-.public-home-category[open] .public-home-category-chevron {
-  transform: rotate(90deg);
-}
-
-.public-home-subcategories {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: 0 var(--space-3) var(--space-3) var(--space-5);
-}
-
-.public-home-subcategory {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  width: 100%;
-  overflow: hidden;
-  text-align: left;
-  border: 0;
-  border-radius: 6px;
-  padding: var(--space-2) var(--space-3);
-  background: transparent;
-  color: var(--muted-foreground);
-  font-size: var(--text-sm);
-  cursor: pointer;
-}
-
-.public-home-subcategory:hover {
-  background: var(--success-muted);
-  color: var(--primary);
-}
-
-.public-home-subcategory::before {
-  content: "";
-  flex-shrink: 0;
-  width: 5px;
-  height: 5px;
-  border-radius: 50%;
-  background: transparent;
-}
-
-.public-home-subcategory.is-active {
-  background: var(--success-muted);
-  color: var(--primary);
-  font-weight: var(--font-medium);
-}
-
-.public-home-subcategory.is-active::before {
-  background: var(--primary);
 }
 
 .public-home-stream-results {
@@ -517,7 +368,7 @@ h2.public-home-results-category-name {
     background: var(--muted);
   }
 
-  .public-home-category-sidebar {
+  .category-sidebar {
     grid-column: 2;
     grid-row: 1;
     border-bottom: 0;

--- a/web/src/styles/pages/public-home.css
+++ b/web/src/styles/pages/public-home.css
@@ -159,6 +159,7 @@
 h2.public-home-results-category-name {
   margin: 0;
   font-family: var(--font-sans);
+
   /* Match .category-sidebar-title. */
   font-size: var(--text-lg);
   font-weight: var(--font-medium);
@@ -187,6 +188,7 @@ h2.public-home-results-category-name {
 
 .public-home-results-subcategory-name {
   margin: 0;
+
   /* One step under category / sidebar title (text-lg). */
   font-size: var(--text-base);
   font-weight: var(--font-semibold);

--- a/web/src/styles/pages/public-home.css
+++ b/web/src/styles/pages/public-home.css
@@ -304,7 +304,8 @@
   flex-shrink: 0;
 }
 
-.public-home h2.public-home-results-category-name {
+/* Unscoped: reused on /my (.my-home-catalog) as well as public home results. */
+h2.public-home-results-category-name {
   margin: 0;
   font-family: var(--font-sans);
   font-size: var(--text-lg);

--- a/web/src/styles/pages/public-stream.css
+++ b/web/src/styles/pages/public-stream.css
@@ -19,7 +19,7 @@
  *       section.public-stream-section.public-stream-runs? (when PassportEnabled)
  *         h2 + ul.public-stream-runs-list > li.public-stream-runs-item
  *           time.public-stream-runs-time + a.public-stream-runs-dpp (+ icon-arrow-up-right)
- *         | .public-stream-runs-empty
+ *         | .empty-state
  */
 
 .public-stream {
@@ -278,41 +278,6 @@ span.public-stream-org-mark {
   width: 14px;
   height: 14px;
   flex-shrink: 0;
-}
-
-.public-stream-runs-empty {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-2);
-  padding: var(--space-4);
-  border: 1px dashed var(--border);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--muted) 60%, transparent);
-  color: var(--muted-foreground);
-  text-align: center;
-}
-
-.public-stream-runs-empty .icon-svg {
-  width: 24px;
-  height: 24px;
-  color: var(--muted-foreground);
-}
-
-.public-stream-runs-empty-title {
-  margin: 0;
-  color: var(--muted-foreground);
-  font-size: var(--text-sm);
-  font-weight: var(--font-semibold);
-  line-height: 1.25rem;
-}
-
-.public-stream-runs-empty-hint {
-  margin: 0;
-  color: var(--muted-foreground);
-  font-size: var(--text-xs);
-  line-height: 1rem;
 }
 
 @media (--md-up) {


### PR DESCRIPTION
## Summary
- Replace authenticated `/my` stream picker with taxonomy-grouped `public_stream_card` catalog (accessible streams only: platform admin → all; org admin → org streams; else org + role).
- Add managed card shell for clone/edit/delete, Create stream in page-header actions, and extract shared CSS-only `empty-state` (shared with public stream runs empty).
- Spec + plan: `docs/superpowers/specs/2026-07-31-my-home-catalog-design.md`, `docs/superpowers/plans/2026-07-31-my-home-catalog.md`.

## Test plan
- [ ] Sign in as role member → `/my` shows only matching streams under category/subcategory headers; cards link to `/my/streams/:key/`
- [ ] Org admin (no workflow role) → all streams for their org; platform admin → all catalog streams
- [ ] Uncategorized accessible streams appear under Uncategorized
- [ ] Create a stream appears in page header when Formata builder allowed; empty state when zero accessible streams
- [ ] Clone/edit/delete menu works on managed cards; public `/` catalog/sidebar unchanged
- [ ] `go test ./cmd/server/ -run 'TestHandleHome|TestUserCanAccess|TestBuildMyHome|TestManagedPublic|TestHandlePublicHome'`


Made with [Cursor](https://cursor.com)