### PR TITLE
feat(admin): rewire platform admin routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ See: `README.md`, `QUICKSTART.md`, `DOCKER.md`, `docs/css.md` (CSS rules), `.age
 - Stream dashboard is `/my/streams/:key/` (lists stream instances for one stream).
 - Legacy `/w/`, `/org-admin/`, `/dashboard`, and `/w/:key/dashboard` are not registered (hard cut → 404).
 - Admin consoles:
-  - Platform admin: `/admin/orgs` (create/edit/delete orgs, upload logos, invite org admins)
+  - Platform admin: `/admin` (redirects to `/admin/organizations`); sections `/admin/organizations`, `/admin/categories`; logo `/admin/organizations/logo/:id`
   - Org admin: `/my/organization/profile`, `/my/organization/roles`, `/my/organization/members` (forms `POST /my/organization/users`, `POST /my/organization/roles`)
 - Platform admin is env-driven (`ADMIN_EMAIL`, `ADMIN_PASSWORD`). On startup the server ensures that account exists in Appwrite (`bootstrapPlatformAdminIdentity`). Cerbos policy `platform_admin_console` gates console access.
 - Auth/org state now lives in Appwrite:
@@ -26,7 +26,7 @@ See: `README.md`, `QUICKSTART.md`, `DOCKER.md`, `docs/css.md` (CSS rules), `.age
   - invites -> memberships
   - signup/login/reset -> Appwrite account/session/recovery flows
 - Global topbar now renders role-aware admin links on authenticated pages:
-  - Platform admin sees `Orgs` (`/admin/orgs`)
+  - Platform admin sees `Admin` (`/admin`)
   - Org admin with org context sees `My Org` (`/my/organization/profile`)
 - Workflow YAML supports `organizations`, `roles`, step-level `organization`, and substep `roles`.
 - Slug collisions on org and role creation now surface explicit `... slug already exists` errors in admin UIs.
@@ -160,7 +160,9 @@ Global routes are registered in `Server.newMux()` (`server/cmd/server/main.go`).
 - `GET /` — public homepage (`handlePublicHome`)
 - `GET/POST /login`, `GET/POST /signup`, `POST /logout` (login default redirect → `/my`)
 - `GET /invite/…`, `GET/POST /reset`, `GET/POST /reset/…`
-- `GET/POST /admin/orgs`, `GET/POST /admin/orgs/` (platform admin org console; logo at `/admin/orgs/logo/:id`)
+- `GET /admin` — platform admin entry (redirects to `/admin/organizations`)
+- `GET/POST /admin/organizations`, `GET/POST /admin/organizations/` (platform admin org console; logo at `/admin/organizations/logo/:id`)
+- `GET/POST /admin/categories` (platform admin category taxonomy)
 - `GET /organization/logo/:slug` — public org logo asset
 - `GET /01/…` — public DPP Digital Link
 - `GET /events` — legacy SSE mux entry (production UI uses stream-scoped path below)

--- a/docs/superpowers/plans/2026-07-31-platform-admin-routing.md
+++ b/docs/superpowers/plans/2026-07-31-platform-admin-routing.md
@@ -1,0 +1,681 @@
+# Platform Admin Routing Rewire Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `/admin` a working platform-admin entry (redirect to organizations), hard-cut rename `/admin/orgs` → `/admin/organizations`, fix breadcrumbs to the org-admin three-crumb shape, and relabel the topbar link to **Admin**.
+
+**Architecture:** Keep today’s flat mux registration. Add `adminPath` (mirror `organizationPath`), a root `/admin` handler that gates then redirects, rename the orgs path prefix everywhere, and make `buildPlatformAdminBreadcrumbs` always emit Dashboard → Platform admin → section.
+
+**Tech Stack:** Go `net/http`, `html/template`, HTMX soft-nav (`admin_console`), existing `requirePlatformAdmin` / Cerbos gate, `go test`, Goa design (`task goa:generate`).
+
+**Spec:** `docs/superpowers/specs/2026-07-31-platform-admin-routing-design.md`
+
+**Worktree:** `.worktrees/feat/platform-admin-routing` on branch `feat/platform-admin-routing`
+
+## Global Constraints
+
+- `/admin` and `/admin/` → auth-gated redirect to `/admin/organizations` (default section)
+- Hard cut: `/admin/orgs` and `/admin/orgs/…` return **404** (no compatibility redirect)
+- Categories stay at `/admin/categories` (+ nested subcategory POSTs)
+- Breadcrumbs always: `Dashboard` → `/my`, `Platform admin` → `/admin`, current section (`Organizations` | `Categories`)
+- Topbar: label **Admin**, href `/admin`
+- ActivePanel keys: `organizations` | `categories` (replace `orgs`)
+- Add `adminPath(rest string)`; use it for constructed admin URLs (nav, redirects, logo, pagination helpers)
+- Do **not** register a subtree pattern `/admin/` that would shadow `/admin/organizations` or `/admin/categories`
+- No new landing page body; no last-visited memory; no unified `handleAdminRoutes` mux refactor
+- Prefer minimal, localized diffs; TDD per task; commit after each task
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `server/cmd/server/paths.go` | Add `adminPath` |
+| `server/cmd/server/paths_test.go` | `adminPath` cases |
+| `server/cmd/server/breadcrumbs.go` | Three-crumb platform admin trails + section helpers |
+| `server/cmd/server/breadcrumbs_test.go` | Update platform admin breadcrumb expectations |
+| `server/cmd/server/admin_root.go` (new) or `main.go` | `handleAdminRoot` redirect |
+| `server/cmd/server/admin_root_test.go` (new) | Redirect + auth + hard-cut 404 cases |
+| `server/cmd/server/main.go` | Mux registration; path prefix `/admin/organizations`; `ActivePanel`; `platformAdminPath`; `ShowAdminLink` (rename from `ShowOrgsLink`); logo path trim |
+| `server/cmd/server/admin_console.go` | Nav hrefs via `adminPath`; ActivePanel `organizations` |
+| `server/cmd/server/admin_console_test.go` | Update expected hrefs / active panel |
+| `server/templates/layout.html` | Topbar Admin link |
+| `server/templates/pages/platform_admin.html` | Replace `/admin/orgs` with `/admin/organizations` |
+| `server/cmd/server/*_test.go` | Sweep `/admin/orgs` → `/admin/organizations`; topbar assertions |
+| `server/design/design.go` + Goa gen | OpenAPI paths |
+| `AGENTS.md` | Document new routes / topbar label |
+
+---
+
+### Task 1: `adminPath` helper
+
+**Files:**
+- Modify: `server/cmd/server/paths.go`
+- Modify: `server/cmd/server/paths_test.go`
+
+**Interfaces:**
+- Consumes: `organizationPath` pattern in `paths.go`
+- Produces: `func adminPath(rest string) string` — empty rest → `/admin`; otherwise `/admin/` + trimmed rest (supports `organizations`, `/categories`, `organizations/logo/x`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/cmd/server/paths_test.go`:
+
+```go
+func TestAdminPath(t *testing.T) {
+	cases := []struct {
+		rest string
+		want string
+	}{
+		{"", "/admin"},
+		{"organizations", "/admin/organizations"},
+		{"/categories", "/admin/categories"},
+		{"organizations/logo/logo-1", "/admin/organizations/logo/logo-1"},
+		{"  organizations  ", "/admin/organizations"},
+	}
+	for _, tc := range cases {
+		if got := adminPath(tc.rest); got != tc.want {
+			t.Fatalf("adminPath(%q) = %q, want %q", tc.rest, got, tc.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && go test ./cmd/server -run TestAdminPath -count=1`
+
+Expected: FAIL — `adminPath` undefined
+
+- [ ] **Step 3: Implement `adminPath`**
+
+Append to `server/cmd/server/paths.go` (after `organizationPath`):
+
+```go
+// adminPath joins /admin with rest.
+// rest may be "organizations", "/categories", or "organizations/logo/{id}".
+func adminPath(rest string) string {
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		return "/admin"
+	}
+	rest = strings.TrimPrefix(rest, "/")
+	return "/admin/" + rest
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && go test ./cmd/server -run TestAdminPath -count=1`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/cmd/server/paths.go server/cmd/server/paths_test.go
+git commit -m "$(cat <<'EOF'
+feat(admin): add adminPath URL helper
+
+EOF
+)"
+```
+
+---
+
+### Task 2: Platform admin breadcrumbs (three crumbs)
+
+**Files:**
+- Modify: `server/cmd/server/breadcrumbs.go`
+- Modify: `server/cmd/server/breadcrumbs_test.go`
+
+**Interfaces:**
+- Consumes: `adminPath`, `appHomePath`
+- Produces: `buildPlatformAdminBreadcrumbs(activePanel string)` always returns 3 items; helpers `platformAdminSectionLabel` / `platformAdminSectionHref` (or inline switch) for `organizations` (default) and `categories`
+
+- [ ] **Step 1: Rewrite failing breadcrumb tests**
+
+Replace `TestBuildPlatformAdminBreadcrumbsOrgsPanel` and `TestBuildPlatformAdminBreadcrumbsCategoriesPanel` in `breadcrumbs_test.go` with:
+
+```go
+func TestBuildPlatformAdminBreadcrumbs(t *testing.T) {
+	cases := map[string]struct {
+		label string
+		href  string
+	}{
+		"organizations": {label: "Organizations", href: "/admin/organizations"},
+		"":              {label: "Organizations", href: "/admin/organizations"},
+		"other":         {label: "Organizations", href: "/admin/organizations"},
+		"categories":    {label: "Categories", href: "/admin/categories"},
+	}
+	for panel, want := range cases {
+		got := buildPlatformAdminBreadcrumbs(panel)
+		if len(got.Items) != 3 {
+			t.Fatalf("panel %q: len(Items) = %d, want 3", panel, len(got.Items))
+		}
+		if got.Items[0].Label != "Dashboard" || got.Items[0].Href != appHomePath {
+			t.Fatalf("panel %q: root = %+v", panel, got.Items[0])
+		}
+		if got.Items[1].Label != "Platform admin" || got.Items[1].Href != adminPath("") || got.Items[1].Current {
+			t.Fatalf("panel %q: middle = %+v", panel, got.Items[1])
+		}
+		if got.Items[2].Label != want.label || got.Items[2].Href != want.href || !got.Items[2].Current {
+			t.Fatalf("panel %q: section = %+v, want label=%q href=%q", panel, got.Items[2], want.label, want.href)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd server && go test ./cmd/server -run 'TestBuildPlatformAdminBreadcrumbs' -count=1`
+
+Expected: FAIL — orgs panel still returns 2 crumbs / wrong hrefs
+
+- [ ] **Step 3: Implement breadcrumbs**
+
+Replace `buildPlatformAdminBreadcrumbs` in `breadcrumbs.go`:
+
+```go
+func buildPlatformAdminBreadcrumbs(activePanel string) BreadcrumbsView {
+	section := strings.TrimSpace(activePanel)
+	return BreadcrumbsView{Items: []BreadcrumbItem{
+		{Label: "Dashboard", Href: appHomePath},
+		{Label: "Platform admin", Href: adminPath("")},
+		{Label: platformAdminSectionLabel(section), Href: platformAdminSectionHref(section), Current: true},
+	}}
+}
+
+func platformAdminSectionLabel(activePanel string) string {
+	switch strings.TrimSpace(activePanel) {
+	case "categories":
+		return "Categories"
+	default:
+		return "Organizations"
+	}
+}
+
+func platformAdminSectionHref(activePanel string) string {
+	switch strings.TrimSpace(activePanel) {
+	case "categories":
+		return adminPath("categories")
+	default:
+		return adminPath("organizations")
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd server && go test ./cmd/server -run 'TestBuildPlatformAdminBreadcrumbs' -count=1`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/cmd/server/breadcrumbs.go server/cmd/server/breadcrumbs_test.go
+git commit -m "$(cat <<'EOF'
+fix(admin): align platform admin breadcrumbs with org-admin shape
+
+EOF
+)"
+```
+
+---
+
+### Task 3: `/admin` root redirect + mux (no subtree shadow)
+
+**Files:**
+- Create: `server/cmd/server/admin_root.go`
+- Create: `server/cmd/server/admin_root_test.go`
+- Modify: `server/cmd/server/main.go` (`newMux` registrations only in this task — add `/admin`; do **not** rename orgs yet)
+
+**Interfaces:**
+- Consumes: `requirePlatformAdmin`, `adminPath`
+- Produces: `func (s *Server) handleAdminRoot(w http.ResponseWriter, r *http.Request)` — GET only; path must be exactly `/admin` (ServeMux may redirect `/admin/` → `/admin`); then `http.Redirect` 303/302 to `adminPath("organizations")`
+
+**Critical:** Register `mux.HandleFunc("/admin", s.handleAdminRoot)` only. Do **not** register `/admin/` as a trailing-slash subtree pattern (it would steal `/admin/organizations` and `/admin/categories`). Rely on Go 1.22+ ServeMux trailing-slash redirect between `/admin` and `/admin/`, or assert `/admin/` behavior in the test and adjust with an exact `{$}` pattern only if needed.
+
+- [ ] **Step 1: Write failing handler tests**
+
+Create `server/cmd/server/admin_root_test.go` (same harness as `TestHandleAdminOrgsPlatformAdminHTMXGetAndLogo`):
+
+```go
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHandleAdminRootRedirectsToOrganizations(t *testing.T) {
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "change-me")
+
+	now := time.Now().UTC()
+	server := &Server{
+		authorizer:  fakeAuthorizer{},
+		identity:    &fakeIdentityStore{},
+		tmpl:        testTemplates(),
+		enforceAuth: true,
+		now:         func() time.Time { return now },
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/admin", nil)
+	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
+	rec := httptest.NewRecorder()
+	server.handleAdminRoot(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if loc := rec.Header().Get("Location"); loc != adminPath("organizations") {
+		t.Fatalf("Location = %q, want %q", loc, adminPath("organizations"))
+	}
+}
+
+func TestHandleAdminRootRejectsUnauthenticated(t *testing.T) {
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "change-me")
+
+	server := &Server{
+		authorizer:  fakeAuthorizer{},
+		identity:    &fakeIdentityStore{},
+		tmpl:        testTemplates(),
+		enforceAuth: true,
+		now:         func() time.Time { return time.Now().UTC() },
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/admin", nil)
+	rec := httptest.NewRecorder()
+	server.handleAdminRoot(rec, req)
+
+	if rec.Code == http.StatusSeeOther {
+		t.Fatalf("must not redirect unauthenticated user, status=%d location=%q", rec.Code, rec.Header().Get("Location"))
+	}
+}
+
+func TestMuxAdminRootRedirects(t *testing.T) {
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "change-me")
+
+	now := time.Now().UTC()
+	server := &Server{
+		authorizer:  fakeAuthorizer{},
+		identity:    &fakeIdentityStore{},
+		tmpl:        testTemplates(),
+		enforceAuth: true,
+		now:         func() time.Time { return now },
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/admin", nil)
+	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
+	rec := httptest.NewRecorder()
+	server.newMux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/admin/organizations" {
+		t.Fatalf("Location = %q, want /admin/organizations", loc)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd server && go test ./cmd/server -run 'TestHandleAdminRoot|TestMuxAdminRoot' -count=1`
+
+Expected: FAIL — `handleAdminRoot` undefined / mux 404
+
+- [ ] **Step 3: Implement handler + register**
+
+Create `server/cmd/server/admin_root.go`:
+
+```go
+package main
+
+import "net/http"
+
+func (s *Server) handleAdminRoot(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requirePlatformAdmin(w, r); !ok {
+		return
+	}
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	http.Redirect(w, r, adminPath("organizations"), http.StatusSeeOther)
+}
+```
+
+In `newMux()` near the other `/admin/…` registrations, add:
+
+```go
+mux.HandleFunc("/admin", s.handleAdminRoot)
+```
+
+Do **not** add `mux.HandleFunc("/admin/", …)` (subtree would shadow section routes).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd server && go test ./cmd/server -run 'TestHandleAdminRoot|TestMuxAdminRoot' -count=1`
+
+Expected: PASS
+
+Also smoke: `cd server && go test ./cmd/server -run 'TestHandleAdminCategories|TestHandleAdminOrgs' -count=1` — categories/orgs must still work (orgs still at old path until Task 4).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/cmd/server/admin_root.go server/cmd/server/admin_root_test.go server/cmd/server/main.go
+git commit -m "$(cat <<'EOF'
+feat(admin): redirect /admin to organizations console
+
+EOF
+)"
+```
+
+---
+
+### Task 4: Hard-cut rename `/admin/orgs` → `/admin/organizations`
+
+**Files:**
+- Modify: `server/cmd/server/main.go` — mux paths, `handleAdminOrgs` path trim prefix, `platformAdminPath`, `platformAdminView` ActivePanel/`buildPlatformAdminBreadcrumbs("organizations")`, `handlePlatformAdminLogo` path trim
+- Modify: `server/cmd/server/admin_console.go` — nav href `adminPath("organizations")`; Active `active == "organizations" || (active != "categories" && …)` prefer `active != "categories"` still OK if default panel is organizations
+- Modify: all Go tests that hit `/admin/orgs` (especially `admin_handler_identity_test.go`, `platform_admin_htmx_test.go`, `auth_session_handler_test.go`, `panel_markup_test.go`, `helpers_misc_coverage_test.go`, `auth_helpers_test.go`, `auth_bootstrap_test.go`, `auth_reset_handler_test.go`, `admin_console_test.go`)
+- Modify: `server/templates/pages/platform_admin.html` — every `/admin/orgs` → `/admin/organizations` (forms, HTMX, logo `src`, pagination)
+- Modify: `server/design/design.go` — OpenAPI HTTP paths for platform orgs methods
+
+**Interfaces:**
+- Consumes: `adminPath`
+- Produces: live console at `/admin/organizations` (+ logo); legacy `/admin/orgs*` → 404 via mux (no handler registered)
+
+- [ ] **Step 1: Write / update failing tests for the new path and hard cut**
+
+Append to `server/cmd/server/admin_root_test.go`:
+
+```go
+func TestLegacyAdminOrgsPathGone(t *testing.T) {
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "change-me")
+
+	now := time.Now().UTC()
+	server := &Server{
+		authorizer:  fakeAuthorizer{},
+		identity:    &fakeIdentityStore{},
+		tmpl:        testTemplates(),
+		enforceAuth: true,
+		now:         func() time.Time { return now },
+	}
+
+	for _, path := range []string{"/admin/orgs", "/admin/orgs/", "/admin/orgs/logo/x"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
+		rec := httptest.NewRecorder()
+		server.newMux().ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("%s status = %d, want 404", path, rec.Code)
+		}
+	}
+}
+
+func TestMuxAdminOrganizationsPathOK(t *testing.T) {
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "change-me")
+
+	now := time.Now().UTC()
+	server := &Server{
+		authorizer: fakeAuthorizer{},
+		identity: &fakeIdentityStore{
+			listOrganizationsFunc: func(ctx context.Context) ([]IdentityOrg, error) {
+				return nil, nil
+			},
+		},
+		tmpl:        testTemplates(),
+		enforceAuth: true,
+		now:         func() time.Time { return now },
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/organizations", nil)
+	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
+	rec := httptest.NewRecorder()
+	server.newMux().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}
+```
+
+Bulk-update existing tests: replace string `/admin/orgs` with `/admin/organizations` in request URLs and assertions. Keep the Go handler name `handleAdminOrgs` (URL rename only).
+
+Add `"context"` to the import block in `admin_root_test.go` for `TestMuxAdminOrganizationsPathOK`.
+
+- [ ] **Step 2: Run a focused subset to see failures**
+
+Run: `cd server && go test ./cmd/server -run 'TestLegacyAdminOrgs|TestAdminOrganizations|TestHandleAdminOrgs|TestPlatformAdmin|platformAdminPath' -count=1`
+
+Expected: FAIL until implementation
+
+- [ ] **Step 3: Implement rename**
+
+In `newMux()`:
+
+```go
+mux.HandleFunc("/admin", s.handleAdminRoot)
+mux.HandleFunc("/admin/organizations", s.handleAdminOrgs)
+mux.HandleFunc("/admin/organizations/", s.handleAdminOrgs)
+mux.HandleFunc("/admin/categories", s.handleAdminCategories)
+mux.HandleFunc("/admin/categories/", s.handleAdminCategoriesPath)
+// remove /admin/orgs registrations
+```
+
+In `handleAdminOrgs`, change prefix trim to `/admin/organizations`.
+
+In `handlePlatformAdminLogo`, trim `/admin/organizations/logo/`.
+
+Update `platformAdminPath`:
+
+```go
+func platformAdminPath(query string, page int) string {
+	// … build query …
+	base := adminPath("organizations")
+	if encoded != "" {
+		return base + "?" + encoded
+	}
+	return base
+}
+```
+
+In `platformAdminView`:
+
+```go
+ActivePanel: "organizations",
+Breadcrumbs: buildPlatformAdminBreadcrumbs("organizations"),
+```
+
+In `platformAdminConsole`:
+
+```go
+{
+	Href:   adminPath("organizations"),
+	Title:  "Organizations",
+	Copy:   "Create and manage organizations",
+	Active: active != "categories",
+},
+{
+	Href:   adminPath("categories"),
+	Title:  "Categories",
+	Copy:   "Manage stream discovery taxonomy",
+	Active: active == "categories",
+},
+```
+
+Templates: replace hardcoded `/admin/orgs` with `/admin/organizations` (or `{{/* keep literal paths matching adminPath */}}`).
+
+`design.go`: change GET/POST `/admin/orgs` → `/admin/organizations`, logo `/admin/organizations/logo/{logo_id}`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd server && go test ./cmd/server -count=1`
+
+Expected: PASS (fix any remaining `/admin/orgs` string assertions)
+
+Then regenerate OpenAPI:
+
+Run: `task goa:generate` (from repo/worktree root)
+
+Commit generated files if they change.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/cmd/server server/templates/pages/platform_admin.html server/design/design.go
+# include any goa gen output under server/gen if changed
+git commit -m "$(cat <<'EOF'
+feat(admin): rename /admin/orgs to /admin/organizations
+
+Hard-cut legacy orgs paths to 404; keep categories URLs unchanged.
+EOF
+)"
+```
+
+---
+
+### Task 5: Topbar **Admin** link + docs
+
+**Files:**
+- Modify: `server/templates/layout.html` — label/href
+- Modify: `server/cmd/server/main.go` — rename `ShowOrgsLink` → `ShowAdminLink` on `PageBase` and assignment site (~1433)
+- Modify: `server/cmd/server/test_helpers_test.go` — stub layout marker `Admin` instead of `Orgs`
+- Modify: any tests asserting `ShowOrgsLink` / `href="/admin/orgs"` / visible `Orgs` (e.g. `auth_session_handler_test.go`)
+- Modify: `AGENTS.md` — platform admin routes and topbar bullet
+
+**Interfaces:**
+- Consumes: `adminPath("")` → `/admin`
+- Produces: account menu item visible when `ShowAdminLink`; text `Admin`; `href="/admin"`
+
+- [ ] **Step 1: Write / update failing assertion**
+
+In the session/layout test that currently forbids or expects `href="/admin/orgs"`, assert:
+
+```go
+if !strings.Contains(body, `href="/admin"`) || !strings.Contains(body, "Admin") {
+	t.Fatalf("expected Admin link to /admin, got:\n%s", body)
+}
+if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, ">Orgs<") {
+	t.Fatalf("legacy Orgs link still present")
+}
+```
+
+Update `test_helpers_test.go` stub:
+
+```go
+{{if .ShowAdminLink}} Admin{{end}}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd server && go test ./cmd/server -run 'ShowOrgs|ShowAdmin|Orgs|Login|Session' -count=1`
+
+Expected: FAIL on renamed field / old copy
+
+- [ ] **Step 3: Implement**
+
+`layout.html`:
+
+```html
+{{ if .ShowAdminLink }}
+  <a href="/admin" class="account-menu-item">
+    …
+    Admin
+  </a>
+{{ end }}
+```
+
+Rename struct field and all references `ShowOrgsLink` → `ShowAdminLink`.
+
+Update `AGENTS.md` bullets:
+
+- Platform admin: `/admin` (redirects to `/admin/organizations`); sections `/admin/organizations`, `/admin/categories`; logo `/admin/organizations/logo/:id`
+- Topbar: platform admin sees `Admin` (`/admin`)
+- Remove legacy `/admin/orgs` citations
+
+- [ ] **Step 4: Full package test**
+
+Run: `cd server && go test ./cmd/server -count=1`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/templates/layout.html server/cmd/server/main.go server/cmd/server/test_helpers_test.go server/cmd/server/*_test.go AGENTS.md
+git commit -m "$(cat <<'EOF'
+feat(admin): topbar Admin entry points at /admin
+
+EOF
+)"
+```
+
+---
+
+### Task 6: Final sweep + verification
+
+**Files:**
+- Any remaining `/admin/orgs` hits under the worktree (docs plans/specs historical mentions may stay; **code + AGENTS.md + live design** must be clean)
+
+- [ ] **Step 1: Search for leftovers**
+
+Run:
+
+```bash
+rg '/admin/orgs|ShowOrgsLink|ActivePanel:.*"orgs"|buildPlatformAdminBreadcrumbs\("orgs"\)' \
+  server AGENTS.md README.md QUICKSTART.md DOCKER.md \
+  --glob '!docs/superpowers/**'
+```
+
+Expected: no matches in live code/docs (historical specs/plans under `docs/superpowers/` may still mention old paths — leave them).
+
+- [ ] **Step 2: Manual checklist (against `task dev` in this worktree)**
+
+1. Platform admin login → account menu shows **Admin** → lands on organizations console via `/admin` redirect  
+2. Breadcrumbs on organizations: Dashboard → Platform admin → Organizations  
+3. Soft-nav to Categories → breadcrumbs end with Categories; Platform admin crumb goes to `/admin`  
+4. `/admin/orgs` → 404  
+5. Org logo still loads from `/admin/organizations/logo/…`  
+6. Org search/pagination HTMX still targets `#platform-admin-results`
+
+- [ ] **Step 3: Commit only if sweep produced fixes**
+
+If `git status` is clean, skip. Otherwise:
+
+```bash
+git add -u
+git commit -m "$(cat <<'EOF'
+chore(admin): finish platform admin routing path sweep
+
+EOF
+)"
+```
+
+---
+
+## Spec coverage (self-check)
+
+| Spec requirement | Task |
+|------------------|------|
+| `/admin` → redirect to organizations | 3 |
+| `/admin/` behaves as entry (via ServeMux or exact handler) | 3 |
+| `/admin/organizations` (+ logo) | 4 |
+| Categories unchanged | 4 (no URL change) |
+| Hard-cut `/admin/orgs*` 404 | 4 |
+| `adminPath` helper | 1 |
+| Three-crumb breadcrumbs; middle → `/admin` | 2 |
+| ActivePanel `organizations` \| `categories` | 4 |
+| Topbar Admin → `/admin` | 5 |
+| AGENTS.md / OpenAPI design update | 4–5 |
+| Tests for redirect, 404, breadcrumbs, paths | 1–5 |
+| No landing page / no unified mux / no categories rename | honored (out of scope) |

--- a/docs/superpowers/specs/2026-07-31-platform-admin-routing-design.md
+++ b/docs/superpowers/specs/2026-07-31-platform-admin-routing-design.md
@@ -1,0 +1,93 @@
+# Platform admin routing rewire
+
+Date: 2026-07-31  
+Scope: `/admin` entry redirect, rename `/admin/orgs` → `/admin/organizations` (hard cut), platform-admin breadcrumbs, topbar account-menu label/href, `adminPath` helpers, hardcoded path sweep (templates/handlers/tests/docs)  
+Out of scope: New admin landing page, last-visited section memory, unified `/admin` mux refactor (org-admin-style router), Categories URL changes, visual redesign beyond labels/crumbs/links
+
+## Goal
+
+Make platform admin navigation coherent now that the console has multiple sections (Organizations and Categories): `/admin` must work as an entry point, section URLs and labels must say “organizations”, breadcrumbs must match the org-admin pattern, and the topbar must point at the console root instead of a single section.
+
+## Decisions
+
+1. **Approach:** Minimal surface fix — keep flat mux registration; add root redirect + rename + breadcrumb/topbar fixes + path helpers.
+2. **`/admin` and `/admin/`:** Auth-gated redirect to `/admin/organizations` (default section). Same platform-admin gate as today’s console.
+3. **Section URLs:** Keep separate section paths. Rename orgs: `/admin/organizations` (and `/admin/organizations/logo/:id`). Categories stay at `/admin/categories` (+ nested subcategory POSTs).
+4. **Hard cut:** `/admin/orgs` and `/admin/orgs/…` return **404**. No compatibility redirect.
+5. **Path helpers:** Add `adminPath(rest string)` in `paths.go` (mirror `organizationPath`). Use it for console nav, redirects, HTMX URLs, logo paths, and list/pagination helpers instead of hardcoded `/admin/…` strings.
+6. **Topbar:** Platform-admin account-menu item label **Admin**, href `/admin`.
+7. **Breadcrumbs:** Always three crumbs, mirroring org admin:
+   - `Dashboard` → `/my`
+   - `Platform admin` → `/admin` (not current; not tied to a section URL)
+   - Current section → `Organizations` or `Categories` with that section’s URL, `Current: true`
+8. **ActivePanel keys:** `organizations` | `categories` (replace today’s `orgs` default).
+9. **Page chrome:** Title remains “Platform admin dashboard”; subtitle continues to follow the active section.
+
+## Routes
+
+| Path | Behavior |
+|------|----------|
+| `GET /admin`, `GET /admin/` | Platform-admin gate → redirect to `/admin/organizations` |
+| `/admin/organizations` (+ trailing slash) | Organizations console (today’s orgs handlers under the new path) |
+| `/admin/organizations/logo/:id` | Organization logo asset |
+| `/admin/categories` (+ nested paths) | Unchanged |
+| `/admin/orgs`, `/admin/orgs/…` | **404** |
+
+## Navigation
+
+### Topbar / account menu
+
+| Before | After |
+|--------|-------|
+| Label **Orgs**, href `/admin/orgs` | Label **Admin**, href `/admin` |
+
+### Sidebar soft-nav
+
+Unchanged structure:
+
+| Title | Href |
+|-------|------|
+| Organizations | `/admin/organizations` |
+| Categories | `/admin/categories` |
+
+### Breadcrumbs
+
+| Section | Trail |
+|---------|--------|
+| Organizations | `Dashboard` → `Platform admin` → `Organizations` (current) |
+| Categories | `Dashboard` → `Platform admin` → `Categories` (current) |
+
+Middle crumb always links to `/admin` (which redirects to the default section).
+
+## Auth & errors
+
+- `/admin` uses the same Cerbos / `requirePlatformAdmin` (or equivalent) gate as existing `/admin/organizations` and `/admin/categories`.
+- Unauthenticated access follows today’s login redirect behavior for the console.
+- Legacy `/admin/orgs*` → plain 404 (no soft redirect).
+
+## Implementation touchpoints
+
+- `server/cmd/server/main.go` — mux registration; rename orgs path prefixes; `/admin` redirect handler.
+- `server/cmd/server/paths.go` — `adminPath`.
+- `server/cmd/server/breadcrumbs.go` (+ tests) — always 3 crumbs; section labels/hrefs via helpers.
+- `server/cmd/server/admin_console.go` — nav hrefs; ActivePanel `organizations`.
+- Templates: `platform_admin.html`, `layout.html` (topbar), any hardcoded `/admin/orgs`.
+- Helpers such as `platformAdminPath` (list/search pagination) → organizations path.
+- Docs: `AGENTS.md` and any specs/README cites of `/admin/orgs`.
+
+## Testing
+
+- `/admin` and `/admin/` redirect to `/admin/organizations` for an authorized platform admin.
+- `/admin/orgs` and `/admin/orgs/logo/…` return 404.
+- Organizations console and logo still work under `/admin/organizations`.
+- Categories routes unchanged.
+- `buildPlatformAdminBreadcrumbs` covers both sections with the three-crumb shape.
+- Template/HTMX/path tests updated for the new URLs and topbar label where covered.
+
+## Out of scope (explicit)
+
+- No dedicated `/admin` landing page body.
+- No cookie/session “last section” memory.
+- No `handleAdminRoutes` unified dispatcher (can revisit when a third section lands).
+- No Categories URL rename.
+- No visual redesign of the admin console beyond labels, crumbs, and links.

--- a/server/cmd/server/admin_console.go
+++ b/server/cmd/server/admin_console.go
@@ -34,7 +34,7 @@ func platformAdminConsole(view PlatformAdminView) AdminConsoleView {
 		Breadcrumbs: view.Breadcrumbs,
 		NavItems: []AdminConsoleNavItem{
 			{
-				Href:   "/admin/orgs",
+				Href:   adminPath("organizations"),
 				Title:  "Organizations",
 				Copy:   "Create and manage organizations",
 				Active: active != "categories",

--- a/server/cmd/server/admin_console.go
+++ b/server/cmd/server/admin_console.go
@@ -40,7 +40,7 @@ func platformAdminConsole(view PlatformAdminView) AdminConsoleView {
 				Active: active != "categories",
 			},
 			{
-				Href:   "/admin/categories",
+				Href:   adminPath("categories"),
 				Title:  "Categories",
 				Copy:   "Manage stream discovery taxonomy",
 				Active: active == "categories",

--- a/server/cmd/server/admin_console_test.go
+++ b/server/cmd/server/admin_console_test.go
@@ -9,12 +9,12 @@ import (
 func TestWantsAdminConsolePartial(t *testing.T) {
 	t.Parallel()
 
-	full := httptest.NewRequest(http.MethodGet, "/admin/orgs", nil)
+	full := httptest.NewRequest(http.MethodGet, "/admin/organizations", nil)
 	if wantsAdminConsolePartial(full) {
 		t.Fatal("non-HTMX must be false")
 	}
 
-	results := httptest.NewRequest(http.MethodGet, "/admin/orgs?q=a", nil)
+	results := httptest.NewRequest(http.MethodGet, "/admin/organizations?q=a", nil)
 	results.Header.Set("HX-Request", "true")
 	results.Header.Set("HX-Target", "platform-admin-results")
 	if wantsAdminConsolePartial(results) {

--- a/server/cmd/server/admin_handler_identity_test.go
+++ b/server/cmd/server/admin_handler_identity_test.go
@@ -156,8 +156,8 @@ func TestPlatformOrganizationsAndRenderPlatformAdmin(t *testing.T) {
 			now:         func() time.Time { return now },
 		}
 		rec := httptest.NewRecorder()
-		server.renderPlatformAdmin(rec, httptest.NewRequest(http.MethodGet, "/admin/orgs", nil), &AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "invite sent", PlatformAdminErrors{})
-		if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "PLATFORM_ADMIN orgs 1 invite sent") {
+		server.renderPlatformAdmin(rec, httptest.NewRequest(http.MethodGet, "/admin/organizations", nil), &AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "invite sent", PlatformAdminErrors{})
+		if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "PLATFORM_ADMIN organizations 1 invite sent") {
 			t.Fatalf("status=%d body=%q", rec.Code, rec.Body.String())
 		}
 	})
@@ -239,7 +239,7 @@ func TestPlatformOrganizationsAndRenderPlatformAdmin(t *testing.T) {
 		if len(filtered) != 1 || filtered[0].Slug != "acme" {
 			t.Fatalf("filtered = %#v", filtered)
 		}
-		if got := platformAdminPath("acme", 2); got != "/admin/orgs?page=2&q=acme" && got != "/admin/orgs?q=acme&page=2" {
+		if got := platformAdminPath("acme", 2); got != "/admin/organizations?page=2&q=acme" && got != "/admin/organizations?q=acme&page=2" {
 			t.Fatalf("platformAdminPath = %q", got)
 		}
 	})
@@ -257,7 +257,7 @@ func TestHandlePlatformAdminLogoAdditionalBranches(t *testing.T) {
 			enforceAuth: true,
 			now:         func() time.Time { return now },
 		}
-		req := httptest.NewRequest(http.MethodPost, "/admin/orgs/logo/logo-1", nil)
+		req := httptest.NewRequest(http.MethodPost, "/admin/organizations/logo/logo-1", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
 
@@ -275,7 +275,7 @@ func TestHandlePlatformAdminLogoAdditionalBranches(t *testing.T) {
 			enforceAuth: true,
 			now:         func() time.Time { return now },
 		}
-		req := httptest.NewRequest(http.MethodGet, "/admin/orgs/logo/", nil)
+		req := httptest.NewRequest(http.MethodGet, "/admin/organizations/logo/", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
 
@@ -297,7 +297,7 @@ func TestHandlePlatformAdminLogoAdditionalBranches(t *testing.T) {
 			enforceAuth: true,
 			now:         func() time.Time { return now },
 		}
-		req := httptest.NewRequest(http.MethodGet, "/admin/orgs/logo/logo-1", nil)
+		req := httptest.NewRequest(http.MethodGet, "/admin/organizations/logo/logo-1", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
 
@@ -319,7 +319,7 @@ func TestHandlePlatformAdminLogoAdditionalBranches(t *testing.T) {
 			enforceAuth: true,
 			now:         func() time.Time { return now },
 		}
-		req := httptest.NewRequest(http.MethodGet, "/admin/orgs/logo/logo-1", nil)
+		req := httptest.NewRequest(http.MethodGet, "/admin/organizations/logo/logo-1", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
 
@@ -346,7 +346,7 @@ func TestHandlePlatformAdminLogoAdditionalBranches(t *testing.T) {
 			enforceAuth: true,
 			now:         func() time.Time { return now },
 		}
-		req := httptest.NewRequest(http.MethodGet, "/admin/orgs/logo/logo-1", nil)
+		req := httptest.NewRequest(http.MethodGet, "/admin/organizations/logo/logo-1", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-member"})
 		rec := httptest.NewRecorder()
 
@@ -574,7 +574,7 @@ func TestHandleAdminOrgsCreateOrganizationWithPlatformAdmin(t *testing.T) {
 		now:         func() time.Time { return now },
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/admin/orgs", strings.NewReader("name=Fresh+Org"))
+	req := httptest.NewRequest(http.MethodPost, "/admin/organizations", strings.NewReader("name=Fresh+Org"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 	rec := httptest.NewRecorder()
@@ -584,7 +584,7 @@ func TestHandleAdminOrgsCreateOrganizationWithPlatformAdmin(t *testing.T) {
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 	}
-	if location := rec.Header().Get("Location"); !strings.Contains(location, "/admin/orgs") || !strings.Contains(location, "confirmation=organization+created") {
+	if location := rec.Header().Get("Location"); !strings.Contains(location, "/admin/organizations") || !strings.Contains(location, "confirmation=organization+created") {
 		t.Fatalf("location = %q", location)
 	}
 	if createName != "Fresh Org" {
@@ -642,7 +642,7 @@ func TestHandleAdminOrgsCreateOrganizationWithOptionalOrgAdminInvite(t *testing.
 		now:         func() time.Time { return now },
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "http://attesta.local/admin/orgs", strings.NewReader("name=Fresh+Org&invite_email=owner%40example.com"))
+	req := httptest.NewRequest(http.MethodPost, "http://attesta.local/admin/organizations", strings.NewReader("name=Fresh+Org&invite_email=owner%40example.com"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 	rec := httptest.NewRecorder()
@@ -655,7 +655,7 @@ func TestHandleAdminOrgsCreateOrganizationWithOptionalOrgAdminInvite(t *testing.
 	if inviteEmail != "owner@example.com" || inviteSessionSecret != "platform-session" {
 		t.Fatalf("inviteEmail=%q inviteSessionSecret=%q", inviteEmail, inviteSessionSecret)
 	}
-	if location := rec.Header().Get("Location"); !strings.Contains(location, "/admin/orgs") || !strings.Contains(location, "confirmation=organization+created+and+invite+sent") {
+	if location := rec.Header().Get("Location"); !strings.Contains(location, "/admin/organizations") || !strings.Contains(location, "confirmation=organization+created+and+invite+sent") {
 		t.Fatalf("location = %q", location)
 	}
 }
@@ -684,7 +684,7 @@ func TestHandleAdminOrgsPlatformAdminHTMXGetAndLogo(t *testing.T) {
 	}
 
 	t.Run("htmx get renders partial", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/admin/orgs?q=acme", nil)
+		req := httptest.NewRequest(http.MethodGet, "/admin/organizations?q=acme", nil)
 		req.Header.Set("HX-Request", "true")
 		req.Header.Set("HX-Target", "platform-admin-results")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
@@ -701,7 +701,7 @@ func TestHandleAdminOrgsPlatformAdminHTMXGetAndLogo(t *testing.T) {
 	})
 
 	t.Run("logo handler streams file", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/admin/orgs/logo/logo-1", nil)
+		req := httptest.NewRequest(http.MethodGet, "/admin/organizations/logo/logo-1", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
 
@@ -760,7 +760,7 @@ func TestHandleAdminOrgsUpdateAndDeleteOrganizationWithPlatformAdmin(t *testing.
 		form.Set("intent", "set_org")
 		form.Set("org_slug", "acme")
 		form.Set("name", "Acme Updated")
-		req := httptest.NewRequest(http.MethodPost, "/admin/orgs", strings.NewReader(form.Encode()))
+		req := httptest.NewRequest(http.MethodPost, "/admin/organizations", strings.NewReader(form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
@@ -806,7 +806,7 @@ func TestHandleAdminOrgsUpdateAndDeleteOrganizationWithPlatformAdmin(t *testing.
 		form := url.Values{}
 		form.Set("intent", "delete_org")
 		form.Set("org_slug", "acme")
-		req := httptest.NewRequest(http.MethodPost, "/admin/orgs", strings.NewReader(form.Encode()))
+		req := httptest.NewRequest(http.MethodPost, "/admin/organizations", strings.NewReader(form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
@@ -843,7 +843,7 @@ func TestHandleAdminOrgsGetAndValidationErrors(t *testing.T) {
 			enforceAuth: true,
 			now:         func() time.Time { return now },
 		}
-		req := httptest.NewRequest(http.MethodGet, "/admin/orgs", nil)
+		req := httptest.NewRequest(http.MethodGet, "/admin/organizations", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
 
@@ -852,7 +852,7 @@ func TestHandleAdminOrgsGetAndValidationErrors(t *testing.T) {
 		if rec.Code != http.StatusOK {
 			t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 		}
-		if !strings.Contains(rec.Body.String(), "PLATFORM_ADMIN orgs 1") {
+		if !strings.Contains(rec.Body.String(), "PLATFORM_ADMIN organizations 1") {
 			t.Fatalf("body = %q", rec.Body.String())
 		}
 	})
@@ -860,7 +860,7 @@ func TestHandleAdminOrgsGetAndValidationErrors(t *testing.T) {
 	t.Run("identity unavailable", func(t *testing.T) {
 		server := &Server{
 			authorizer: fakeAuthorizer{}, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodGet, "/admin/orgs", nil)
+		req := httptest.NewRequest(http.MethodGet, "/admin/organizations", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
 
@@ -874,7 +874,7 @@ func TestHandleAdminOrgsGetAndValidationErrors(t *testing.T) {
 	t.Run("invalid subpath", func(t *testing.T) {
 		server := &Server{
 			authorizer: fakeAuthorizer{}, identity: &fakeIdentityStore{}, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodGet, "/admin/orgs/unknown", nil)
+		req := httptest.NewRequest(http.MethodGet, "/admin/organizations/unknown", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
 
@@ -888,7 +888,7 @@ func TestHandleAdminOrgsGetAndValidationErrors(t *testing.T) {
 	t.Run("missing organization name", func(t *testing.T) {
 		server := &Server{
 			authorizer: fakeAuthorizer{}, identity: &fakeIdentityStore{}, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPost, "/admin/orgs", strings.NewReader(""))
+		req := httptest.NewRequest(http.MethodPost, "/admin/organizations", strings.NewReader(""))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
@@ -913,7 +913,7 @@ func TestHandleAdminOrgsGetAndValidationErrors(t *testing.T) {
 			enforceAuth: true,
 			now:         func() time.Time { return now },
 		}
-		req := httptest.NewRequest(http.MethodPost, "/admin/orgs", strings.NewReader("name=Fresh+Org"))
+		req := httptest.NewRequest(http.MethodPost, "/admin/organizations", strings.NewReader("name=Fresh+Org"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
@@ -928,7 +928,7 @@ func TestHandleAdminOrgsGetAndValidationErrors(t *testing.T) {
 	t.Run("method not allowed", func(t *testing.T) {
 		server := &Server{
 			authorizer: fakeAuthorizer{}, identity: &fakeIdentityStore{}, tmpl: testTemplates(), enforceAuth: true, now: func() time.Time { return now }}
-		req := httptest.NewRequest(http.MethodPut, "/admin/orgs", nil)
+		req := httptest.NewRequest(http.MethodPut, "/admin/organizations", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
 
@@ -954,7 +954,7 @@ func TestHandleAdminOrgsGetAndValidationErrors(t *testing.T) {
 			enforceAuth: true,
 			now:         func() time.Time { return now },
 		}
-		req := httptest.NewRequest(http.MethodPost, "/admin/orgs", strings.NewReader("name=Fresh+Org"))
+		req := httptest.NewRequest(http.MethodPost, "/admin/organizations", strings.NewReader("name=Fresh+Org"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
@@ -1033,7 +1033,7 @@ func TestHandleAdminOrgsInviteOrgAdminWithPlatformAdmin(t *testing.T) {
 	form.Set("intent", "invite_org_admin")
 	form.Set("org_slug", "acme")
 	form.Set("email", "owner@example.com")
-	req := httptest.NewRequest(http.MethodPost, "http://attesta.local/admin/orgs", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "http://attesta.local/admin/organizations", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 	rec := httptest.NewRecorder()
@@ -1052,7 +1052,7 @@ func TestHandleAdminOrgsInviteOrgAdminWithPlatformAdmin(t *testing.T) {
 	if inviteRedirect != "http://attesta.local/invite/accept" {
 		t.Fatalf("invite redirect = %q", inviteRedirect)
 	}
-	if !strings.Contains(rec.Body.String(), "PLATFORM_ADMIN orgs 1 invite sent") {
+	if !strings.Contains(rec.Body.String(), "PLATFORM_ADMIN organizations 1 invite sent") {
 		t.Fatalf("body = %q", rec.Body.String())
 	}
 }
@@ -1115,7 +1115,7 @@ func TestHandleAdminOrgsInviteOrgAdminSendsInviteForUnknownEmail(t *testing.T) {
 	form.Set("intent", "invite_org_admin")
 	form.Set("org_slug", "acme")
 	form.Set("email", "new-owner@example.com")
-	req := httptest.NewRequest(http.MethodPost, "http://attesta.local/admin/orgs", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "http://attesta.local/admin/organizations", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 	rec := httptest.NewRecorder()
@@ -1131,7 +1131,7 @@ func TestHandleAdminOrgsInviteOrgAdminSendsInviteForUnknownEmail(t *testing.T) {
 	if inviteRedirect != "http://attesta.local/invite/accept" || deletedSecret != "platform-session" {
 		t.Fatalf("redirect=%q deleted=%q", inviteRedirect, deletedSecret)
 	}
-	if !strings.Contains(rec.Body.String(), "PLATFORM_ADMIN orgs 1 invite sent") {
+	if !strings.Contains(rec.Body.String(), "PLATFORM_ADMIN organizations 1 invite sent") {
 		t.Fatalf("body = %q", rec.Body.String())
 	}
 }
@@ -1187,7 +1187,7 @@ func TestHandleAdminOrgsInviteOrgAdminUpdatesExistingMembershipOnly(t *testing.T
 	form.Set("intent", "invite_org_admin")
 	form.Set("org_slug", "acme")
 	form.Set("email", "member@example.com")
-	req := httptest.NewRequest(http.MethodPost, "http://attesta.local/admin/orgs", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest(http.MethodPost, "http://attesta.local/admin/organizations", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 	rec := httptest.NewRecorder()
@@ -1203,7 +1203,7 @@ func TestHandleAdminOrgsInviteOrgAdminUpdatesExistingMembershipOnly(t *testing.T
 	if loginEmail != "admin@example.com" || deletedSecret != "platform-session" {
 		t.Fatalf("login=%q deleted=%q", loginEmail, deletedSecret)
 	}
-	if !strings.Contains(rec.Body.String(), "PLATFORM_ADMIN orgs 1 org admin access updated") {
+	if !strings.Contains(rec.Body.String(), "PLATFORM_ADMIN organizations 1 org admin access updated") {
 		t.Fatalf("body = %q", rec.Body.String())
 	}
 }
@@ -1244,7 +1244,7 @@ func TestHandleAdminOrgsInviteOrgAdminErrors(t *testing.T) {
 		form.Set("intent", "invite_org_admin")
 		form.Set("org_slug", "acme")
 		form.Set("email", "member@example.com")
-		req := httptest.NewRequest(http.MethodPost, "http://attesta.local/admin/orgs", strings.NewReader(form.Encode()))
+		req := httptest.NewRequest(http.MethodPost, "http://attesta.local/admin/organizations", strings.NewReader(form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
@@ -1286,7 +1286,7 @@ func TestHandleAdminOrgsInviteOrgAdminErrors(t *testing.T) {
 		form.Set("intent", "invite_org_admin")
 		form.Set("org_slug", "acme")
 		form.Set("email", "owner@example.com")
-		req := httptest.NewRequest(http.MethodPost, "http://attesta.local/admin/orgs", strings.NewReader(form.Encode()))
+		req := httptest.NewRequest(http.MethodPost, "http://attesta.local/admin/organizations", strings.NewReader(form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
@@ -1304,7 +1304,7 @@ func TestHandleAdminOrgsInviteOrgAdminErrors(t *testing.T) {
 		form := url.Values{}
 		form.Set("intent", "invite_org_admin")
 		form.Set("org_slug", "acme")
-		req := httptest.NewRequest(http.MethodPost, "/admin/orgs", strings.NewReader(form.Encode()))
+		req := httptest.NewRequest(http.MethodPost, "/admin/organizations", strings.NewReader(form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
@@ -1322,7 +1322,7 @@ func TestHandleAdminOrgsInviteOrgAdminErrors(t *testing.T) {
 		form := url.Values{}
 		form.Set("intent", "invite_org_admin")
 		form.Set("email", "owner@example.com")
-		req := httptest.NewRequest(http.MethodPost, "/admin/orgs", strings.NewReader(form.Encode()))
+		req := httptest.NewRequest(http.MethodPost, "/admin/organizations", strings.NewReader(form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
@@ -1350,7 +1350,7 @@ func TestHandleAdminOrgsInviteOrgAdminErrors(t *testing.T) {
 		form.Set("intent", "invite_org_admin")
 		form.Set("org_slug", "acme")
 		form.Set("email", "owner@example.com")
-		req := httptest.NewRequest(http.MethodPost, "/admin/orgs", strings.NewReader(form.Encode()))
+		req := httptest.NewRequest(http.MethodPost, "/admin/organizations", strings.NewReader(form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
@@ -1382,7 +1382,7 @@ func TestHandleAdminOrgsInviteOrgAdminErrors(t *testing.T) {
 		form.Set("intent", "invite_org_admin")
 		form.Set("org_slug", "acme")
 		form.Set("email", "owner@example.com")
-		req := httptest.NewRequest(http.MethodPost, "/admin/orgs", strings.NewReader(form.Encode()))
+		req := httptest.NewRequest(http.MethodPost, "/admin/organizations", strings.NewReader(form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
@@ -1424,7 +1424,7 @@ func TestHandleAdminOrgsInviteOrgAdminErrors(t *testing.T) {
 		form.Set("intent", "invite_org_admin")
 		form.Set("org_slug", "acme")
 		form.Set("email", "owner@example.com")
-		req := httptest.NewRequest(http.MethodPost, "http://attesta.local/admin/orgs", strings.NewReader(form.Encode()))
+		req := httptest.NewRequest(http.MethodPost, "http://attesta.local/admin/organizations", strings.NewReader(form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
@@ -1469,7 +1469,7 @@ func TestHandleAdminOrgsInviteOrgAdminErrors(t *testing.T) {
 		form.Set("intent", "invite_org_admin")
 		form.Set("org_slug", "acme")
 		form.Set("email", "owner@example.com")
-		req := httptest.NewRequest(http.MethodPost, "http://attesta.local/admin/orgs", strings.NewReader(form.Encode()))
+		req := httptest.NewRequest(http.MethodPost, "http://attesta.local/admin/organizations", strings.NewReader(form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
@@ -1536,7 +1536,7 @@ func TestHandleAdminOrgsCreateOrganizationWithLogo(t *testing.T) {
 		t.Fatalf("writer.Close error: %v", err)
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/admin/orgs", strings.NewReader(body.String()))
+	req := httptest.NewRequest(http.MethodPost, "/admin/organizations", strings.NewReader(body.String()))
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 	rec := httptest.NewRecorder()
@@ -1584,7 +1584,7 @@ func TestHandleAdminOrgsCreateOrganizationErrors(t *testing.T) {
 		if err := writer.Close(); err != nil {
 			t.Fatalf("writer.Close error: %v", err)
 		}
-		req := httptest.NewRequest(http.MethodPost, "/admin/orgs", strings.NewReader(body.String()))
+		req := httptest.NewRequest(http.MethodPost, "/admin/organizations", strings.NewReader(body.String()))
 		req.Header.Set("Content-Type", writer.FormDataContentType())
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
@@ -1615,7 +1615,7 @@ func TestHandleAdminOrgsCreateOrganizationErrors(t *testing.T) {
 			enforceAuth: true,
 			now:         func() time.Time { return now },
 		}
-		req := httptest.NewRequest(http.MethodPost, "/admin/orgs", strings.NewReader("name=Fresh+Org"))
+		req := httptest.NewRequest(http.MethodPost, "/admin/organizations", strings.NewReader("name=Fresh+Org"))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
@@ -1665,7 +1665,7 @@ func TestHandleAdminOrgsCreateOrganizationErrors(t *testing.T) {
 		if err := writer.Close(); err != nil {
 			t.Fatalf("writer.Close error: %v", err)
 		}
-		req := httptest.NewRequest(http.MethodPost, "/admin/orgs", strings.NewReader(body.String()))
+		req := httptest.NewRequest(http.MethodPost, "/admin/organizations", strings.NewReader(body.String()))
 		req.Header.Set("Content-Type", writer.FormDataContentType())
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
@@ -1718,7 +1718,7 @@ func TestHandleAdminOrgsCreateOrganizationErrors(t *testing.T) {
 		if err := writer.Close(); err != nil {
 			t.Fatalf("writer.Close error: %v", err)
 		}
-		req := httptest.NewRequest(http.MethodPost, "/admin/orgs", strings.NewReader(body.String()))
+		req := httptest.NewRequest(http.MethodPost, "/admin/organizations", strings.NewReader(body.String()))
 		req.Header.Set("Content-Type", writer.FormDataContentType())
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()

--- a/server/cmd/server/admin_root.go
+++ b/server/cmd/server/admin_root.go
@@ -1,0 +1,14 @@
+package main
+
+import "net/http"
+
+func (s *Server) handleAdminRoot(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requirePlatformAdmin(w, r); !ok {
+		return
+	}
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	http.Redirect(w, r, adminPath("organizations"), http.StatusSeeOther)
+}

--- a/server/cmd/server/admin_root_test.go
+++ b/server/cmd/server/admin_root_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHandleAdminRootRedirectsToOrganizations(t *testing.T) {
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "change-me")
+
+	now := time.Now().UTC()
+	server := &Server{
+		authorizer:  fakeAuthorizer{},
+		identity:    &fakeIdentityStore{},
+		tmpl:        testTemplates(),
+		enforceAuth: true,
+		now:         func() time.Time { return now },
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/admin", nil)
+	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
+	rec := httptest.NewRecorder()
+	server.handleAdminRoot(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if loc := rec.Header().Get("Location"); loc != adminPath("organizations") {
+		t.Fatalf("Location = %q, want %q", loc, adminPath("organizations"))
+	}
+}
+
+func TestHandleAdminRootRejectsUnauthenticated(t *testing.T) {
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "change-me")
+
+	server := &Server{
+		authorizer:  fakeAuthorizer{},
+		identity:    &fakeIdentityStore{},
+		tmpl:        testTemplates(),
+		enforceAuth: true,
+		now:         func() time.Time { return time.Now().UTC() },
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/admin", nil)
+	rec := httptest.NewRecorder()
+	server.handleAdminRoot(rec, req)
+
+	if loc := rec.Header().Get("Location"); loc == adminPath("organizations") {
+		t.Fatalf("must not redirect unauthenticated user to organizations, status=%d location=%q", rec.Code, loc)
+	}
+}
+
+func TestMuxAdminRootRedirects(t *testing.T) {
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "change-me")
+
+	now := time.Now().UTC()
+	server := &Server{
+		authorizer:  fakeAuthorizer{},
+		identity:    &fakeIdentityStore{},
+		tmpl:        testTemplates(),
+		enforceAuth: true,
+		now:         func() time.Time { return now },
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/admin", nil)
+	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
+	rec := httptest.NewRecorder()
+	server.newMux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/admin/organizations" {
+		t.Fatalf("Location = %q, want /admin/organizations", loc)
+	}
+}

--- a/server/cmd/server/admin_root_test.go
+++ b/server/cmd/server/admin_root_test.go
@@ -79,3 +79,29 @@ func TestMuxAdminRootRedirects(t *testing.T) {
 		t.Fatalf("Location = %q, want /admin/organizations", loc)
 	}
 }
+
+func TestMuxAdminRootTrailingSlashRedirects(t *testing.T) {
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "change-me")
+
+	now := time.Now().UTC()
+	server := &Server{
+		authorizer:  fakeAuthorizer{},
+		identity:    &fakeIdentityStore{},
+		tmpl:        testTemplates(),
+		enforceAuth: true,
+		now:         func() time.Time { return now },
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/", nil)
+	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
+	rec := httptest.NewRecorder()
+	server.newMux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/admin/organizations" {
+		t.Fatalf("Location = %q, want /admin/organizations", loc)
+	}
+}

--- a/server/cmd/server/admin_root_test.go
+++ b/server/cmd/server/admin_root_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -103,5 +104,55 @@ func TestMuxAdminRootTrailingSlashRedirects(t *testing.T) {
 	}
 	if loc := rec.Header().Get("Location"); loc != "/admin/organizations" {
 		t.Fatalf("Location = %q, want /admin/organizations", loc)
+	}
+}
+
+func TestLegacyAdminOrgsPathGone(t *testing.T) {
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "change-me")
+
+	now := time.Now().UTC()
+	server := &Server{
+		authorizer:  fakeAuthorizer{},
+		identity:    &fakeIdentityStore{},
+		tmpl:        testTemplates(),
+		enforceAuth: true,
+		now:         func() time.Time { return now },
+	}
+
+	for _, path := range []string{"/admin/orgs", "/admin/orgs/", "/admin/orgs/logo/x"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
+		rec := httptest.NewRecorder()
+		server.newMux().ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("%s status = %d, want 404", path, rec.Code)
+		}
+	}
+}
+
+func TestMuxAdminOrganizationsPathOK(t *testing.T) {
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "change-me")
+
+	now := time.Now().UTC()
+	server := &Server{
+		authorizer: fakeAuthorizer{},
+		identity: &fakeIdentityStore{
+			listOrganizationsFunc: func(ctx context.Context) ([]IdentityOrg, error) {
+				return nil, nil
+			},
+		},
+		tmpl:        testTemplates(),
+		enforceAuth: true,
+		now:         func() time.Time { return now },
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/organizations", nil)
+	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
+	rec := httptest.NewRecorder()
+	server.newMux().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%q", rec.Code, http.StatusOK, rec.Body.String())
 	}
 }

--- a/server/cmd/server/auth_bootstrap_test.go
+++ b/server/cmd/server/auth_bootstrap_test.go
@@ -15,14 +15,14 @@ func TestServerMuxMountsPlatformAdminRoutes(t *testing.T) {
 		enforceAuth: true,
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/admin/orgs", nil)
+	req := httptest.NewRequest(http.MethodGet, "/admin/organizations", nil)
 	rec := httptest.NewRecorder()
 	server.newMux().ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 	}
-	if rec.Header().Get("Location") != "/login?next=%2Fadmin%2Forgs" {
+	if rec.Header().Get("Location") != "/login?next=%2Fadmin%2Forganizations" {
 		t.Fatalf("location = %q", rec.Header().Get("Location"))
 	}
 }

--- a/server/cmd/server/auth_helpers_test.go
+++ b/server/cmd/server/auth_helpers_test.go
@@ -335,7 +335,7 @@ func TestRequirePlatformAdmin(t *testing.T) {
 	}
 
 	t.Run("unauthenticated redirects", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/admin/orgs", nil)
+		req := httptest.NewRequest(http.MethodGet, "/admin/organizations", nil)
 		rec := httptest.NewRecorder()
 		if _, ok := server.requirePlatformAdmin(rec, req); ok {
 			t.Fatal("expected requirePlatformAdmin to fail")
@@ -346,7 +346,7 @@ func TestRequirePlatformAdmin(t *testing.T) {
 	})
 
 	t.Run("platform admin allowed", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/admin/orgs", nil)
+		req := httptest.NewRequest(http.MethodGet, "/admin/organizations", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
 		rec := httptest.NewRecorder()
 		user, ok := server.requirePlatformAdmin(rec, req)
@@ -359,7 +359,7 @@ func TestRequirePlatformAdmin(t *testing.T) {
 	})
 
 	t.Run("non platform admin forbidden", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/admin/orgs", nil)
+		req := httptest.NewRequest(http.MethodGet, "/admin/organizations", nil)
 		req.AddCookie(&http.Cookie{Name: "attesta_session", Value: "session-member"})
 		rec := httptest.NewRecorder()
 		if _, ok := server.requirePlatformAdmin(rec, req); ok {

--- a/server/cmd/server/auth_reset_handler_test.go
+++ b/server/cmd/server/auth_reset_handler_test.go
@@ -398,7 +398,7 @@ func TestHandleResetPageHidesAdminTopbarLinks(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
 	body := rec.Body.String()
-	if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, `href="/my/organization/profile"`) {
+	if strings.Contains(body, `href="/admin/organizations"`) || strings.Contains(body, `href="/my/organization/profile"`) {
 		t.Fatalf("expected reset page without admin nav links, got %q", body)
 	}
 }

--- a/server/cmd/server/auth_reset_handler_test.go
+++ b/server/cmd/server/auth_reset_handler_test.go
@@ -398,7 +398,7 @@ func TestHandleResetPageHidesAdminTopbarLinks(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
 	body := rec.Body.String()
-	if strings.Contains(body, `href="/admin/organizations"`) || strings.Contains(body, `href="/my/organization/profile"`) {
+	if strings.Contains(body, `href="/admin"`) || strings.Contains(body, `href="/admin/organizations"`) || strings.Contains(body, `href="/my/organization/profile"`) {
 		t.Fatalf("expected reset page without admin nav links, got %q", body)
 	}
 }

--- a/server/cmd/server/auth_session_handler_test.go
+++ b/server/cmd/server/auth_session_handler_test.go
@@ -103,7 +103,7 @@ func TestHandleLoginCreatesPlatformAdminSessionCookie(t *testing.T) {
 	form := url.Values{}
 	form.Set("email", "admin@example.com")
 	form.Set("password", "change-me")
-	form.Set("next", "/admin/orgs")
+	form.Set("next", "/admin/organizations")
 	req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
@@ -113,8 +113,8 @@ func TestHandleLoginCreatesPlatformAdminSessionCookie(t *testing.T) {
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusSeeOther)
 	}
-	if rec.Header().Get("Location") != "/admin/orgs" {
-		t.Fatalf("location = %q, want /admin/orgs", rec.Header().Get("Location"))
+	if rec.Header().Get("Location") != "/admin/organizations" {
+		t.Fatalf("location = %q, want /admin/organizations", rec.Header().Get("Location"))
 	}
 	cookies := rec.Result().Cookies()
 	if len(cookies) == 0 || cookies[0].Name != "attesta_session" {
@@ -219,7 +219,7 @@ func TestHandleLoginPageHidesAdminTopbarLinks(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
 	body := rec.Body.String()
-	if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, `href="/my/organization/profile"`) {
+	if strings.Contains(body, `href="/admin/organizations"`) || strings.Contains(body, `href="/my/organization/profile"`) {
 		t.Fatalf("expected login page without admin nav links, got %q", body)
 	}
 	if strings.Contains(body, `class="btn btn-ghost btn-lg nav-action"`) {

--- a/server/cmd/server/auth_session_handler_test.go
+++ b/server/cmd/server/auth_session_handler_test.go
@@ -219,11 +219,50 @@ func TestHandleLoginPageHidesAdminTopbarLinks(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
 	}
 	body := rec.Body.String()
-	if strings.Contains(body, `href="/admin/organizations"`) || strings.Contains(body, `href="/my/organization/profile"`) {
+	if strings.Contains(body, `href="/admin"`) || strings.Contains(body, `href="/admin/organizations"`) || strings.Contains(body, `href="/my/organization/profile"`) {
 		t.Fatalf("expected login page without admin nav links, got %q", body)
 	}
 	if strings.Contains(body, `class="btn btn-ghost btn-lg nav-action"`) {
 		t.Fatalf("expected login page without Login topbar link, got %q", body)
+	}
+}
+
+func TestHandleHomeShowsAdminTopbarLinkForPlatformAdmin(t *testing.T) {
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "change-me")
+
+	store := NewMemoryStore()
+	if _, err := store.SaveFormataBuilderStream(t.Context(), FormataBuilderStream{
+		Stream:          workflowStreamYAML("Admin nav test"),
+		CreatedByUserID: platformAdminStreamUserID(),
+		UpdatedByUserID: platformAdminStreamUserID(),
+		UpdatedAt:       time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveFormataBuilderStream: %v", err)
+	}
+
+	tmpl := parseTestTemplates(t)
+	server := &Server{
+		store:       store,
+		tmpl:        tmpl,
+		authorizer:  fakeAuthorizer{},
+		enforceAuth: true,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/my", nil)
+	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})
+	rec := httptest.NewRecorder()
+	server.handleHome(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `href="/admin"`) || !strings.Contains(body, "Admin") {
+		t.Fatalf("expected Admin link to /admin, got:\n%s", body)
+	}
+	if strings.Contains(body, `href="/admin/orgs"`) || strings.Contains(body, ">Orgs<") {
+		t.Fatalf("legacy Orgs link still present")
 	}
 }
 

--- a/server/cmd/server/breadcrumbs.go
+++ b/server/cmd/server/breadcrumbs.go
@@ -30,18 +30,29 @@ func buildOrgAdminBreadcrumbs(activePanel string) BreadcrumbsView {
 }
 
 func buildPlatformAdminBreadcrumbs(activePanel string) BreadcrumbsView {
+	section := strings.TrimSpace(activePanel)
+	return BreadcrumbsView{Items: []BreadcrumbItem{
+		{Label: "Dashboard", Href: appHomePath},
+		{Label: "Platform admin", Href: adminPath("")},
+		{Label: platformAdminSectionLabel(section), Href: platformAdminSectionHref(section), Current: true},
+	}}
+}
+
+func platformAdminSectionLabel(activePanel string) string {
 	switch strings.TrimSpace(activePanel) {
 	case "categories":
-		return BreadcrumbsView{Items: []BreadcrumbItem{
-			{Label: "Dashboard", Href: appHomePath},
-			{Label: "Platform admin", Href: "/admin/orgs"},
-			{Label: "Categories", Href: "/admin/categories", Current: true},
-		}}
+		return "Categories"
 	default:
-		return BreadcrumbsView{Items: []BreadcrumbItem{
-			{Label: "Dashboard", Href: appHomePath},
-			{Label: "Platform admin", Href: "/admin/orgs", Current: true},
-		}}
+		return "Organizations"
+	}
+}
+
+func platformAdminSectionHref(activePanel string) string {
+	switch strings.TrimSpace(activePanel) {
+	case "categories":
+		return adminPath("categories")
+	default:
+		return adminPath("organizations")
 	}
 }
 

--- a/server/cmd/server/breadcrumbs_test.go
+++ b/server/cmd/server/breadcrumbs_test.go
@@ -85,34 +85,29 @@ func TestBuildOrgAdminBreadcrumbsSections(t *testing.T) {
 	}
 }
 
-func TestBuildPlatformAdminBreadcrumbsOrgsPanel(t *testing.T) {
-	cases := []string{"orgs", "", "other"}
-	for _, panel := range cases {
+func TestBuildPlatformAdminBreadcrumbs(t *testing.T) {
+	cases := map[string]struct {
+		label string
+		href  string
+	}{
+		"organizations": {label: "Organizations", href: "/admin/organizations"},
+		"":              {label: "Organizations", href: "/admin/organizations"},
+		"other":         {label: "Organizations", href: "/admin/organizations"},
+		"categories":    {label: "Categories", href: "/admin/categories"},
+	}
+	for panel, want := range cases {
 		got := buildPlatformAdminBreadcrumbs(panel)
-		if len(got.Items) != 2 {
-			t.Fatalf("panel %q: len(Items) = %d, want 2", panel, len(got.Items))
+		if len(got.Items) != 3 {
+			t.Fatalf("panel %q: len(Items) = %d, want 3", panel, len(got.Items))
 		}
 		if got.Items[0].Label != "Dashboard" || got.Items[0].Href != appHomePath {
 			t.Fatalf("panel %q: root = %+v", panel, got.Items[0])
 		}
-		if got.Items[1].Label != "Platform admin" || got.Items[1].Href != "/admin/orgs" || !got.Items[1].Current {
-			t.Fatalf("panel %q: current = %+v", panel, got.Items[1])
+		if got.Items[1].Label != "Platform admin" || got.Items[1].Href != adminPath("") || got.Items[1].Current {
+			t.Fatalf("panel %q: middle = %+v", panel, got.Items[1])
 		}
-	}
-}
-
-func TestBuildPlatformAdminBreadcrumbsCategoriesPanel(t *testing.T) {
-	got := buildPlatformAdminBreadcrumbs("categories")
-	if len(got.Items) != 3 {
-		t.Fatalf("len(Items) = %d, want 3", len(got.Items))
-	}
-	if got.Items[0].Label != "Dashboard" || got.Items[0].Href != appHomePath {
-		t.Fatalf("root = %+v", got.Items[0])
-	}
-	if got.Items[1].Label != "Platform admin" || got.Items[1].Href != "/admin/orgs" || got.Items[1].Current {
-		t.Fatalf("middle = %+v", got.Items[1])
-	}
-	if got.Items[2].Label != "Categories" || got.Items[2].Href != "/admin/categories" || !got.Items[2].Current {
-		t.Fatalf("current = %+v", got.Items[2])
+		if got.Items[2].Label != want.label || got.Items[2].Href != want.href || !got.Items[2].Current {
+			t.Fatalf("panel %q: section = %+v, want label=%q href=%q", panel, got.Items[2], want.label, want.href)
+		}
 	}
 }

--- a/server/cmd/server/helpers_misc_coverage_test.go
+++ b/server/cmd/server/helpers_misc_coverage_test.go
@@ -107,7 +107,7 @@ func TestRenderPlatformAdminAdditionalBranches(t *testing.T) {
 	}
 	rec := httptest.NewRecorder()
 
-	server.renderPlatformAdmin(rec, httptest.NewRequest(http.MethodGet, "/admin/orgs", nil), &AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "", PlatformAdminErrors{Invite: " invite failed "})
+	server.renderPlatformAdmin(rec, httptest.NewRequest(http.MethodGet, "/admin/organizations", nil), &AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "", PlatformAdminErrors{Invite: " invite failed "})
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
@@ -119,7 +119,7 @@ func TestRenderPlatformAdminAdditionalBranches(t *testing.T) {
 	broken := &Server{
 		authorizer: fakeAuthorizer{}, tmpl: template.Must(template.New("broken").Parse(`{{define "platform_admin.html"}}{{template "missing" .}}{{end}}`)), now: func() time.Time { return now }}
 	errRec := httptest.NewRecorder()
-	broken.renderPlatformAdmin(errRec, httptest.NewRequest(http.MethodGet, "/admin/orgs", nil), &AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "", PlatformAdminErrors{})
+	broken.renderPlatformAdmin(errRec, httptest.NewRequest(http.MethodGet, "/admin/organizations", nil), &AccountUser{Email: "admin@example.com", IsPlatformAdmin: true}, "", PlatformAdminErrors{})
 	if errRec.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want %d", errRec.Code, http.StatusInternalServerError)
 	}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -2322,6 +2322,7 @@ func (s *Server) newMux() *http.ServeMux {
 	mux.HandleFunc("/login", s.handleLogin)
 	mux.HandleFunc("/signup", s.handleSignup)
 	mux.HandleFunc("/logout", s.handleLogout)
+	mux.HandleFunc("/admin", s.handleAdminRoot)
 	mux.HandleFunc("/admin/orgs", s.handleAdminOrgs)
 	mux.HandleFunc("/admin/orgs/", s.handleAdminOrgs)
 	mux.HandleFunc("/admin/categories", s.handleAdminCategories)

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -2323,6 +2323,7 @@ func (s *Server) newMux() *http.ServeMux {
 	mux.HandleFunc("/signup", s.handleSignup)
 	mux.HandleFunc("/logout", s.handleLogout)
 	mux.HandleFunc("/admin", s.handleAdminRoot)
+	mux.HandleFunc("/admin/{$}", s.handleAdminRoot)
 	mux.HandleFunc("/admin/orgs", s.handleAdminOrgs)
 	mux.HandleFunc("/admin/orgs/", s.handleAdminOrgs)
 	mux.HandleFunc("/admin/categories", s.handleAdminCategories)

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -281,7 +281,7 @@ type PageBase struct {
 	WorkflowPath    string
 	UserEmail       string
 	IsPlatformAdmin bool
-	ShowOrgsLink    bool
+	ShowAdminLink   bool
 	ShowMyOrgLink   bool
 	ShowLogout      bool
 }
@@ -1430,11 +1430,11 @@ func (s *Server) pageBaseForUser(user *AccountUser, body, workflowKey, workflowN
 	base.UserEmail = strings.TrimSpace(user.Email)
 	base.IsPlatformAdmin = user.IsPlatformAdmin
 	base.ShowLogout = s.enforceAuth
-	showOrgsLink, err := s.canAccessPlatformAdminConsole(context.Background(), user)
+	showAdminLink, err := s.canAccessPlatformAdminConsole(context.Background(), user)
 	if err != nil {
 		logCapabilityCheckError(err, "cerbos check failed for platform admin navigation")
 	}
-	base.ShowOrgsLink = showOrgsLink
+	base.ShowAdminLink = showAdminLink
 	showMyOrgLink, err := s.canAccessOrgAdminConsole(context.Background(), user)
 	if err != nil {
 		logCapabilityCheckError(err, "cerbos check failed for org admin navigation")

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -2324,8 +2324,8 @@ func (s *Server) newMux() *http.ServeMux {
 	mux.HandleFunc("/logout", s.handleLogout)
 	mux.HandleFunc("/admin", s.handleAdminRoot)
 	mux.HandleFunc("/admin/{$}", s.handleAdminRoot)
-	mux.HandleFunc("/admin/orgs", s.handleAdminOrgs)
-	mux.HandleFunc("/admin/orgs/", s.handleAdminOrgs)
+	mux.HandleFunc("/admin/organizations", s.handleAdminOrgs)
+	mux.HandleFunc("/admin/organizations/", s.handleAdminOrgs)
 	mux.HandleFunc("/admin/categories", s.handleAdminCategories)
 	mux.HandleFunc("/admin/categories/", s.handleAdminCategoriesPath)
 	mux.HandleFunc("/invite/", s.handleInvite)
@@ -3305,10 +3305,11 @@ func platformAdminPath(query string, page int) string {
 	if page > 1 {
 		values.Set("page", strconv.Itoa(page))
 	}
+	base := adminPath("organizations")
 	if encoded := values.Encode(); encoded != "" {
-		return "/admin/orgs?" + encoded
+		return base + "?" + encoded
 	}
-	return "/admin/orgs"
+	return base
 }
 
 func redirectPlatformAdminWithMessage(w http.ResponseWriter, r *http.Request, query string, page int, confirmation string) {
@@ -3505,8 +3506,8 @@ func (s *Server) platformAdminView(user *AccountUser, confirmation string, errs 
 	rows := platformAdminOrganizationRows(context.Background(), orgPage.Organizations, s.identity)
 	view := PlatformAdminView{
 		PageBase:                 s.pageBaseForUser(user, "platform_admin_body", "", ""),
-		ActivePanel:              "orgs",
-		Breadcrumbs:              buildPlatformAdminBreadcrumbs("orgs"),
+		ActivePanel:              "organizations",
+		Breadcrumbs:              buildPlatformAdminBreadcrumbs("organizations"),
 		SearchQuery:              errs.SearchQuery,
 		CurrentPage:              currentPage,
 		TotalPages:               totalPages,
@@ -3559,7 +3560,7 @@ func (s *Server) handleAdminOrgs(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "identity unavailable", http.StatusServiceUnavailable)
 		return
 	}
-	path := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/admin/orgs"))
+	path := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/admin/organizations"))
 	if strings.HasPrefix(path, "/logo/") {
 		s.handlePlatformAdminLogo(w, r)
 		return
@@ -4157,7 +4158,7 @@ func (s *Server) handlePlatformAdminLogo(w http.ResponseWriter, r *http.Request)
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	logoID := strings.Trim(strings.TrimPrefix(r.URL.Path, "/admin/orgs/logo/"), "/")
+	logoID := strings.Trim(strings.TrimPrefix(r.URL.Path, "/admin/organizations/logo/"), "/")
 	if logoID == "" || s.identity == nil {
 		http.NotFound(w, r)
 		return

--- a/server/cmd/server/panel_markup_test.go
+++ b/server/cmd/server/panel_markup_test.go
@@ -221,7 +221,7 @@ func TestPlatformAdminPanelMarkup(t *testing.T) {
 		`class="rail-layout rail-layout-ready"`,
 		`class="panel panel-sticky"`,
 		`class="sidebar-nav"`,
-		`href="/admin/orgs"`,
+		`href="/admin/organizations"`,
 		`href="/admin/categories"`,
 		`class="panel rail-layout-main"`,
 		`class="panel-head-actions"`,

--- a/server/cmd/server/paths.go
+++ b/server/cmd/server/paths.go
@@ -43,3 +43,14 @@ func organizationPath(rest string) string {
 	rest = strings.TrimPrefix(rest, "/")
 	return "/my/organization/" + rest
 }
+
+// adminPath joins /admin with rest.
+// rest may be "organizations", "/categories", or "organizations/logo/{id}".
+func adminPath(rest string) string {
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		return "/admin"
+	}
+	rest = strings.TrimPrefix(rest, "/")
+	return "/admin/" + rest
+}

--- a/server/cmd/server/paths_test.go
+++ b/server/cmd/server/paths_test.go
@@ -46,6 +46,24 @@ func TestPublicStreamPath(t *testing.T) {
 	}
 }
 
+func TestAdminPath(t *testing.T) {
+	cases := []struct {
+		rest string
+		want string
+	}{
+		{"", "/admin"},
+		{"organizations", "/admin/organizations"},
+		{"/categories", "/admin/categories"},
+		{"organizations/logo/logo-1", "/admin/organizations/logo/logo-1"},
+		{"  organizations  ", "/admin/organizations"},
+	}
+	for _, tc := range cases {
+		if got := adminPath(tc.rest); got != tc.want {
+			t.Fatalf("adminPath(%q) = %q, want %q", tc.rest, got, tc.want)
+		}
+	}
+}
+
 func TestPublicHomePath(t *testing.T) {
 	cases := []struct {
 		cat, sub, want string

--- a/server/cmd/server/platform_admin_htmx_test.go
+++ b/server/cmd/server/platform_admin_htmx_test.go
@@ -32,7 +32,7 @@ func TestHandleAdminCategoriesHTMXReturnsAdminConsole(t *testing.T) {
 		t.Fatalf("HTMX soft-nav must not include layout, got: %s", body)
 	}
 	for _, want := range []string{
-		`hx-get="/admin/orgs"`,
+		`hx-get="/admin/organizations"`,
 		`hx-target="#admin-console"`,
 		"Manage stream discovery taxonomy",
 		"Supply Chain",
@@ -57,7 +57,7 @@ func TestHandleAdminOrgsHTMXSearchStillReturnsResults(t *testing.T) {
 		now:         func() time.Time { return now },
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/admin/orgs?q=acme", nil)
+	req := httptest.NewRequest(http.MethodGet, "/admin/organizations?q=acme", nil)
 	req.Header.Set("HX-Request", "true")
 	req.Header.Set("HX-Target", "platform-admin-results")
 	req.AddCookie(&http.Cookie{Name: "attesta_session", Value: platformAdminSessionValue()})

--- a/server/cmd/server/test_helpers_test.go
+++ b/server/cmd/server/test_helpers_test.go
@@ -72,7 +72,7 @@ func testFormataRuntimeConfig() RuntimeConfig {
 func testTemplates() *template.Template {
 	return template.Must(template.New("test").Parse(`
 	{{define "layout.html"}}
-	  NAV Home Backoffice{{if .ShowOrgsLink}} Orgs{{end}}{{if .ShowMyOrgLink}} MyOrg{{end}} |
+	  NAV Home Backoffice{{if .ShowAdminLink}} Admin{{end}}{{if .ShowMyOrgLink}} MyOrg{{end}} |
 	  {{if eq .Body "home_picker_body"}}{{template "home_picker_body" .}}
 	  {{else if eq .Body "public_home_body"}}{{template "public_home_body" .}}
 	  {{else if eq .Body "signup_body"}}{{template "signup_body" .}}

--- a/server/design/design.go
+++ b/server/design/design.go
@@ -406,7 +406,7 @@ var _ = Service("admin", func() {
 		})
 		Result(Empty)
 		HTTP(func() {
-			GET("/admin/orgs")
+			GET("/admin/organizations")
 			Param("q")
 			Param("page")
 			Response(StatusOK)
@@ -419,7 +419,7 @@ var _ = Service("admin", func() {
 	Method("platformOrgAction", func() {
 		Result(Empty)
 		HTTP(func() {
-			POST("/admin/orgs")
+			POST("/admin/organizations")
 			Response(StatusOK)
 			Response(StatusSeeOther)
 			Response(StatusBadRequest)
@@ -436,7 +436,7 @@ var _ = Service("admin", func() {
 		})
 		Result(Empty)
 		HTTP(func() {
-			GET("/admin/orgs/logo/{logo_id}")
+			GET("/admin/organizations/logo/{logo_id}")
 			Response(StatusOK)
 			Response(StatusNotFound)
 			Response(StatusUnauthorized)

--- a/server/templates/layout.html
+++ b/server/templates/layout.html
@@ -176,10 +176,10 @@
                         {{ template "icon-layout-dashboard" . }}
                         Dashboard
                       </a>
-                      {{ if .ShowOrgsLink }}
-                        <a href="/admin/orgs" class="account-menu-item">
+                      {{ if .ShowAdminLink }}
+                        <a href="/admin" class="account-menu-item">
                           {{ template "icon-building-grid" . }}
-                          Orgs
+                          Admin
                         </a>
                       {{ end }}
                       {{ if .ShowMyOrgLink }}

--- a/server/templates/pages/platform_admin.html
+++ b/server/templates/pages/platform_admin.html
@@ -1,4 +1,4 @@
-{{/* Used on /admin/orgs to render platform administration page */}}
+{{/* Used on /admin/organizations to render platform administration page */}}
 
 {{ define "platform_admin_body" }}
   <div class="stack u-max-w-7xl u-mx-auto">
@@ -26,7 +26,7 @@
 
     <form
       method="get"
-      action="/admin/orgs"
+      action="/admin/organizations"
       class="platform-admin-search"
       id="platform-admin-search"
     >
@@ -43,7 +43,7 @@
           value="{{ .SearchQuery }}"
           placeholder="Search organizations by name"
           autocomplete="off"
-          hx-get="/admin/orgs"
+          hx-get="/admin/organizations"
           hx-target="#platform-admin-results"
           hx-select="#platform-admin-results"
           hx-swap="outerHTML"
@@ -75,7 +75,7 @@
         </header>
         <form
           method="post"
-          action="/admin/orgs"
+          action="/admin/organizations"
           class="input-form"
           enctype="multipart/form-data"
         >
@@ -635,7 +635,7 @@
             <div class="list-row-main">
               {{ if .LogoAttachmentID }}
                 <img
-                  src="/admin/orgs/logo/{{ .LogoAttachmentID }}"
+                  src="/admin/organizations/logo/{{ .LogoAttachmentID }}"
                   alt="{{ .Name }} logo"
                   class="org-profile-logo org-profile-logo-sm"
                 />
@@ -698,7 +698,7 @@
                     {{ template "icon-close" . }}
                   </button>
                 </header>
-                <form method="post" action="/admin/orgs" class="input-form">
+                <form method="post" action="/admin/organizations" class="input-form">
                   <input type="hidden" name="intent" value="invite_org_admin" />
                   <input type="hidden" name="org_slug" value="{{ .Slug }}" />
                   <input type="hidden" name="q" value="{{ $.SearchQuery }}" />
@@ -785,7 +785,7 @@
                 </header>
                 <form
                   method="post"
-                  action="/admin/orgs"
+                  action="/admin/organizations"
                   class="input-form"
                   enctype="multipart/form-data"
                 >
@@ -860,7 +860,7 @@
                 {{ if and (eq $.OrganizationDialogAction "delete") (eq $.OrganizationDialogSlug .Slug) $.OrganizationError }}
                   <p class="error">{{ $.OrganizationError }}</p>
                 {{ end }}
-                <form method="post" action="/admin/orgs" class="input-form">
+                <form method="post" action="/admin/organizations" class="input-form">
                   <input type="hidden" name="intent" value="delete_org" />
                   <input type="hidden" name="org_slug" value="{{ .Slug }}" />
                   <input type="hidden" name="q" value="{{ $.SearchQuery }}" />
@@ -892,7 +892,7 @@
         <div class="platform-admin-pagination-pages">
           <a
             class="btn btn-secondary pagination-btn{{ if not .HasPreviousPage }} is-disabled{{ end }}"
-            href="/admin/orgs{{- if or .SearchQuery (gt .PreviousPage 1) -}}
+            href="/admin/organizations{{- if or .SearchQuery (gt .PreviousPage 1) -}}
               ?{{- if .SearchQuery -}}
                 q={{ .SearchQuery | urlquery }}{{- if gt .PreviousPage 1 -}}
                   &
@@ -901,7 +901,7 @@
                 page={{ .PreviousPage }}
               {{- end -}}
             {{- end -}}"
-            hx-get="/admin/orgs{{- if or .SearchQuery (gt .PreviousPage 1) -}}
+            hx-get="/admin/organizations{{- if or .SearchQuery (gt .PreviousPage 1) -}}
               ?{{- if .SearchQuery -}}
                 q={{ .SearchQuery | urlquery }}{{- if gt .PreviousPage 1 -}}
                   &
@@ -924,12 +924,12 @@
               {{ else }}
                 btn btn-secondary
               {{ end }}"
-              href="/admin/orgs{{- if or $.SearchQuery (gt . 1) -}}
+              href="/admin/organizations{{- if or $.SearchQuery (gt . 1) -}}
                 ?{{- if $.SearchQuery -}}
                   q={{ $.SearchQuery | urlquery }}{{- if gt . 1 -}}&{{ end }}
                 {{- end -}}{{- if gt . 1 -}}page={{ . }}{{ end }}
               {{- end -}}"
-              hx-get="/admin/orgs{{- if or $.SearchQuery (gt . 1) -}}
+              hx-get="/admin/organizations{{- if or $.SearchQuery (gt . 1) -}}
                 ?{{- if $.SearchQuery -}}
                   q={{ $.SearchQuery | urlquery }}{{- if gt . 1 -}}&{{ end }}
                 {{- end -}}{{- if gt . 1 -}}page={{ . }}{{ end }}
@@ -943,14 +943,14 @@
           {{ end }}
           <a
             class="btn btn-secondary pagination-btn{{ if not .HasNextPage }} is-disabled{{ end }}"
-            href="/admin/orgs{{- if or .SearchQuery (gt .NextPage 1) -}}
+            href="/admin/organizations{{- if or .SearchQuery (gt .NextPage 1) -}}
               ?{{- if .SearchQuery -}}
                 q={{ .SearchQuery | urlquery }}{{- if gt .NextPage 1 -}}
                   &
                 {{ end }}
               {{- end -}}{{- if gt .NextPage 1 -}}page={{ .NextPage }}{{ end }}
             {{- end -}}"
-            hx-get="/admin/orgs{{- if or .SearchQuery (gt .NextPage 1) -}}
+            hx-get="/admin/organizations{{- if or .SearchQuery (gt .NextPage 1) -}}
               ?{{- if .SearchQuery -}}
                 q={{ .SearchQuery | urlquery }}{{- if gt .NextPage 1 -}}
                   &


### PR DESCRIPTION
## Summary
- Add `/admin` entry redirect to `/admin/organizations` (exact `/admin/{$}` for trailing slash; no subtree shadow)
- Hard-cut rename `/admin/orgs` → `/admin/organizations` (legacy paths 404); keep `/admin/categories`
- Align breadcrumbs (Dashboard → Platform admin → section), topbar **Admin** → `/admin`, and `adminPath` helpers

## Test plan
- [ ] Platform admin: account menu **Admin** → `/admin` redirects to organizations console
- [ ] Breadcrumbs on Organizations and Categories: three crumbs; middle links to `/admin`
- [ ] Soft-nav between Organizations ↔ Categories still swaps `#admin-console`
- [ ] `/admin/orgs` and `/admin/orgs/logo/…` return 404
- [ ] Org logo, search, and pagination still work under `/admin/organizations`
- [ ] `cd server && go test ./cmd/server -count=1`


Made with [Cursor](https://cursor.com)