### PR TITLE
Polish public home stream results and mobile category chips

### DIFF
--- a/server/cmd/server/category_sidebar_test.go
+++ b/server/cmd/server/category_sidebar_test.go
@@ -15,6 +15,7 @@ func TestCategorySidebarTemplateHTMXLeaf(t *testing.T) {
 			Slug: "supply-chain", Name: "Supply Chain", IconURL: "/c.svg", Expanded: true,
 			SubCategories: []CategorySidebarLeafView{{
 				Slug: "procurement", Name: "Procurement", Active: true,
+				IconURL: "/static/taxonomy/procurement-workflow.svg",
 				PartialURL: "/streams/public?category=supply-chain&subCategory=procurement",
 				PushURL:    "/?category=supply-chain&subCategory=procurement",
 			}},
@@ -29,6 +30,8 @@ func TestCategorySidebarTemplateHTMXLeaf(t *testing.T) {
 		`class="category-sidebar-title">Stream Categories<`,
 		`hx-get="/streams/public?category=supply-chain&amp;subCategory=procurement"`,
 		`hx-push-url="/?category=supply-chain&amp;subCategory=procurement"`,
+		`class="category-sidebar-subcategory-icon"`,
+		`src="/static/taxonomy/procurement-workflow.svg"`,
 		`is-active`,
 	} {
 		if !strings.Contains(body, want) {

--- a/server/cmd/server/components.go
+++ b/server/cmd/server/components.go
@@ -93,6 +93,7 @@ type PublicStreamPageView struct {
 type CategorySidebarLeafView struct {
 	Slug       string
 	Name       string
+	IconURL    string
 	Active     bool
 	Href       string // /my anchors, e.g. #cat-supply-chain--procurement
 	PartialURL string // public home HTMX get

--- a/server/cmd/server/my_home.go
+++ b/server/cmd/server/my_home.go
@@ -121,9 +121,10 @@ func buildMyHomeCategorySidebar(groups []MyHomeStreamGroupView) CategorySidebarV
 			}
 		}
 		current.SubCategories = append(current.SubCategories, CategorySidebarLeafView{
-			Slug: g.SubCategorySlug,
-			Name: g.SubCategoryName,
-			Href: "#" + g.AnchorID,
+			Slug:    g.SubCategorySlug,
+			Name:    g.SubCategoryName,
+			IconURL: g.SubCategoryIconURL,
+			Href:    "#" + g.AnchorID,
 		})
 	}
 	flush()

--- a/server/cmd/server/my_home_test.go
+++ b/server/cmd/server/my_home_test.go
@@ -116,8 +116,8 @@ func TestBuildMyHomeStreamGroupsSetsAnchorIDs(t *testing.T) {
 
 func TestBuildMyHomeCategorySidebarFromGroups(t *testing.T) {
 	groups := []MyHomeStreamGroupView{
-		{CategorySlug: "supply-chain", CategoryName: "Supply Chain", CategoryIconURL: "/c.svg", SubCategorySlug: "procurement", SubCategoryName: "Procurement", AnchorID: "cat-supply-chain--procurement", ShowCategoryHeader: true},
-		{CategorySlug: "supply-chain", CategoryName: "Supply Chain", CategoryIconURL: "/c.svg", SubCategorySlug: "order-fulfillment", SubCategoryName: "Order Fulfillment", AnchorID: "cat-supply-chain--order-fulfillment"},
+		{CategorySlug: "supply-chain", CategoryName: "Supply Chain", CategoryIconURL: "/c.svg", SubCategorySlug: "procurement", SubCategoryName: "Procurement", SubCategoryIconURL: "/s.svg", AnchorID: "cat-supply-chain--procurement", ShowCategoryHeader: true},
+		{CategorySlug: "supply-chain", CategoryName: "Supply Chain", CategoryIconURL: "/c.svg", SubCategorySlug: "order-fulfillment", SubCategoryName: "Order Fulfillment", SubCategoryIconURL: "/o.svg", AnchorID: "cat-supply-chain--order-fulfillment"},
 		{Uncategorized: true, CategoryName: "Uncategorized", AnchorID: "cat-uncategorized", ShowCategoryHeader: true},
 	}
 	got := buildMyHomeCategorySidebar(groups)
@@ -132,6 +132,9 @@ func TestBuildMyHomeCategorySidebarFromGroups(t *testing.T) {
 	}
 	if got.Categories[0].SubCategories[0].Href != "#cat-supply-chain--procurement" {
 		t.Fatalf("href0=%q", got.Categories[0].SubCategories[0].Href)
+	}
+	if got.Categories[0].SubCategories[0].IconURL != "/s.svg" {
+		t.Fatalf("IconURL0=%q", got.Categories[0].SubCategories[0].IconURL)
 	}
 	if got.Categories[1].Name != "Uncategorized" || got.Categories[1].SubCategories[0].Href != "#cat-uncategorized" {
 		t.Fatalf("uncat=%+v", got.Categories[1])

--- a/server/cmd/server/public_home.go
+++ b/server/cmd/server/public_home.go
@@ -78,6 +78,7 @@ func buildPublicHomeCategories(categories []TaxonomyCategoryNode, selectedCat, s
 			subs = append(subs, CategorySidebarLeafView{
 				Slug:       sub.Slug,
 				Name:       sub.Name,
+				IconURL:    sub.IconURL,
 				Active:     cat.Slug == selectedCat && sub.Slug == selectedSub,
 				PartialURL: "/streams/public?" + encoded,
 				PushURL:    publicHomePath(cat.Slug, sub.Slug),

--- a/server/cmd/server/public_home_test.go
+++ b/server/cmd/server/public_home_test.go
@@ -138,8 +138,8 @@ func TestBuildPublicHomeCategoriesMarksActiveAndURLs(t *testing.T) {
 		{
 			Slug: "supply-chain", Name: "Supply Chain", IconURL: "/static/taxonomy/batch-traceability.svg",
 			SubCategories: []TaxonomySubCategoryNode{
-				{Slug: "procurement", Name: "Procurement"},
-				{Slug: "order-fulfillment", Name: "Order Fulfillment"},
+				{Slug: "procurement", Name: "Procurement", IconURL: "/static/taxonomy/procurement-workflow.svg"},
+				{Slug: "order-fulfillment", Name: "Order Fulfillment", IconURL: "/static/taxonomy/order-fulfillment.svg"},
 			},
 		},
 		{
@@ -161,6 +161,9 @@ func TestBuildPublicHomeCategoriesMarksActiveAndURLs(t *testing.T) {
 	}
 	if got.Categories[0].SubCategories[1].Active != true || got.Categories[0].SubCategories[0].Active {
 		t.Fatalf("active flags: %#v", got.Categories[0].SubCategories)
+	}
+	if got.Categories[0].SubCategories[1].IconURL != "/static/taxonomy/order-fulfillment.svg" {
+		t.Fatalf("IconURL=%q", got.Categories[0].SubCategories[1].IconURL)
 	}
 	wantPartial := "/streams/public?category=supply-chain&subCategory=order-fulfillment"
 	wantPush := "/?category=supply-chain&subCategory=order-fulfillment"

--- a/server/templates/components/category_sidebar.html
+++ b/server/templates/components/category_sidebar.html
@@ -39,7 +39,12 @@
                 class="category-sidebar-subcategory{{ if .Active }} is-active{{ end }}"
                 href="{{ .Href }}"
                 data-subcategory-slug="{{ .Slug }}"
-              >{{ .Name }}</a>
+              >
+                {{ if .IconURL }}
+                  <img class="category-sidebar-subcategory-icon" src="{{ .IconURL }}" alt="" width="16" height="16" />
+                {{ end }}
+                <span>{{ .Name }}</span>
+              </a>
             {{ else }}
               <button
                 type="button"
@@ -49,7 +54,12 @@
                 hx-target="#public-home-stream-results"
                 hx-swap="outerHTML settle:350ms"
                 hx-push-url="{{ .PushURL }}"
-              >{{ .Name }}</button>
+              >
+                {{ if .IconURL }}
+                  <img class="category-sidebar-subcategory-icon" src="{{ .IconURL }}" alt="" width="16" height="16" />
+                {{ end }}
+                <span>{{ .Name }}</span>
+              </button>
             {{ end }}
           {{ end }}
         </div>

--- a/server/templates/components/category_sidebar.html
+++ b/server/templates/components/category_sidebar.html
@@ -47,7 +47,7 @@
                 data-subcategory-slug="{{ .Slug }}"
                 hx-get="{{ .PartialURL }}"
                 hx-target="#public-home-stream-results"
-                hx-swap="outerHTML"
+                hx-swap="outerHTML settle:350ms"
                 hx-push-url="{{ .PushURL }}"
               >{{ .Name }}</button>
             {{ end }}

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1651,32 +1651,6 @@ const initLandingCategorySidebar = () => {
     }
     btn.classList.add("is-active");
   });
-  // Stacked sidebar (below --md-up): after filter swap, bring results into view.
-  // HTMX sets detail.elt to the swap target for outerHTML, not the clicked button.
-  document.body.addEventListener("htmx:afterSettle", (event) => {
-    const target = event.target;
-    if (
-      !(target instanceof Element) ||
-      target.id !== "public-home-stream-results"
-    ) {
-      return;
-    }
-    const split = document.getElementById("streams");
-    if (!(split instanceof HTMLElement)) {
-      return;
-    }
-    // Side-by-side layout uses display:grid from --md-up.
-    if (getComputedStyle(split).display === "grid") {
-      return;
-    }
-    const reduceMotion = window.matchMedia(
-      "(prefers-reduced-motion: reduce)",
-    ).matches;
-    target.scrollIntoView({
-      behavior: reduceMotion ? "auto" : "smooth",
-      block: "start",
-    });
-  });
 };
 
 initLandingCategorySidebar();

--- a/web/src/styles/components/category-sidebar.css
+++ b/web/src/styles/components/category-sidebar.css
@@ -16,6 +16,8 @@
  *         span.category-sidebar-category-chevron
  *       .category-sidebar-subcategories
  *         a.category-sidebar-subcategory[.is-active] | button.category-sidebar-subcategory[.is-active]
+ *           img.category-sidebar-subcategory-icon?
+ *           span
  *     p.category-sidebar-empty
  */
 
@@ -166,6 +168,13 @@ a.category-sidebar-subcategory {
 .category-sidebar-subcategory:hover {
   background: var(--success-muted);
   color: var(--primary);
+}
+
+.category-sidebar-subcategory-icon {
+  display: none;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
 }
 
 .category-sidebar-subcategory::before {

--- a/web/src/styles/pages/public-home.css
+++ b/web/src/styles/pages/public-home.css
@@ -440,6 +440,55 @@ h2.public-home-results-category-name {
   .public-home-dev {
     padding-inline: var(--space-4);
   }
+
+  /* Public home only: subcategory filters as a horizontal chip scroller. */
+  .public-home .category-sidebar-category-summary {
+    padding-block: var(--space-2);
+  }
+
+  .public-home .category-sidebar-subcategories {
+    flex-direction: row;
+    flex-wrap: nowrap;
+    gap: var(--space-2);
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+    box-sizing: border-box;
+    padding: 0 var(--space-3) var(--space-3);
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    scrollbar-width: thin;
+  }
+
+  .public-home .category-sidebar-subcategory {
+    width: auto;
+    flex-shrink: 0;
+    white-space: nowrap;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: var(--space-2) var(--space-4);
+    background: var(--card);
+  }
+
+  .public-home .category-sidebar-subcategory-icon {
+    display: block;
+  }
+
+  .public-home .category-sidebar-subcategory::before {
+    display: none;
+  }
+
+  .public-home .category-sidebar-subcategory.is-active {
+    border-color: var(--primary);
+  }
+
+  .public-home .public-home-results-category-header {
+    display: none;
+  }
+
+  .public-home-stream-results {
+    gap: var(--space-3);
+  }
 }
 
 @media (--sm-down) {

--- a/web/src/styles/pages/public-home.css
+++ b/web/src/styles/pages/public-home.css
@@ -141,6 +141,19 @@
   padding: var(--space-6);
 }
 
+@keyframes public-home-results-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.public-home-stream-results.htmx-added {
+  animation: public-home-results-fade-in 350ms ease;
+}
+
 .public-home-results-category-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Fade in public home stream results after HTMX category swaps.
- On mobile, render subcategory filters as a horizontal chip scroller with icons, tighter category/results spacing, and no post-click scroll jump.
- Hide the duplicate results category header on mobile.

## Test plan
- [ ] Open `/` on a narrow viewport — subcategory chips scroll horizontally with icons
- [ ] Click a chip — results swap without scrolling the page
- [ ] Desktop sidebar still shows vertical subcategory list without chip icons
- [ ] Mobile results omit the parent category header; gap between results blocks feels tighter


Made with [Cursor](https://cursor.com)